### PR TITLE
Fix nginx crash in console plugin with ubi9-minimal base image

### DIFF
--- a/controller/console/reconciler.go
+++ b/controller/console/reconciler.go
@@ -29,14 +29,21 @@ const (
 
 	servingCertAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
 
-	nginxConfig = `error_log /dev/stdout info;
+	nginxConfig = `pid /tmp/nginx/nginx.pid;
+error_log /dev/stdout info;
 events {}
 http {
-  include            /etc/nginx/mime.types;
-  default_type       application/octet-stream;
-  keepalive_timeout  65;
+  client_body_temp_path /tmp/nginx/client_body;
+  proxy_temp_path       /tmp/nginx/proxy;
+  fastcgi_temp_path     /tmp/nginx/fastcgi;
+  uwsgi_temp_path       /tmp/nginx/uwsgi;
+  scgi_temp_path        /tmp/nginx/scgi;
+  include               /etc/nginx/mime.types;
+  default_type          application/octet-stream;
+  keepalive_timeout     65;
   server {
     listen              9443 ssl;
+    listen              [::]:9443 ssl;
     ssl_certificate     /var/cert/tls.crt;
     ssl_certificate_key /var/cert/tls.key;
     root                /usr/share/nginx/html;


### PR DESCRIPTION
## Summary
- Add `pid`, temp directory paths, and IPv6 listen directive to the nginx config generated by the console reconciler
- Without these, nginx fails with `open() "/run/nginx.pid" failed (Permission denied)` when the console image uses `ubi9-minimal` + `microdnf install nginx` instead of the pre-configured `ubi9/nginx-120` image
- Aligns the agentic operator's nginx config with the base operator's version in `lightspeed-operator/internal/controller/console/assets.go`

## Context
Found while testing [openshift/lightspeed-agentic-console#2](https://github.com/openshift/lightspeed-agentic-console/pull/2) (Konflux hermetic build migration to ubi9-minimal). The `ubi9/nginx-120` image had built-in non-root-friendly defaults; raw nginx from microdnf does not.

## Test plan
- [x] Deployed console plugin with ubi9-minimal Dockerfile on OCP 4.21.5
- [x] Verified nginx starts successfully with the updated ConfigMap
- [x] Verified proposals page loads at `/lightspeed/proposals`

🤖 Generated with [Claude Code](https://claude.com/claude-code)