### PR TITLE
docs: add AI agent specs under .ai/spec/

### DIFF
--- a/.ai/spec/README.md
+++ b/.ai/spec/README.md
@@ -1,0 +1,38 @@
+# Lightspeed Agentic Operator -- Specifications
+
+These specs define the requirements, behaviors, and architecture for the lightspeed-agentic-operator. They are organized into two layers:
+
+- **[`what/`](what/)** -- Behavioral rules: WHAT the system must do. Technology-neutral, testable assertions. Use these to understand requirements, fix bugs, or rebuild components.
+- **[`how/`](how/)** -- Architecture specs: HOW the current implementation is structured. Module boundaries, data flow, design patterns. Use these to navigate, modify, and extend the codebase.
+
+## Scope
+
+These specs cover the **lightspeed-agentic-operator** Go/kubebuilder application only. The sandbox runtime, console plugin, and skills packaging are separate projects with their own specs.
+
+## Audience
+
+AI agents (Claude). Specs optimize for precision, unambiguous rules, and machine-parseable structure.
+
+## Quick Start
+
+| I want to... | Read |
+|--------------|------|
+| Understand the proposal workflow | `what/proposal-lifecycle.md` |
+| Look up a CRD field | `what/crd-api.md` |
+| Understand the approval system | `what/approval.md` |
+| Understand sandbox pod lifecycle | `what/sandbox-execution.md` |
+| Navigate the controller codebase | `how/reconciler.md` |
+| Understand the CLI plugin | `how/cli.md` |
+
+## Conventions
+
+- `[PLANNED: OLS-XXXX]` markers indicate existing rules about to change due to open Jira work
+- "Planned Changes" sections list new capabilities not yet in code
+- CRD field names reference `spec.*` and `status.*` paths
+- Internal constants are stated as behavioral rules without numeric values
+
+## Project Context
+
+This operator watches `Proposal` CRs and drives them through a multi-phase workflow (analysis, execution, verification) by calling the sandbox runtime's `POST /v1/agent/run` endpoint. The console plugin provides the human-facing UI. Skills are mounted as OCI image volumes.
+
+Jira tracking: Feature OCPSTRAT-3095, Epic OLS-2894.

--- a/.ai/spec/how/README.md
+++ b/.ai/spec/how/README.md
@@ -1,0 +1,14 @@
+# Architecture Specifications (how/)
+
+These specs describe HOW the operator is structured -- module boundaries, data flow, design patterns, key abstractions, and implementation decisions. They are grounded in the current Go/kubebuilder codebase and should be updated when the code changes.
+
+## Spec Index
+
+| Spec | Description |
+|------|-------------|
+| [reconciler.md](reconciler.md) | Controller package: reconciler, handler dispatch, sandbox management, agent communication, templates |
+| [cli.md](cli.md) | oc-agentic CLI plugin: command tree, K8s API calls, watch streaming, output formatting |
+
+## Relationship to what/ Specs
+
+The [`what/` specs](../what/README.md) define behavioral contracts (technology-neutral). These `how/` specs describe the implementation that fulfills those contracts. When the two diverge, the `what/` spec is the source of truth for correct behavior.

--- a/.ai/spec/how/cli.md
+++ b/.ai/spec/how/cli.md
@@ -1,0 +1,146 @@
+# `oc-agentic` CLI — architecture (how)
+
+Audience: AI agents. Command behavior and user-facing rules belong in **what/** specs where applicable (e.g. `what/approval.md` for approval semantics). This document describes **code layout, client wiring, and I/O paths**.
+
+---
+
+## Entry point: `cmd/oc-agentic/main.go`
+
+- Builds `genericclioptions.IOStreams` from `os.Stdin` / `Stdout` / `Stderr`.
+- `cli.NewRootCmd(streams).Execute()` — Cobra root.
+
+---
+
+## Module map: `cli/`
+
+| File | Types | Key functions |
+|------|-------|----------------|
+| `root.go` | — | `NewRootCmd(streams)` — registers `proposal` subtree and `version` |
+| `version.go` | Package var `Version` (default `dev`) | `NewVersionCmd(streams)` |
+
+---
+
+## Module map: `cli/proposal/`
+
+| File | Types | Key functions |
+|------|-------|----------------|
+| `proposal.go` | — | `NewProposalCmd(streams)` — registers subcommands |
+| `helpers.go` | Color constants; `scheme` (`runtime.Scheme` with client-go + `agenticv1alpha1`); output constants | `NewClient`, `NewClientFromConfig`, `ResolveNamespace`, `IsTerminalPhase`, `PhaseColor`, `ColoredPhase`, `HumanDuration`, `PrintTable`, `MarshalOutput`, `SortProposalsByAge`, `IsValidPhase`, `IsValidStep`, `NormalizeStep`, `ValidateOutputFormat`, `stepStatusFromConditions`, `valueOrDash`, `int32PtrStr` |
+| `create.go` | `CreateOptions` (embeds `IOStreams`, holds `configFlags`, typed `client.Client`, namespace) | `NewCreateCmd`, `Complete`, `Validate`, `Run` |
+| `list.go` | `ListOptions` | `NewListCmd`, `Complete`, `Validate`, `Run`, `printTable`, `printWideTable` |
+| `get.go` | `GetOptions` | `NewGetCmd`, `Complete`, `Validate`, `Run`, `printDetail` |
+| `approve.go` | `ApproveOptions` | `NewApproveCmd`, `Complete`, `Validate`, `Run`, `getOrCreateApproval`, `pendingStages`, `normalizeStageType` |
+| `deny.go` | `DenyOptions` | `NewDenyCmd`, `Complete`, `Run`, `nextPendingStage` |
+| `delete.go` | `DeleteOptions` | `NewDeleteCmd`, `Complete`, `Run` |
+| `watch.go` | `WatchOptions`; package var `proposalGVR` | `NewWatchCmd`, `Complete`, `Run`, `doWatch`, `extractConditions` |
+| `logs.go` | `LogsOptions` | `NewLogsCmd`, `Complete`, `Validate`, `Run`, `resolveSandbox` |
+
+`*_test.go` files under `cli/` exercise commands (not fully enumerated here).
+
+---
+
+## Command tree
+
+```
+oc-agentic
+├── proposal (aliases: proposals, prop)
+│   ├── list (ls)
+│   ├── get NAME
+│   ├── create
+│   ├── approve NAME
+│   ├── deny NAME
+│   ├── watch NAME
+│   ├── logs NAME
+│   └── delete NAME
+└── version
+```
+
+---
+
+## Kubernetes client usage (not generic “dynamic” for CRUD)
+
+- **Primary:** `sigs.k8s.io/controller-runtime/pkg/client.Client` constructed by `NewClient(configFlags)` → `configFlags.ToRESTConfig()` → `client.New(cfg, client.Options{Scheme: scheme})`.
+- **Typed API:** `Create`/`Get`/`List`/`Patch`/`Delete` use `agenticv1alpha1` types (`Proposal`, `ProposalList`, `ProposalApproval`).
+- **Watch:** `cli/proposal/watch.go` uses **`k8s.io/client-go/dynamic`** `Resource(proposalGVR).Namespace(ns).Watch` with `FieldSelector` on `metadata.name` — events arrive as `*unstructured.Unstructured`.
+- **Logs:** `k8s.io/client-go/kubernetes.Clientset` `CoreV1().Pods(ns).GetLogs(name, opts).Stream` — pod name taken from proposal status sandbox info (see below).
+
+There is **no** unstructured client for proposal CRUD in the main commands; only watch uses dynamic + unstructured.
+
+---
+
+## `genericclioptions` integration
+
+- Every command embeds or holds `*genericclioptions.ConfigFlags` from `genericclioptions.NewConfigFlags(true)`.
+- **`AddFlags`** on each cobra command wires kubeconfig/context/namespace flags consistent with `kubectl` / `oc`.
+- **`IOStreams`** passed from root for all printing and JSON/YAML encoders.
+- **Namespace resolution:** `ResolveNamespace` prefers `*ConfigFlags.Namespace`; else kubeconfig current context namespace; else `"default"`.
+
+---
+
+## Per-command API behavior (concise)
+
+- **`create`:** Builds `Proposal` with `GenerateName: "ag-"`, `Spec.Request`, `TargetNamespaces`, `Analysis.Agent` from flag default `"default"`. `client.Create`. Output: line message or `-o json|yaml` via `MarshalOutput`.
+- **`list`:** `client.List` `ProposalList`, optional `client.InNamespace`, filter by `--phase` using `agenticv1alpha1.DerivePhase` on each item. Table via `PrintTable` + `ColoredPhase` + `HumanDuration`; `-o wide` adds target namespaces column; `-A` lists cluster-wide.
+- **`get`:** `client.Get` by name; human-readable sections from `Spec`, `Status.Steps`, and `Status.Conditions` (step summaries via `stepStatusFromConditions`).
+- **`approve`:** Loads `Proposal`; `getOrCreateApproval` (get or create `ProposalApproval` with owner ref — create path omits controller flags present in controller’s `ensureProposalApproval`; operator reconciler may enrich). Builds `[]ApprovalStage` entries, `client.Patch(MergeFrom)` on approval. `--all` uses `pendingStages` derived from spec non-zero steps vs existing stage types. `--wait` delegates to `doWatch`.
+- **`deny`:** Requires existing `ProposalApproval`; appends denied stage with `ApprovalDecisionDenied`. `--stage` defaults via `nextPendingStage` walk order analysis → execution → verification.
+- **`delete`:** `client.Delete` minimal `Proposal` object keyed by name/namespace.
+- **`watch`:** Dynamic watch; `extractConditions` pulls `status.conditions` into `[]metav1.Condition`; phase from `DerivePhase`; prints only on phase change; stops when `IsTerminalPhase` (Completed, Failed, Escalated, Denied — note helpers.go set).
+- **`logs`:** Loads proposal via controller-runtime client; `resolveSandbox` picks explicit `--step` (normalized via `NormalizeStep`) or prefers verification, then execution, then analysis sandbox info. Uses **`SandboxInfo.ClaimName` as pod name** and `SandboxInfo.Namespace` (fallback proposal namespace). Streams with optional `-f`.
+
+---
+
+## Output formatting
+
+- **Tables:** `text/tabwriter` via `PrintTable`.
+- **Phases:** ANSI colors in `PhaseColor` / `ColoredPhase` (green complete, red failed/denied, yellow in-progress, magenta escalated).
+- **Structured:** `-o json` uses `encoding/json` encoder with indent; `-o yaml` uses `sigs.k8s.io/yaml` `Marshal`.
+- **Validation:** `ValidateOutputFormat` — list allows `wide` in addition to json/yaml; get/create allow json/yaml only.
+
+---
+
+## Shared helpers (`cli/proposal/helpers.go`)
+
+- **Scheme:** Registers `clientgoscheme` + `agenticv1alpha1` for typed client.
+- **Phase/step validation:** `validProposalPhases` slice must stay aligned with API constants (comment in file). `validSandboxSteps` for logs `--step`.
+- **Sorting:** `SortProposalsByAge` descending by `CreationTimestamp`.
+- **Duration:** `k8s.io/apimachinery/pkg/util/duration.HumanDuration`.
+
+---
+
+## Data Flow
+
+```
+User invokes oc-agentic proposal <cmd> [flags]
+  │
+  ├─ Cobra dispatches to subcommand Run()
+  │    ├─ Complete(): resolve namespace, build K8s client
+  │    ├─ Validate(): check required args, output format
+  │    └─ Run():
+  │         ├─ CRUD commands → controller-runtime typed client → API server
+  │         ├─ watch → dynamic client Watch() → event loop → phase change detection → terminal check
+  │         └─ logs → clientset Pods().GetLogs().Stream() → io.Copy to stdout
+  │
+  └─ Output: table (tabwriter), JSON (encoding/json), YAML (sigs.k8s.io/yaml), or colored text
+```
+
+## Key Abstractions
+
+- **Typed client** (`controller-runtime`): Used for all CRUD operations on `Proposal`, `ProposalApproval`. Provides compile-time safety via `agenticv1alpha1` types.
+- **Dynamic client** (`client-go`): Used only for watch operations. Returns `*unstructured.Unstructured` events decoded via `DerivePhase`.
+- **Clientset** (`client-go`): Used only for pod log streaming. Direct CoreV1 API access.
+- **`ConfigFlags`**: Standard kubeconfig/context/namespace flag bundle shared across all subcommands.
+- **Phase derivation dependency**: CLI uses `agenticv1alpha1.DerivePhase` from the API package directly, ensuring phase logic stays in sync between operator and CLI.
+
+## Cross-references
+
+- Proposal phases and condition → phase mapping: **`api/v1alpha1` `DerivePhase`** — see **what/proposal-lifecycle.md** (not duplicated here).
+- Approval stage types and policy interaction: reconciler and CLI both append to `ProposalApproval.Spec.Stages` — see **what/approval.md**.
+- Sandbox claim/pod relationship for log streaming: **what/sandbox-execution.md** if documented; this how spec notes the CLI’s use of `Status.Steps.*.Sandbox` only.
+
+---
+
+## Implementation notes
+
+- **`validProposalPhases` in `helpers.go`** is missing `Proposed` and `Escalating` relative to `ProposalPhase` in `api/v1alpha1/proposal_types.go`. `list --phase` validation (`IsValidPhase`) can reject phase strings that `DerivePhase` still produces; align the slice with API constants when fixing UX.
+- **`watch` terminal set:** `IsTerminalPhase` matches four phases (includes `Escalated`); matches common completion paths; verify against **what/** if `Analyzing` as terminal edge cases matter.

--- a/.ai/spec/how/reconciler.md
+++ b/.ai/spec/how/reconciler.md
@@ -1,0 +1,180 @@
+# Proposal controller — architecture (how)
+
+Audience: AI agents. Behavioral rules and phase semantics live in **what/** specs (e.g. `what/proposal-lifecycle.md`, `what/crd-api.md`, `what/approval.md`, `what/sandbox-execution.md`). This document maps **structure, call graph, and implementation mechanics** only.
+
+---
+
+## Entry point: `cmd/main.go`
+
+- Parses flags: `metrics-bind-address`, `health-probe-bind-address`, `namespace` (falls back to `POD_NAMESPACE`), `template-name` (default base `SandboxTemplate` name, e.g. `lightspeed-agent`).
+- Builds controller-runtime `Manager` with core + `agenticv1alpha1` scheme.
+- Wires **dependency injection**:
+  - `proposal.NewSandboxManager(mgr.GetClient(), namespace)` → `SandboxProvider` for the agent caller.
+  - `proposal.NewSandboxAgentCaller(sandboxMgr, mgr.GetClient(), proposal.NewAgentHTTPClient, namespace, templateName)` → satisfies `proposal.AgentCaller`.
+  - `proposal.ProposalReconciler{ Client: mgr.GetClient(), Log: ..., Agent: agentCaller }` → `SetupWithManager(mgr)`.
+- Registers health/readiness probes only; **does not** invoke `controller/console` (console ensure is a separate library entry; see Console section).
+
+---
+
+## Module map: `controller/proposal/`
+
+| File | Types / primary responsibilities | Key functions / methods |
+|------|----------------------------------|-------------------------|
+| `reconciler.go` | `ProposalReconciler` (embeds `client.Client`, `Agent AgentCaller`, `Log`) | `Reconcile`, `SetupWithManager` |
+| `handlers.go` | (methods on `ProposalReconciler`) | `handleAnalysis`, `handleRevision`, `handleExecution`, `handleVerification`, `handleEscalation`, `handleFailed`, `denyProposal`, `conditionTime` |
+| `helpers.go` | `revisionData`, `analysisQuery`, `executionQuery`, `verificationQuery`, `escalationData`; embedded templates via `//go:embed templates/*.tmpl` | `renderTemplate`, `failStep`, `statusPatch`, `hasSandboxClaims`, `isTerminal`, `setVerificationSkipped`, `getLatestAnalysisResult`, `selectedOption`, `trimNonSelectedOptions`, `resetExecutionAndVerification`, `maxAttempts`, `buildEscalationRequest`, `needsRevision`, `buildRevisionContext`, `buildAnalysisQuery`, `buildExecutionQuery`, `buildVerificationQuery`, `prettyJSON` |
+| `approval.go` | — | `getApprovalPolicy`, `getProposalApproval`, `ensureProposalApproval`, `isStageApproved`, `isStageDenied`, `getStageOverrideAgent`, `getStageOption` |
+| `resolve.go` | `resolvedStep`, `resolvedWorkflow` | `resolveProposal`, `stepAgentName` |
+| `agent.go` | `AgentCaller`, `StubAgentCaller`; `AnalysisOutput`, `ExecutionOutput`, `VerificationOutput`, `EscalationOutput` | Interface methods on `StubAgentCaller` |
+| `sandbox.go` | `SandboxProvider`, `SandboxManager` | `NewSandboxManager`, `Claim`, `WaitReady`, `Release`, `buildClaim` |
+| `sandbox_agent.go` | `SandboxAgentCaller`; private JSON DTOs for unmarshaling agent responses local to this file | `NewSandboxAgentCaller`, `Analyze`, `Execute`, `Verify`, `Escalate`, `ReleaseSandboxes`, `callWithSandbox`, `patchSandboxInfo`, `buildAgentContext`, `collectFailedResults`, `stepString` |
+| `sandbox_templates.go` | `templateHashInput`; label constants (`LabelManaged`, `LabelProposal`, etc.); MCP env DTOs | `EnsureAgentTemplate`, `SandboxTemplateServiceAccount`, `computeTemplateHash`, `agentTemplateName`, `gcOldTemplates`, `patchLLMCredentials`, `credentialsSecretName`, `providerURL`, `patchRequiredSecrets`, `patchMCPServers`, `patchSkillsImage`, `patchSkillsPaths`, `patchAgentMode`, unstructured helpers (`firstContainer`, `setEnvVar`, `addEnvFromSecret`, …) |
+| `client.go` | `AgentHTTPClientInterface`, `AgentHTTPClient`; `agentRunRequest`, `agentContext`, `agentExecutionResult`, `agentPreviousAttempt`, `agentRunResponse` | `NewAgentHTTPClient`, `(*AgentHTTPClient).Run`, `executionOutputToAgentResult` |
+| `schemas.go` | Package vars: default/minimal analysis schemas, execution/verification/escalation schemas; `defaultOutputSchemas`, `builtInPropertyJSON` | `init` (precompute property JSON), `injectBuiltInProperty`, `outputSchemaForStep` |
+| `rbac.go` | — | `ensureExecutionRBAC`, `cleanupExecutionRBAC`, `annotatedRBACNamespaces`, `deleteIfExists`, `rbacTargetNamespaces`, `truncateK8sName`, `executionRoleName`, `clusterRoleName`, `rbacLabels`, `rbacRulesToPolicyRules`, `normalizeCoreAPIGroup` |
+| `results.go` | `statusHolder` interface (defined; no references elsewhere in this package) | `resultCRName`, `proposalOwnerRef`, `resultLabels`, `executionRetryIndex`, `resultConditions`, `createAnalysisResult`, `createExecutionResult`, `createVerificationResult`, `createEscalationResult`, `createIdempotent` |
+| `templates/*.tmpl` | Text templates | Names: `analysis_query.tmpl`, `execution_query.tmpl`, `verification_query.tmpl`, `revision_context.tmpl`, `escalation_request.tmpl` |
+| `reconciler_test.go` | `testAgentCaller`, fixtures | `testScheme`, `testDefaultAgent`, `testProposal`, `reconcileOnce`, `getProposal`, … |
+| `state_machine_test.go` | Policy/combo tests | Helpers: `testManualPolicy`, `newManualReconciler`, `approveStage`, `denyStage`, `assertPhase`, … |
+| `approval_test.go` | Tests for approval helpers | — |
+| `client_test.go` | HTTP client tests | — |
+| `handlers_test.go` | Handler-focused tests | — |
+| `helpers_test.go` | Helper tests | — |
+| `results_test.go` | Result CR tests | — |
+| `resolve_test.go` | Resolution tests | — |
+| `revision_test.go` | Revision flow tests | — |
+| `rbac_test.go` | RBAC ensure/cleanup tests | — |
+| `sandbox_test.go` | Sandbox manager tests | — |
+| `sandbox_agent_test.go` | Agent caller tests | — |
+| `sandbox_templates_test.go` | Template ensure/GC tests | — |
+| `schemas_test.go` | Output schema assembly tests | — |
+
+---
+
+## Module map: `controller/console/`
+
+| File | Types | Key functions |
+|------|-------|----------------|
+| `reconciler.go` | `AgenticConsoleConfig` (Image, Namespace); constants for plugin name, cert, nginx config string | `EnsureAgenticConsole` (orchestrates ordered ensures), `labels`, `ensureConfigMap`, `ensureServiceAccount`, `ensureService`, `ensureDeployment`, `ensureConsolePlugin`, `ensureConsoleActivation` |
+| `reconciler_test.go` | — | Tests for idempotency, image updates, skip when no image |
+
+**Integration note:** `EnsureAgenticConsole` is **not** registered in `cmd/main.go` in this repo snapshot; another binary or future setup is expected to call it with `AgenticConsoleConfig`. It mutates OpenShift `Console` cluster CR `spec.plugins` via retry-on-conflict.
+
+---
+
+## Data flow: reconcile loop
+
+1. **Watch / enqueue:** controller-runtime delivers `ctrl.Request` for a `Proposal` namespaced name. `SetupWithManager` also `Owns` child CRs (`ProposalApproval`, `AnalysisResult`, `ExecutionResult`, `VerificationResult`, `EscalationResult`) and **Watches** cluster `ApprovalPolicy` to enqueue all non-terminal proposals.
+2. **`Reconcile` load:** `Get` `Proposal`; ignore not-found.
+3. **Deletion path:** If `DeletionTimestamp` set and finalizer `agentic.openshift.io/execution-rbac-cleanup` present: `Agent.ReleaseSandboxes`, `cleanupExecutionRBAC`, remove finalizer, return.
+4. **Phase:** `agenticv1alpha1.DerivePhase(proposal.Status.Conditions)` — see **what/** for semantics.
+5. **Finalizer add:** If not terminal and finalizer missing, add RBAC cleanup finalizer (re-fetch proposal after patch).
+6. **Terminal / failed shortcuts:** Completed/Denied/Escalated → optional sandbox release via `Agent.ReleaseSandboxes`. `ProposalPhaseFailed` → `handleFailed` (RBAC cleanup if annotation set).
+7. **Shared prelude:** `getApprovalPolicy` (cluster singleton name `cluster`), `ensureProposalApproval`, `resolveProposal`. Resolution failure → set `ProposalConditionAnalyzed=False` with `reasonWorkflowFailed`, status patch, return (no requeue).
+8. **Phase switch:** Routes to `handleRevision` (if `needsRevision`) before analysis/execution/escalation arms; otherwise `handleAnalysis`, `handleExecution`, `handleVerification`, `handleEscalation`, or no-op.
+9. **Handlers** set step conditions (`Unknown` → agent call → `True`/`False`), create result CRs, append `Status.Steps.*.Results`, `statusPatch` proposal.
+10. **Agent path:** All agent steps go through `r.Agent.*` which (in production) is `SandboxAgentCaller`: template + `EnsureAgentTemplate` → `Sandbox.Claim` → early `patchSandboxInfo` on proposal → `WaitReady` → `AgentHTTPClient.Run` → JSON unmarshal into outputs.
+
+---
+
+## Handler dispatch pattern
+
+- **Single `Reconcile`** dispatches on **derived phase** and **revision predicate** (`needsRevision`: non-empty `Spec.RevisionFeedback` and `Generation > ObservedGeneration` on `ProposalConditionAnalyzed`).
+- **Revision** clears downstream conditions and step sandboxes for execution/verification, resets analyzed condition to `Unknown`, appends revision context to request text, re-runs analysis path logic.
+- **In-progress idempotency:** Each handler checks existing condition status (`Unknown` / `True`) to avoid duplicate agent invocations on requeue.
+- **Approval gates:** Handlers call `isStageDenied` / `isStageApproved` before progressing; waiting states return `(Result{}, nil)` without error.
+
+---
+
+## `SandboxManager` (pod CRUD, readiness, release)
+
+- Implements `SandboxProvider`.
+- **Claim:** Builds unstructured `SandboxClaim` (`extensions.agents.x-k8s.io/v1alpha1`, kind `SandboxClaim`) with labels `agentic.openshift.io/proposal`, `agentic.openshift.io/step`, `spec.sandboxTemplateRef`, `lifecycle.shutdownPolicy=Delete`. Name pattern `ls-{step}-{proposal}` truncated.
+- **WaitReady:** Polls claim → reads `status.sandbox.name` → loads `Sandbox` (`agents.x-k8s.io/v1alpha1`) until `status.conditions` contains `Ready=True`, then returns `status.serviceFQDN`.
+- **Release:** Deletes claim; treats NotFound as success.
+- **No log streaming in controller:** logs are cluster-side (`kubectl` / CLI); manager only waits for FQDN.
+
+---
+
+## `SandboxAgentCaller` and HTTP
+
+- **Constructor:** Accepts `SandboxProvider`, `client.Client`, `ClientFactory func(endpoint string) AgentHTTPClientInterface`, operator namespace, `BaseTemplateName`, `Timeout` (default from const).
+- **`callWithSandbox` order:** `EnsureAgentTemplate` → `Claim` → `patchSandboxInfo` (status subresource merge) → `WaitReady` → normalize URL (`http://{fqdn}:8080` if no scheme) → `outputSchemaForStep` → `ClientFactory(endpoint).Run(ctx, "", query, schema, agentCtx)`.
+- **`Run` contract:** Empty `systemPrompt`; full payload in POST body per `client.go` (`query`, `outputSchema`, `context`). Path constant `/v1/agent/run`.
+- **`buildAgentContext`:** `TargetNamespaces`, `ApprovedOption` / `ExecutionResult` per step, `PreviousAttempts` from failed `StepResultRef` outcomes across analysis/execution/verification result lists.
+- **`ReleaseSandboxes`:** Iterates `Status.Steps.{Analysis,Execution,Verification,Escalation}.Sandbox.ClaimName` and calls `Release` for each non-empty.
+
+---
+
+## `AgentHTTPClient` / `AgentHTTPClientInterface`
+
+- **`AgentHTTPClientInterface`:** `Run(ctx, systemPrompt, query, outputSchema, agentCtx) (*agentRunResponse, error)`.
+- **`NewAgentHTTPClient`:** Returns concrete type with long HTTP timeout, TLS `InsecureSkipVerify` for in-cluster calls.
+- **`Run`:** Marshals `agentRunRequest`, POSTs, reads capped body size, non-200 → error with truncated body; 200 → raw JSON in `agentRunResponse.Response` for caller to unmarshal phase-specific structs.
+
+---
+
+## Template system
+
+- **Embed:** `helpers.go` embeds `templates/*.tmpl` into `templateFS`; `template.Must(ParseFS(...))`.
+- **Query builders:** `buildAnalysisQuery` (`analysis_query.tmpl` + `analysisQuery`), `buildExecutionQuery` (`execution_query.tmpl` + pretty-printed option JSON), `buildVerificationQuery` (`verification_query.tmpl` + option + execution JSON via `executionOutputToAgentResult`).
+- **Revision:** `buildRevisionContext` → `revision_context.tmpl`.
+- **Escalation:** `buildEscalationRequest` → `escalation_request.tmpl` with proposal identity, request, and slices of `StepResultRef` from status (`Name`, `Outcome` per API — verify template field names match; `StepResultRef` has no `Success` field).
+
+---
+
+## Result CR creation
+
+- **Naming:** `resultCRName(proposalName, step, len(existingResults)+1)` with K8s name truncation.
+- **`createIdempotent`:** `Create` object (API server drops status on create), then `Status().Patch(MergeFrom)` from a deep copy that retained full status — required because status subresource is separate.
+- **Owner:** Controller ref to `Proposal`; labels `LabelProposal`, `LabelStep`.
+- **Execution/Verification result CRs:** `Spec.RetryIndex` from `executionRetryIndex` ( ties to verification retry semantics in **what/** specs).
+
+---
+
+## RBAC resource lifecycle
+
+- **Creation:** `handleExecution`, when selected option has non-empty `RBAC` rules, calls `ensureExecutionRBAC(ctx, Client, proposal, &selectedOption.RBAC, defaultSandboxSA, proposal.Namespace)`. Creates namespaced `Role`/`RoleBinding` per target namespace (from `Spec.TargetNamespaces` or rule namespace fields), persists comma-joined namespaces in annotation `agentic.openshift.io/rbac-namespaces`, and cluster `ClusterRole`/`ClusterRoleBinding` when cluster rules present. Sandbox SA name constant `defaultSandboxSA` (`lightspeed-agent` in `helpers.go`).
+- **Cleanup:** `cleanupExecutionRBAC` reads annotation to delete bindings/roles; deletes cluster RBAC by derived name. Invoked on: proposal deletion (finalizer), `handleFailed` if annotation set, after successful escalation completion, and terminal phases via sandbox release path is separate.
+- **`normalizeCoreAPIGroup`:** Maps LLM-facing `"core"` to `""` in K8s `PolicyRule.APIGroups`.
+
+---
+
+## Key abstractions
+
+- **`AgentCaller`:** Boundary between reconciler and runtime (stub vs sandbox+HTTP). Methods mirror workflow steps plus `ReleaseSandboxes`.
+- **`SandboxProvider`:** Swappable claim/wait/release (tests can fake).
+- **`resolveProposal`:** Produces `resolvedWorkflow` with cached `Agent` + `LLMProvider` per name; applies per-stage agent overrides from `ProposalApproval` via `getStageOverrideAgent`; `Execution`/`Verification` steps nil when corresponding spec sections are zero.
+- **`EnsureAgentTemplate`:** Deterministic derived `SandboxTemplate` name from hash of LLM spec, model, skills, MCP servers, required secrets, step, and **base template resourceVersion**. Patches pod template env/volumes for credentials, Vertex/Bedrock/Azure extras, skills image/paths, MCP JSON env, `LIGHTSPEED_MODE`. GC older templates labeled for same agent+step.
+
+---
+
+## Integration points (who calls whom)
+
+```
+cmd/main
+  └─ NewSandboxManager / NewSandboxAgentCaller / ProposalReconciler.SetupWithManager
+
+ProposalReconciler.Reconcile
+  └─ approval.go, resolve.go
+  └─ handlers.go → results.go, rbac.go, helpers.go (status, option trim)
+  └─ Agent (SandboxAgentCaller)
+        └─ sandbox_templates.go (EnsureAgentTemplate)
+        └─ sandbox.go (Claim/WaitReady/Release)
+        └─ helpers.go (query templates), schemas.go (outputSchemaForStep)
+        └─ client.go (HTTP Run)
+```
+
+---
+
+## Implementation notes (gotchas)
+
+- **`cmd/main.go` scheme:** Only core + `agenticv1alpha1`. Watching or applying arbitrary CRDs from tests may need extended schemes (see `reconciler_test.go`).
+- **Max concurrent reconciles:** `SetupWithManager` reads cluster `ApprovalPolicy` via API reader for `MaxConcurrentProposals`, else `DefaultMaxConcurrentProposals` from API package.
+- **Policy watch:** Enqueues **all** non-terminal proposals on any `ApprovalPolicy` event — can be chatty.
+- **Workflow resolution errors:** Patched onto `ProposalConditionAnalyzed` false — see API for exact condition ordering vs `DerivePhase`.
+- **`selectedOption` vs trim:** Verification uses latest analysis result’s **first** option (`Options[0]`) when resolving; execution path uses `trimNonSelectedOptions` which respects `ProposalApproval` execution option index when multiple options exist.
+- **`maxAttempts`:** Combines `ApprovalPolicy.Spec.MaxAttempts` ceiling with per-approval execution override (`helpers.go`); retry semantics interact with verification failure branch in `handleVerification` (see **what/proposal-lifecycle.md**).
+- **Sandbox FQDN:** Agent URL assumes port `8080` unless endpoint already has `http` prefix.
+- **Logs CLI vs status:** CLI `logs` uses `SandboxInfo.ClaimName` as **pod name** in `GetLogs`; ensure cluster layout matches (if claim name ≠ pod name, logs command would need revision — operational detail for agents touching `logs.go`).
+- **Tests:** `state_machine_test.go` is the primary lifecycle matrix; `testAgentCaller` implements `AgentCaller` with injectable errors/results; fake client uses `WithStatusSubresource` for proposal and result types.

--- a/.ai/spec/what/README.md
+++ b/.ai/spec/what/README.md
@@ -1,0 +1,16 @@
+# Behavioral Specifications (what/)
+
+These specs define WHAT the operator must do -- testable behavioral rules, configuration surface, constraints, and planned changes. They are technology-neutral where possible and survive a complete rewrite.
+
+## Spec Index
+
+| Spec | Description |
+|------|-------------|
+| [proposal-lifecycle.md](proposal-lifecycle.md) | Proposal phases, condition-driven state machine, retry logic, revision, escalation |
+| [crd-api.md](crd-api.md) | All CRD types and field semantics: Proposal, Agent, LLMProvider, ApprovalPolicy, result CRs |
+| [approval.md](approval.md) | Human-in-the-loop approval system: policy modes, stage gates, deny semantics |
+| [sandbox-execution.md](sandbox-execution.md) | Sandbox pod lifecycle, RBAC scoping, agent communication, skills mounting |
+
+## Relationship to how/ Specs
+
+These `what/` specs define the behavioral contract. The [`how/` specs](../how/README.md) describe the current Go implementation. Read `what/` to understand requirements, read `how/` to understand the codebase structure.

--- a/.ai/spec/what/approval.md
+++ b/.ai/spec/what/approval.md
@@ -1,0 +1,54 @@
+# Human approval and policy
+
+Behavioral specification for gating asynchronous workflow steps. **Phase derivation** is in `proposal-lifecycle.md`. **CRD field shapes** are in `crd-api.md`.
+
+## Behavioral Rules
+
+1. **Policy resource**: Default cluster behavior is read from a cluster-scoped `ApprovalPolicy` named `cluster`. If the object is absent, the controller MUST behave as if all stages require manual human approval entries (no automatic stages).
+2. **Per-proposal resource**: Each `Proposal` MUST have a paired `ProposalApproval` with identical `metadata.name` and `metadata.namespace`. The controller MUST create it on first reconcile if missing, with an initial `spec.stages` containing only stages marked `Automatic` in the policy (each auto stage is inserted with empty parameters and without an explicit `decision` — see rule 6).
+3. **Owner reference**: The created `ProposalApproval` MUST be owned by its `Proposal` (controller owner ref, block owner deletion) so it is garbage-collected with the proposal.
+4. **Stage coverage**: Policy lists optional `spec.stages[]` entries named `Analysis`, `Execution`, `Verification`, or `Escalation`. Any workflow step **not** listed in the policy defaults to **Manual** gate behavior.
+5. **API vocabulary — `ApprovalMode`**: `Automatic` means the step is treated as approved without requiring a user-appended `ProposalApproval` stage entry (policy alone suffices). `Manual` means the step MUST have a matching entry in `ProposalApproval.spec.stages` unless no longer needed because the workflow ended earlier.
+6. **Auto seed shapes**: On creation only, automatic stages MUST be represented as `ApprovalStage` entries with the correct `type`, empty nested `analysis|execution|verification|escalation` struct, and **no** explicit `decision` field (implicitly not denied).
+7. **Approved vs denied — `ProposalApproval` entry**: A stage is **approved** for gating if a `ProposalApproval.spec.stages` element exists with matching `type` and `decision` is **not** `Denied`. Omitted `decision` MUST be treated as approved (not denied).
+8. **Denied terminal**: If any stage has `decision: Denied`, the controller MUST transition the proposal to a denied terminal condition (`Denied=True` at proposal level). Denial MUST be honored at the gate for the matching step when evaluated (analysis, execution, verification, or escalation).
+9. **Combined gate function**: For a sandbox step `S`, the effective **approve** signal is true if either (a) `ProposalApproval` contains an approved (non-denied) stage entry for `S`, OR (b) `ApprovalPolicy.spec.stages` contains `name=S` with `approval: Automatic`. This allows policy changes after creation to unblock proposals that still have empty `ProposalApproval` stages (fallback path).
+10. **Order of operations**: Analysis MUST pass its gate before the controller runs analysis. Execution MUST pass execution gate after analysis succeeds AND before RBAC + execution. Verification MUST pass verification gate before verification runs. Escalation MUST pass escalation gate before escalation runs.
+11. **Proposed idle**: When analysis is complete and execution is configured, the proposal remains in the **Proposed** derived phase until the execution gate opens (manual approval or automatic policy) — reconciliation MUST be idempotent while waiting.
+12. **Verifying idle**: After execution succeeds and verification is configured, the proposal remains **Verifying** while waiting for verification approval when manual.
+13. **Escalation idle**: When escalation is required, the proposal remains **Escalating** until escalation is approved (or auto policy) and the escalation agent completes or fails.
+14. **Execution option selection**: When multiple `RemediationOption` entries exist on the latest `AnalysisResult`, the user MUST select one via `ProposalApproval` execution stage `option`. If omitted, the effective index MUST default to option `0`.
+15. **Trim-on-execute**: Before executing, when more than one option remains stored, the controller SHOULD persist a trimmed `AnalysisResult.status.options` containing only the selected option; when only one option exists, trimming is a no-op beyond selection.
+16. **Execution agent override**: `ProposalApproval` execution stage `agent`, when set, MUST override `spec.execution.agent` / default agent naming for resolving the `Agent` CR for that step.
+17. **Analysis/verification/escalation agent overrides**: Each stage’s nested object MAY carry `agent` which MUST override the proposal’s step agent for that stage when non-empty (escalation default remains analysis agent if no override — per controller resolution rules).
+18. **Max attempts — ceiling**: Let `ceiling` be `ApprovalPolicy.spec.maxAttempts` when that value is positive; otherwise `ceiling` MUST be treated as `1` for attempt budgeting.
+19. **Max attempts — execution cap**: When `ProposalApproval` execution stage sets `maxAttempts` > 0, the effective maximum attempts MUST be the lesser of that value and `ceiling`. When execution stage omits `maxAttempts` or sets zero, the effective maximum MUST be `ceiling`.
+20. **Max attempts — policy absent**: With no `ApprovalPolicy` object, `ceiling` MUST be `1`; execution stage `maxAttempts` MUST still be capped by that effective ceiling (cannot raise attempts without a policy defining a higher ceiling).
+21. **Attempts semantics**: “Max attempts” counts total execution runs in the current analysis context (initial run plus post-verification retries) until success or escalation per `proposal-lifecycle.md`.
+22. **Verification approval persistence**: User approval for verification MUST apply across verification retries within the same analysis iteration (tests verify a single verification approval covers multiple verify invocations after execution retries).
+23. **CEL invariants on `ProposalApproval`**: Users MUST NOT remove prior stages; MUST NOT flip decisions; MUST NOT lower execution `maxAttempts` once set — CRD validation enforces these.
+24. **Append-only human workflow**: Operators SHOULD instruct users to add new stages by patching `spec.stages` append-only rather than replacing the whole list, to respect CEL.
+25. **Escalation stage existence**: Escalation is not in `Proposal.spec`; it appears only when retry/verification logic escalates. Approval for escalation follows the same Automatic/Manual rules as other stages.
+
+## Configuration Surface
+
+- `ApprovalPolicy.metadata.name` (must equal `cluster`)
+- `ApprovalPolicy.spec.stages[].name`, `ApprovalPolicy.spec.stages[].approval`
+- `ApprovalPolicy.spec.maxAttempts`, `ApprovalPolicy.spec.maxConcurrentProposals`
+- `ProposalApproval.metadata.name`, `ProposalApproval.metadata.namespace`
+- `ProposalApproval.spec.stages[].type`, `ProposalApproval.spec.stages[].decision`
+- `ProposalApproval.spec.stages[].analysis.agent`
+- `ProposalApproval.spec.stages[].execution.agent`, `.option`, `.maxAttempts`
+- `ProposalApproval.spec.stages[].verification.agent`
+- `ProposalApproval.spec.stages[].escalation.agent`
+
+## Constraints
+
+- Product documentation that speaks in terms such as “always approve”, “always require approval”, or “require approval only for execution” MUST be translated into explicit `Automatic`/`Manual` combinations on `ApprovalPolicy.spec.stages`; the CRD does **not** encode those phrases as enumerated `ApprovalMode` values.
+- Policy MUST NOT be namespace-scoped in the current API — only the cluster singleton is read by name `cluster`.
+
+## Planned Changes
+
+- [PLANNED: OLS-2894] **Proposal-scoped policy hints** (e.g. annotations) evaluated **before** cluster `ApprovalPolicy` for enterprise overrides.
+- [PLANNED: OLS-2894] **Namespace-scoped `ApprovalPolicy`** or additional policy CRDs if tenancy demands policies per namespace instead of a single cluster singleton.
+- [PLANNED: OLS-3019] Re-authorization or **re-approval** for long-running or deviating executions beyond append-only stage semantics.

--- a/.ai/spec/what/crd-api.md
+++ b/.ai/spec/what/crd-api.md
@@ -1,0 +1,86 @@
+# CRD API semantics (`agentic.openshift.io/v1alpha1`)
+
+Kubernetes API surface for the agentic operator. **Lifecycle and gates** are in `proposal-lifecycle.md` and `approval.md`. **Sandbox runtime behavior** is in `sandbox-execution.md`.
+
+## Behavioral Rules
+
+1. **Group/version**: All kinds in this specification use API group `agentic.openshift.io` and version `v1alpha1`.
+2. **Scope — namespaced**: `Proposal`, `ProposalApproval`, `AnalysisResult`, `ExecutionResult`, `VerificationResult`, `EscalationResult` MUST be namespace-scoped; their `metadata.namespace` is the tenant/workload namespace.
+3. **Scope — cluster**: `Agent`, `LLMProvider`, and `ApprovalPolicy` MUST be cluster-scoped; `metadata.name` is the global identifier.
+4. **Proposal identity**: A `Proposal` MUST include required immutable fields per CEL: at minimum `spec.request` and `spec.analysis`. Omitting `spec.execution` or `spec.verification` means those steps do not exist for that proposal (see `proposal-lifecycle.md`).
+5. **Proposal — `spec.request`**: Human/agent input text; immutable after creation; max length enforced by validation.
+6. **Proposal — `spec.revisionFeedback`**: Only mutable spec field; when set/non-empty and `metadata.generation` advances beyond the analyzed condition’s `observedGeneration`, operators MUST trigger re-analysis per `proposal-lifecycle.md`.
+7. **Proposal — `spec.targetNamespaces`**: Optional list of namespaces for context and RBAC targeting; immutable once set; when empty, RBAC targeting MAY fall back to namespaces declared in analysis RBAC output at execution time (see `sandbox-execution.md`).
+8. **Proposal — `spec.analysisOutput`**: Immutable after set. `mode` defaults to full analysis schema when empty/default. `mode=Minimal` REQUIRES `schema` to be set, forbids `spec.execution` and `spec.verification`, and restricts option shape accordingly.
+9. **Proposal — `spec.tools`**: Default `ToolsSpec` for all steps; immutable once set. Per-step `tools` on `spec.analysis` / `spec.execution` / `spec.verification` replaces the default for that step only when non-zero.
+10. **Proposal — `spec.analysis|execution|verification`**: Immutable `ProposalStep` records after set. Each non-zero step MAY name `agent` (DNS subdomain) defaulting to `default` when empty; MAY carry per-step `tools`.
+11. **Proposal — `status`**: Observed-only. `status.conditions` holds map-merge conditions (types include `Analyzed`, `Executed`, `Verified`, `Denied`, `Escalated`). `status.steps` holds per-step sandbox info, retry counter (execution), and result refs.
+12. **Phase display types**: `ProposalPhase` and `StepPhase` string enums in the API describe display labels only; they are not stored fields on `Proposal` (phase is derived — see `proposal-lifecycle.md`). `StepPhase` values include `PendingApproval`, `Running`, `Completed`, `Failed`, `Skipped`.
+13. **Sandbox step enum**: `SandboxStep` values `Analysis`, `Execution`, `Verification`, `Escalation` identify workflow steps for approvals, sandbox labels, and policies.
+14. **Agent — `spec.llmProvider`**: Required reference by name to a cluster `LLMProvider`.
+15. **Agent — `spec.model`**: Required provider-specific model identifier string; validation restricts charset.
+16. **Agent — `spec.timeouts`**: Optional per-step and chat timeouts in seconds with min/max bounds per field.
+17. **Agent — `spec.maxTurns`**: Optional bound on tool-use turns per invocation.
+18. **Agent — `status.conditions`**: Observed readiness; `Ready` condition documents whether referenced provider resources are accessible (see operator reconcile behavior).
+19. **LLMProvider — discriminator**: `spec.type` MUST match exactly one embedded config: `anthropic`, `googleCloudVertex`, `openAI`, `azureOpenAI`, or `awsBedrock`; CEL enforces mutual exclusion.
+20. **LLMProvider — secrets**: Each provider’s `credentialsSecret` references a `Secret` **by name** in the operator namespace (documented on fields as the deployment namespace for the operator, e.g. OpenShift Lightspeed namespace); required secret **keys** are defined per provider type on the API field comments (e.g. API key env file key names).
+21. **LLMProvider — endpoints**: Optional URL overrides per provider; validation enforces HTTP/HTTPS URL shape. Azure requires `endpoint`; optional separate URL override field exists where defined.
+22. **ApprovalPolicy — singleton name**: CRD validation requires `metadata.name` equals `cluster`.
+23. **ApprovalPolicy — `spec.stages`**: Optional list keyed by `name` (`SandboxStep`). Each entry sets `approval` to `Automatic` or `Manual`. Stages not listed default to **Manual** per API comments.
+24. **ApprovalPolicy — `spec.maxAttempts`**: Upper bound for execution attempts (initial + retries) when verification fails; default behavior when unset is defined in controller (see `approval.md`).
+25. **ApprovalPolicy — `spec.maxConcurrentProposals`**: Caps concurrent reconciles when positive; operator falls back to a default constant when unset.
+26. **ProposalApproval — pairing**: For each `Proposal`, the controller MUST create (if missing) a same-named `ProposalApproval` in the same namespace with controller owner reference to the `Proposal`.
+27. **ProposalApproval — `spec.stages`**: Append-only map list keyed by `type` (`ApprovalStageType`). Each stage carries a discriminated union: exactly one of `analysis`, `execution`, `verification`, `escalation` MUST be present matching `type`. Optional `decision` may be `Approved` (default when omitted) or `Denied`; `Denied` is terminal per API rules.
+28. **ProposalApproval — immutability CEL**: Stages cannot be removed; decisions cannot change once set; execution `maxAttempts` cannot decrease once set.
+29. **Execution approval fields**: `spec.stages[].execution.option` selects 0-based analysis option index; `maxAttempts` caps attempts but MUST NOT exceed policy `maxAttempts`; `agent` overrides the `Proposal` step’s agent when set.
+30. **AnalysisResult**: `spec.proposalName` immutable; `status.options` holds `RemediationOption` entries; `status.sandbox` and `status.failureReason` optional; conditions use shared result condition types.
+31. **ExecutionResult**: Adds `spec.retryIndex` (bound to allowed retry range per field validation); `status.actionsTaken`, `status.verification` (inline), optional `failureReason`, `sandbox`.
+32. **VerificationResult**: `spec.retryIndex` parallels execution for the same attempt cluster; `status.checks`, `status.summary`, optional `failureReason`, `sandbox`.
+33. **EscalationResult**: `status.summary`, `status.content`, optional `failureReason`, `sandbox`; no `retryIndex`.
+34. **RemediationOption**: Cohesion rules require `diagnosis` and `proposal` to be paired when present; `components` holds schemaless JSON for adapter data shaped by `spec.analysisOutput.schema`.
+35. **RBACResult / RBACRule**: Analysis MAY request namespace-scoped and cluster-scoped rules with verb/apigroup/resource metadata and mandatory `justification`; `namespace` on rules MUST align with proposal targeting rules (validated at runtime by policy engine per field comments).
+36. **ToolsSpec**: MAY include `skills` (unique images), `mcpServers` (unique names), `requiredSecrets` (unique names). `SkillsSource.image` MUST be a valid pullspec; optional `paths` restrict mounted subtrees.
+37. **SecretRequirement**: Names a namespace-local `Secret`; `mountAs` discriminates `EnvVar` vs `FilePath` with required nested config per type.
+38. **MCPHeaderValueSource**: Discriminated by `type`; `Secret` requires nested `secret` name reference.
+39. **Result CR ownership**: Result CRs MUST declare controller `ownerReferences` to their `Proposal` for GC; naming follows operator conventions (see `sandbox-execution.md` for when they are created).
+40. **Label conventions**: Operator uses labels for proposal name, step, component, and managed template markers (exact keys are implementation-specific; behavior: selectors for GC/list, not duplicated here).
+41. **CEL immutability** (Proposal): Enforced transitions include: `request`, `targetNamespaces`, `analysisOutput`, `tools`, `analysis`, `execution`, `verification` immutability after initial set as encoded in API markers.
+
+## Configuration Surface (by path)
+
+### Proposal
+- `metadata.*`
+- `spec.request`, `spec.targetNamespaces`, `spec.revisionFeedback`, `spec.analysisOutput`, `spec.tools`, `spec.analysis`, `spec.execution`, `spec.verification`
+- `status.conditions`, `status.steps.analysis|execution|verification|escalation.*`
+
+### Agent
+- `metadata.name`, `spec.llmProvider.name`, `spec.model`, `spec.timeouts.*`, `spec.maxTurns`, `status.conditions`
+
+### LLMProvider
+- `metadata.name`, `spec.type`, `spec.anthropic.*`, `spec.googleCloudVertex.*`, `spec.openAI.*`, `spec.azureOpenAI.*`, `spec.awsBedrock.*`
+
+### ApprovalPolicy
+- `metadata.name` (must be `cluster`), `spec.stages[]`, `spec.maxAttempts`, `spec.maxConcurrentProposals`
+
+### ProposalApproval
+- `metadata.name`, `metadata.namespace`, `spec.stages[]`, `status.stages[]`
+
+### AnalysisResult / ExecutionResult / VerificationResult / EscalationResult
+- `metadata.name`, `metadata.namespace`, `spec.*`, `status.*`
+
+### Shared / embedded types
+- `ToolsSpec`: `skills[]`, `mcpServers[]`, `requiredSecrets[]`
+- `SkillsSource`: `image`, `paths[]`
+- `SecretRequirement`: `name`, `description`, `mountAs.*`
+- `StepResultRef`: `name`, `outcome`
+- `SandboxInfo`: `claimName`, `namespace`
+
+## Constraints
+
+- Cross-object references (`Agent`, `LLMProvider`, `Secret`) MUST resolve or reconciliation surfaces resolution errors as workflow failures per controller behavior.
+- **User-facing policy modes** in product docs mentioning “always approve / require approval for execution only” MUST map onto the actual API values `Automatic` and `Manual` plus stage lists; there is no separate enum for those phrases in the CRD.
+
+## Planned Changes
+
+- [PLANNED: OLS-2940] Autonomous workflow CRD migrations may rename or reshape fields; specs MUST be updated when `v1alpha1` changes.
+- [PLANNED: OLS-2894] Explicit **Agent** fields for per-step system prompts if moved from template/runtime-only assembly (today prompts are composed outside `Agent` CR — see `sandbox-execution.md`).

--- a/.ai/spec/what/proposal-lifecycle.md
+++ b/.ai/spec/what/proposal-lifecycle.md
@@ -1,0 +1,69 @@
+# Proposal lifecycle (state machine)
+
+Behavioral specification for the `Proposal` resource lifecycle. **Approval gates, sandbox calls, and RBAC** are defined in `approval.md` and `sandbox-execution.md`. **Field semantics** are in `crd-api.md`.
+
+## Behavioral Rules
+
+1. **Source of truth**: `status.conditions` (Kubernetes conditions keyed by `type`) is authoritative. The **phase** is a derived display value only; it is not persisted as its own field.
+2. **Phases**: The system MUST derive exactly one phase label from `status.conditions` using the algorithm in rule 9 (and precedence rules 10–11). Valid labels: `Pending`, `Analyzing`, `Proposed`, `Executing`, `Verifying`, `Completed`, `Failed`, `Denied`, `Escalating`, `Escalated`.
+3. **Condition types (proposal-level)**: The workflow uses `Analyzed`, `Executed`, `Verified`, `Denied`, `Escalated` (string values as defined on the API). Status values are `True`, `False`, or `Unknown`.
+4. **Terminal phases**: `Completed`, `Denied`, `Escalated`, and `Failed` are terminal for reconciliation progression. After `Completed`, `Denied`, or `Escalated`, the controller MUST stop active work and MAY release sandbox claims when present. `Failed` triggers failure cleanup behaviors (see `sandbox-execution.md` for RBAC cleanup interactions).
+5. **Workflow shape**: `spec.analysis` is always required. `spec.execution` and `spec.verification` MAY be omitted; omission skips those steps subject to rules 20–22.
+6. **Revision loop**: If `spec.revisionFeedback` is non-empty AND `metadata.generation` is greater than `Analyzed.observedGeneration`, the system MUST treat the proposal as needing **re-analysis** before continuing downstream steps. Re-analysis MUST append revision context to the user-visible request text (after `spec.request`), then reset execution/verification/escalation progress as implemented for revision handling, and MUST NOT advance execution until the new analysis completes.
+7. **Execution retries (verification-gated)**: When `spec.verification` is present, after a successful execution the verification step MAY fail **objectively** if the agent reports failure **or** any verification check records a non-pass outcome (even when a coarse success flag might otherwise read true). In that case the system MAY increment `status.steps.execution.retryCount` and clear execution/verification progress to run execution again, bounded by the effective max attempt count from approval policy and execution approval (see `approval.md`). While awaiting a retry, `Verified` MUST be `False` with reason indicating retrying execution.
+8. **Escalation injection**: When verification has failed and retries are exhausted (per `approval.md`), the system MUST set `Verified` to `False` with reason indicating retries exhausted and MUST set `Escalated` to `Unknown` with reason indicating retries exhausted, entering the escalating phase until the escalation step completes or fails.
+9. **DerivePhase — precedence (first match in order)**:
+   - If `Escalated` exists with status `True` → phase `Escalated`.
+   - Else if `Denied` exists with status `True` → phase `Denied`.
+   - Else if `Escalated` exists → if status is `Unknown` → phase `Escalating`; otherwise → phase `Failed`.
+   - Else evaluate `Verified` if present:
+     - If `Verified` is `True` → phase `Completed`.
+     - If `Verified` is `Unknown` → phase `Verifying`.
+     - If `Verified` is `False` AND reason indicates retrying execution → phase `Executing`.
+     - If `Verified` is `False` otherwise → phase `Failed`.
+   - Else evaluate `Executed` if present:
+     - If `Executed` is `True` → phase `Verifying`.
+     - If `Executed` is `Unknown` → phase `Executing`.
+     - If `Executed` is `False` → phase `Failed`.
+   - Else evaluate `Analyzed` if present:
+     - If `Analyzed` is `True` → phase `Proposed`.
+     - If `Analyzed` is `Unknown` → phase `Analyzing`.
+     - If `Analyzed` is `False` → phase `Failed`.
+   - Else → phase `Pending`.
+10. **Denial vs escalation in derivation**: `Escalated=True` MUST win over `Denied=True` if both are present because derivation checks complete escalation before denial. Otherwise `Denied=True` MUST win over non-terminal progress (`Analyzed`, `Executed`, `Verified` combinations).
+11. **Advisory completion**: If execution is absent and verification is absent, after successful analysis the controller MAY set `Executed` and `Verified` to `True` with skip reasons such that the derived phase is `Completed`.
+12. **Trust mode completion**: If execution is present and verification is absent, after successful execution the controller MUST set `Verified` to `True` with a skip reason such that the derived phase is `Completed`.
+13. **Skipped steps**: `Executed=True` with skip reason and `Verified=True` with skip reason together MUST derive `Completed` when that is the intended advisory outcome per tests and valid condition combinations.
+14. **Step phases (display vocabulary)**: The API defines per-step display phases `PendingApproval`, `Running`, `Completed`, `Failed`, `Skipped` (see `crd-api.md`). A conforming implementation SHOULD map: `Running` ↔ corresponding proposal-level step condition `Unknown` with in-progress reason; `Completed` ↔ `True` with complete/passed/skipped reason as applicable; `Failed` ↔ `False`; `Skipped` ↔ `True` with skipped reason on execution/verification where applicable; `PendingApproval` ↔ step not yet active while proposal phase waits on approval for that step (see `approval.md`). The controller in this repo primarily materializes **proposal-level** `status.conditions`; per-step `status.steps.*.conditions` MAY be empty until populated by future work.
+15. **Success**: `Verified=True` MUST yield `Completed` once rule 9 reaches the `Verified` branch, unless an earlier branch already returned `Escalated` or `Denied` per rules 9–10.
+16. **Step failure**: Any of `Analyzed`, `Executed`, or `Verified` with status `False` and reasons that are not the dedicated retrying-execution reason MUST yield `Failed` when reached by the derivation order in rule 9 (unless superseded by `Escalated` / `Denied` per rules 9–10).
+17. **Escalation failure**: `Escalated` with status `False` MUST yield `Failed` once rule 9 evaluates the `Escalated` presence branch (non-`True`, non-`Unknown`).
+18. **Result CR linkage**: Each analysis/execution/verification/escalation attempt SHOULD append a `status.steps.*.results[]` entry naming the corresponding result resource with an outcome matching agent success/failure for that attempt.
+19. **Observed generation**: Conditions SHOULD carry `observedGeneration` aligned with `metadata.generation` when the controller updates them for the current spec generation, except revision completion MAY pin the analyzed condition to the generation that triggered the revision, per existing reconciliation behavior.
+20. **Immutable spec (excluding revision)**: Once set, `spec.request`, `spec.targetNamespaces`, `spec.analysisOutput`, `spec.tools`, `spec.analysis`, `spec.execution`, and `spec.verification` MUST NOT change; CEL on the CRD enforces this. Only `spec.revisionFeedback` is mutable for iterative feedback.
+21. **Option trim after analysis**: When multiple remediation options exist, execution MUST use the option selected through the approval resource; non-selected options MAY be removed from the stored analysis result before execution (see `approval.md`).
+22. **Selected option for verification**: Verification MUST use the same selected remediation option as execution (latest trimmed analysis result).
+
+## Configuration Surface
+
+- `spec.request`
+- `spec.revisionFeedback`
+- `spec.targetNamespaces`
+- `spec.analysisOutput` / `spec.analysisOutput.mode` / `spec.analysisOutput.schema`
+- `spec.tools` and per-step `spec.analysis.tools`, `spec.execution.tools`, `spec.verification.tools`
+- `spec.analysis`, `spec.execution`, `spec.verification`
+- `metadata.generation` (revision detection vs `status.conditions`)
+- `status.conditions[*].type`, `status.conditions[*].status`, `status.conditions[*].reason`, `status.conditions[*].observedGeneration`
+- `status.steps.execution.retryCount`
+- `status.steps.*.results`, `status.steps.*.sandbox`
+
+## Constraints
+
+- Derivation MUST be a pure function of `status.conditions` for phase display (same conditions → same phase).
+- Downstream steps MUST NOT run before approval and precondition rules in `approval.md` are satisfied.
+- Total execution attempts (initial + retries) MUST NOT exceed the effective limit from `approval.md`.
+
+## Planned Changes
+
+- [PLANNED: OLS-2913] Populate `status.steps.<step>.conditions` consistently for UIs/CLI without inferring only from top-level conditions.
+- [PLANNED: OLS-2894] **Per-proposal approval overrides** (e.g. annotations) and **namespace-scoped approval policy** if product requires policy resolution beyond cluster singleton `ApprovalPolicy` named `cluster` (current code: cluster singleton only; see `approval.md`).

--- a/.ai/spec/what/sandbox-execution.md
+++ b/.ai/spec/what/sandbox-execution.md
@@ -1,0 +1,60 @@
+# Sandbox execution and agent I/O
+
+Behavioral specification for how workflow steps run inside ephemeral **sandboxes** and how the operator talks to the agent HTTP API. **Approval gates** are in `approval.md`. **CRD fields** for tools, secrets, and agents are in `crd-api.md`.
+
+## Behavioral Rules
+
+1. **Sandbox API objects**: For each step invocation, the controller MUST create a namespaced **SandboxClaim** (API group `extensions.agents.x-k8s.io`, `v1alpha1`) that references a **SandboxTemplate** by name and uses a shutdown policy that deletes the sandbox when released.
+2. **Operator namespace**: Sandbox claims and sandbox workloads MUST reside in the **operator’s configured namespace** (process flag `namespace` or equivalent environment substitution), not necessarily the `Proposal` namespace.
+3. **Template selection**: Before claiming, the controller MUST ensure a **derived** `SandboxTemplate` exists: it clones a **base** template identified by configured default template name, patches it with resolved LLM credentials, model id, tools (skills, MCP, required secrets), and step mode, and names it deterministically using a hash of relevant inputs so identical configurations reuse the same template.
+4. **Template immutability & GC**: If a derived template for the same agent + step + hash already exists, creation MUST be a no-op. Older derived templates for the same agent+step with different names SHOULD be garbage-collected after successful creation of the newest.
+5. **Claim naming**: Claim names MUST be derived from proposal name and step label, truncated to valid Kubernetes name length limits.
+6. **Readiness**: The controller MUST poll sandbox/claim status until the backing `Sandbox` reports `Ready=True` (standard condition pattern) and exposes a **service FQDN** for in-cluster HTTP, or until a configurable **sandbox wait budget** elapses (error path).
+7. **Endpoint construction**: Agent HTTP URL MUST be formed from the readiness endpoint; if the endpoint is not already an absolute URL with HTTP scheme, the client MUST prefix standard cluster HTTP scheme and port expected for the agent container.
+8. **HTTP contract**: Each step MUST call the agent **`POST /v1/agent/run`** with JSON body carrying at least `query`, `outputSchema`, and `context`; optional `systemPrompt` and `timeout_ms` exist in the wire shape but **system prompt MUST be sent empty** in the current implementation (prompt material lives in `query` and templates).
+9. **Response handling**: HTTP success responses MUST be parsed as JSON matching the per-step schema (analysis/execution/verification/escalation). Non-success HTTP MUST fail the step with an error surfaced to proposal conditions.
+10. **Output schema selection**: `outputSchema` MUST be the step-specific JSON schema: analysis schema depends on `spec.analysisOutput.mode`, whether execution/verification steps exist in the proposal, and optional injected `components` sub-schema from `spec.analysisOutput.schema`; other steps use fixed schemas for their response shapes.
+11. **Analysis query payload**: The `query` string MUST encode the user request or revision-augmented request and encode workflow flags indicating whether execution/verification steps exist (template-rendered).
+12. **Execution query payload**: The `query` MUST include JSON describing the approved remediation option.
+13. **Verification query payload**: The `query` MUST include the approved option JSON and a JSON description of the latest execution output (actions and inline verification) when available.
+14. **Context envelope**: The `context` object MUST include `targetNamespaces` from `spec.targetNamespaces`, synthesized `previousAttempts` from failed prior `status.steps.*.results` entries, `approvedOption` when executing/verifying, and `executionResult` when verifying. Note: the sandbox context prefix formatter (see sandbox `run-api.md`) only expands `targetNamespaces`, `attempt`, `previousAttempts`, and `approvedOption` into the model prompt; `executionResult` is carried in `context` for tracing but verification execution details are primarily conveyed to the model via the `query` body (rendered from the verification template).
+15. **Secrets — proposal** `spec.tools.requiredSecrets` / per-step tools: Secret objects MUST live in the **same namespace as the `Proposal`**. Mounting into sandbox MUST honor `SecretMountSpec`: environment variable injection OR file mount at configured absolute path.
+16. **Secrets — LLM credentials**: LLM provider credentials MUST be loaded from secret names declared on the `LLMProvider` and wired into the derived template via env/volumes per provider type (including optional file mounts for provider types that require file-based credentials).
+17. **Secrets — MCP headers**: When an MCP header sources a Secret, the template MUST mount that secret on a dedicated read-only path suitable for header injection configuration.
+18. **Skills volumes**: Skills MUST be conveyed as OCI image volume(s) on the sandbox pod template; when `SkillsSource.paths` is set, the controller MUST mount each path as a `subPath` under the configured skills mount root using stable mount naming derived from the path’s final segment. When multiple `skills` entries exist in `ToolsSpec`, template derivation MUST apply image/path patching based on the **first** non-empty skills source (current behavior).
+19. **MCP servers**: MCP configuration MUST be serialized to an environment variable payload listing servers, URLs, timeouts, and header sources so the agent runtime can open MCP connections without CR-specific code in the agent.
+20. **Sandbox observability patch**: Immediately after creating a claim, the controller MUST patch `Proposal.status.steps.<step>.sandbox` with claim name and operator namespace so consoles/CLIs can tail logs before the sandbox is ready.
+21. **Execution RBAC materialization**: When the approved remediation option includes RBAC requests, before execution the controller MUST create namespace-scoped `Role`+`RoleBinding` pairs in each target namespace ClusterRole+ClusterRoleBinding for cluster-scoped rules, binding subjects to the **sandbox service account** used by the template (cluster-wide default name configured in operator). Idempotent create MUST tolerate existing objects.
+22. **RBAC subjects namespace**: RoleBindings MUST reference the service account in the **operator namespace** (where sandbox pods run), even when roles live in target namespaces.
+23. **RBAC tracking annotation**: The controller SHOULD persist the list of namespaces receiving namespace-scoped RBAC on the `Proposal` via a dedicated annotation so cleanup can run after retries or status resets.
+24. **RBAC cleanup**: When the proposal reaches configured terminal outcomes, fails fatally, completes escalation successfully, or is deleted, the controller MUST delete execution RBAC objects it created, using the annotation or equivalent persisted scope information.
+25. **Finalizers**: Non-deleted proposals MUST gain a cleanup finalizer before leaving non-terminal phases so deletion can run RBAC and sandbox release hooks safely.
+26. **Result CR writes**: After each successful or failed agent invocation (per step), the controller MUST create/update an `AnalysisResult`, `ExecutionResult`, `VerificationResult`, or `EscalationResult` with immutable spec, owner reference to the `Proposal`, started/completed conditions, embedded outcome payload, sandbox reference, and optional `failureReason` for system errors.
+27. **Retry index**: `ExecutionResult` and `VerificationResult` MUST record the current execution retry index in spec for correlation with `status.steps.execution.retryCount`.
+28. **Sandbox release**: On proposal deletion and on terminal phases (`Completed`, `Denied`, `Escalated`), the controller MUST delete known sandbox claims recorded under `status.steps.*.sandbox` (best-effort aggregation; first error MAY be returned for visibility).
+29. **Concurrency cap**: Maximum concurrent proposal reconciles SHOULD respect `ApprovalPolicy.spec.maxConcurrentProposals` when present (see `crd-api.md`).
+
+## Configuration Surface
+
+- Operator process: namespace (operator install namespace), base sandbox template name
+- `SandboxTemplate` base object name in operator namespace (default from operator bootstrap)
+- `Proposal.metadata.namespace` (secrets + result CRs)
+- `spec.tools`, per-step `spec.*.tools` (`SkillsSource`, `MCPServerConfig`, `SecretRequirement`)
+- `spec.targetNamespaces` and RBAC materialization targets
+- `spec.analysisOutput` (analysis schema behavior)
+- `Agent.spec.model`, `LLMProvider.spec.*` (credentials secret names, endpoints, regional fields)
+- `Proposal` annotation `agentic.openshift.io/rbac-namespaces` (RBAC scope for cleanup)
+- `Proposal` finalizer string `agentic.openshift.io/execution-rbac-cleanup`
+
+## Constraints
+
+- Sandbox features that depend on **OCI image volumes** require Kubernetes version support as documented on `ToolsSpec` / `SkillsSource` API comments.
+- Required Secret **keys** for optional proposal-mounted secrets using `EnvVar` MUST match what the template expects (MCP header secrets and generic required secrets may differ — MCP env-from pattern in implementation may expect a specific key name for token-like secrets).
+- Agent HTTP is cluster-internal; clients MUST NOT assume public internet TLS semantics.
+
+## Planned Changes
+
+- [PLANNED: OLS-2957] **Sandbox template management** UX and CRD ergonomics (base/derived lifecycle, versioning) may change operator/template coupling described in rules 2–4.
+- [PLANNED: OLS-3038] **TLS verification and network policy** for agent traffic may replace permissive internal TLS client behavior.
+- [PLANNED: OLS-3044] **Provider parity**: environment variable contract for non-Claude providers in templates MUST track sandbox image capabilities.
+- [PLANNED: OLS-2894] Support **multiple concurrent skills images** in template derivation beyond the first `skills` entry if product requires composite skill bundles.


### PR DESCRIPTION
Adds behavioral (what/) and architecture (how/) specifications for the operator, aligned with the lightspeed-service spec style.

Includes proposal lifecycle, CRD API semantics, approval policy, sandbox execution, reconciler architecture, and oc-agentic CLI layout. Documentation only; no code changes.

Made with [Cursor](https://cursor.com)