### PR TITLE
Add mock agent and e2e test for operator flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@
 | `config/rbac/` | SA, bindings, generated `role.yaml` |
 | `config/manager/`, `config/default/` | In-cluster Deployment kustomize |
 | `examples/setup/` | Day-0 YAML (agents, policies, proposals) |
+| `test/agent/` | Mock agent HTTP server (`POST /v1/agent/run`), image Makefile, `cmd/schemadump` |
+| `test/agent/sandboxtemplate/` | Kustomize base `SandboxTemplate` for in-cluster mock |
+| `test/e2e/` | Build tag **`e2e`**: black-box tests against live cluster + running operator (`make test-e2e`) |
 
 ## Proposal lifecycle phases
 

--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,16 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: fmt vet ## Run unit tests (main + api + cli modules).
-	# Root module: controller, cli, etc.
-	go test ./... -count=1
+	# Root module: controller, cli, etc. (exclude test/e2e — needs -tags=e2e and a running mock; see test-e2e).
+	go test $$(go list ./... | grep -vF 'github.com/openshift/lightspeed-agentic-operator/test/e2e') -count=1
 	# API module is separate go.mod; GOWORK=off avoids picking up a repo root go.work.
 	cd api && GOWORK=off go test ./... -count=1
+
+##@ Testing
+
+.PHONY: test-e2e
+test-e2e: ## Run e2e tests against a live cluster (operator must be running). See test/e2e/ for prereqs.
+	go test -tags=e2e ./test/e2e/... -count=1 -v -timeout 30m
 
 .PHONY: api-lint
 api-lint: ## Kube API linter on api/ (needs golangci-lint on PATH; builds plugin to bin/). See README.md.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ make api-lint       # Kube API linter on api/ (golangci-lint custom + plugin; se
 
 ### Testing
 
-**`make test`** runs **`fmt`**, **`vet`**, **`go test ./... -count=1`**, and **`cd api && GOWORK=off go test ./... -count=1`** (the API tree is a separate module; **`GOWORK=off`** avoids a repo-root **`go.work`** hijacking module choice). For noisy debugging: **`go test ./controller/proposal/... -v`**, **`go test ./api/... -v`**, **`go test ./cli/... -v`**.
+**`make test`** runs **`fmt`**, **`vet`**, root-module tests, and **`cd api && GOWORK=off go test ./... -count=1`** (the API tree is a separate module; **`GOWORK=off`** avoids a repo-root **`go.work`** hijacking module choice). The **`test/e2e`** package is excluded from this target — it requires **`-tags=e2e`** and a running mock agent.
+
+**`make test-e2e`** runs **`go test -tags=e2e ./test/e2e/...`** against a live cluster with the operator running. Prerequisites: **`make run TEMPLATE_NAME=lightspeed-agent-mock`** (or deployed operator with **`--template-name=lightspeed-agent-mock`**) and mock agent SandboxTemplate applied (**`kubectl apply -k test/agent/sandboxtemplate`**). See `test/e2e/` package doc for details.
+
+For noisy debugging: **`go test ./controller/proposal/... -v`**, **`go test ./api/... -v`**, **`go test ./cli/... -v`**.
 
 ### API lint (Kube API linter)
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,19 @@ rules:
 - apiGroups:
   - agentic.openshift.io
   resources:
+  - analysisresults/status
+  - escalationresults/status
+  - executionresults/status
+  - proposalapprovals/status
+  - proposals/status
+  - verificationresults/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - agentic.openshift.io
+  resources:
   - proposalapprovals
   - proposals
   verbs:
@@ -39,15 +52,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - agentic.openshift.io
-  resources:
-  - proposalapprovals/status
-  - proposals/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - agentic.openshift.io
   resources:
@@ -66,13 +70,21 @@ rules:
   - extensions.agents.x-k8s.io
   resources:
   - sandboxclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.agents.x-k8s.io
+  resources:
   - sandboxtemplates
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:

--- a/controller/proposal/approval.go
+++ b/controller/proposal/approval.go
@@ -59,13 +59,13 @@ func ensureProposalApproval(
 			}
 			switch ps.Name {
 			case agenticv1alpha1.SandboxStepAnalysis:
-				stage.Analysis = agenticv1alpha1.AnalysisApproval{}
+				stage.Analysis = agenticv1alpha1.AnalysisApproval{Agent: proposal.Spec.Analysis.Agent}
 			case agenticv1alpha1.SandboxStepExecution:
-				stage.Execution = agenticv1alpha1.ExecutionApproval{}
+				stage.Execution = agenticv1alpha1.ExecutionApproval{Agent: proposal.Spec.Execution.Agent}
 			case agenticv1alpha1.SandboxStepVerification:
-				stage.Verification = agenticv1alpha1.VerificationApproval{}
+				stage.Verification = agenticv1alpha1.VerificationApproval{Agent: proposal.Spec.Verification.Agent}
 			case agenticv1alpha1.SandboxStepEscalation:
-				stage.Escalation = agenticv1alpha1.EscalationApproval{}
+				stage.Escalation = agenticv1alpha1.EscalationApproval{Agent: proposal.Spec.Analysis.Agent}
 			}
 			autoStages = append(autoStages, stage)
 		}

--- a/controller/proposal/reconciler.go
+++ b/controller/proposal/reconciler.go
@@ -37,6 +37,7 @@ type ProposalReconciler struct {
 // +kubebuilder:rbac:groups=agentic.openshift.io,resources=executionresults,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=agentic.openshift.io,resources=verificationresults,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=agentic.openshift.io,resources=escalationresults,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=agentic.openshift.io,resources=analysisresults/status;executionresults/status;verificationresults/status;escalationresults/status,verbs=get;patch;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;create;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;create;delete
 

--- a/controller/proposal/sandbox.go
+++ b/controller/proposal/sandbox.go
@@ -23,6 +23,10 @@ var (
 	}
 )
 
+// +kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxtemplates,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxclaims,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch
+
 // SandboxProvider abstracts sandbox lifecycle for testability.
 type SandboxProvider interface {
 	Claim(ctx context.Context, proposalName, step, templateName string) (claimName string, err error)

--- a/test/agent/Dockerfile
+++ b/test/agent/Dockerfile
@@ -1,0 +1,26 @@
+# HTTP mock for the in-sandbox agent contract (POST /v1/agent/run on :8080).
+# Build: make -C test/agent docker-build
+# Push:  make -C test/agent docker-push-local  OR  docker-build-quay + docker-push-quay QUAY_IMAGE=quay.io/...
+# Cluster: base SandboxTemplate — test/agent/sandboxtemplate/ (kubectl apply -k; edit images for Quay).
+#
+# Builder image tracks go.mod; bump if toolchain rejects the tag.
+FROM golang:1.25.7-bookworm AS builder
+
+WORKDIR /workspace
+COPY go.mod go.sum ./
+COPY api/go.mod api/go.sum api/
+COPY api/ api/
+RUN go mod download
+
+COPY controller/ controller/
+COPY test/agent/ test/agent/
+
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /mock-agent ./test/agent
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /mock-agent /mock-agent
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/mock-agent"]
+CMD ["-addr", ":8080"]

--- a/test/agent/Makefile
+++ b/test/agent/Makefile
@@ -1,0 +1,18 @@
+# Mock agent image build and push.
+# Build from repo root, push to Quay (or any registry).
+#
+# Usage:
+#   make -C test/agent docker-build
+#   make -C test/agent docker-push
+_AGENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+ROOT := $(abspath $(_AGENT_DIR)/../..)
+CONTAINER_TOOL ?= $(shell which podman >/dev/null 2>&1 && echo podman || echo docker)
+IMAGE ?= quay.io/openshift-lightspeed/ols-qe:lightspeed-mock-agent
+
+.PHONY: docker-build docker-push
+
+docker-build: ## Build mock agent image.
+	cd $(ROOT) && $(CONTAINER_TOOL) build -f test/agent/Dockerfile -t $(IMAGE) .
+
+docker-push: ## Push $(IMAGE) to registry.
+	$(CONTAINER_TOOL) push $(IMAGE)

--- a/test/agent/cmd/schemadump/main.go
+++ b/test/agent/cmd/schemadump/main.go
@@ -1,0 +1,37 @@
+// Prints a full POST /v1/agent/run JSON body per phase. Embeds outputSchema
+// as raw JSON bytes (no json.Marshal on the schema) so test/agent can use
+// bytes.Equal against controller/proposal schema vars.
+//
+// Usage: go run ./test/agent/cmd/schemadump [execution|verification|escalation|analysis]
+package main
+
+import (
+	"fmt"
+	"os"
+
+	proposal "github.com/openshift/lightspeed-agentic-operator/controller/proposal"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: schemadump [execution|verification|escalation|analysis]")
+		os.Exit(2)
+	}
+	var schema []byte
+	switch os.Args[1] {
+	case "execution":
+		schema = proposal.ExecutionOutputSchema
+	case "verification":
+		schema = proposal.VerificationOutputSchema
+	case "escalation":
+		schema = proposal.EscalationOutputSchema
+	case "analysis":
+		schema = []byte(`{"type":"object","properties":{"options":{"type":"array","minItems":1}}}`)
+	default:
+		fmt.Fprintln(os.Stderr, "unknown phase")
+		os.Exit(2)
+	}
+	_, _ = os.Stdout.Write([]byte(`{"query":"curl-smoke","outputSchema":`))
+	_, _ = os.Stdout.Write(schema)
+	_, _ = os.Stdout.Write([]byte(`,"context":{"targetNamespaces":["demo-ns"]}}`))
+}

--- a/test/agent/main.go
+++ b/test/agent/main.go
@@ -1,0 +1,280 @@
+// Mock agent HTTP server for e2e and local testing. Implements the same
+// contract as the in-sandbox agent service: POST /v1/agent/run with JSON
+// body matching controller/proposal/client.go (query, systemPrompt,
+// outputSchema, context, timeout_ms). Response body is raw JSON matching
+// controller/proposal/sandbox_agent.go expectations per step.
+//
+// Request JSON must stay in sync with agentRunRequest + agentContext in
+// controller/proposal/client.go. Response bodies must unmarshal into the
+// per-step structs in controller/proposal/sandbox_agent.go (analysisResponse,
+// executionResponse, verificationResponse, and the anonymous struct for
+// Escalate).
+//
+// After editing this binary, rebuild and restart the process so callers hit
+// the new behavior.
+//
+// Run: go run ./test/agent -addr :8080
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+	proposal "github.com/openshift/lightspeed-agentic-operator/controller/proposal"
+)
+
+// Per-phase response delays (hardcoded). Execution and verification get 60s delay so that
+// e2e tests can observe intermediate state (e.g. RBAC exists while execution is in-flight).
+
+type runRequest struct {
+	Query        string          `json:"query"`
+	SystemPrompt string          `json:"systemPrompt,omitempty"`
+	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
+	Context      *runContext     `json:"context,omitempty"`
+	TimeoutMs    *int64          `json:"timeout_ms,omitempty"`
+}
+
+// runContext mirrors controller/proposal/client.go agentContext JSON so the
+// operator's marshaled requests decode without dropping fields.
+type runContext struct {
+	TargetNamespaces []string                           `json:"targetNamespaces,omitempty"`
+	PreviousAttempts []runPreviousAttempt               `json:"previousAttempts,omitempty"`
+	ApprovedOption   *agenticv1alpha1.RemediationOption `json:"approvedOption,omitempty"`
+	ExecutionResult  *runExecutionResult                `json:"executionResult,omitempty"`
+}
+
+type runPreviousAttempt struct {
+	Attempt       int32  `json:"attempt"`
+	FailureReason string `json:"failureReason,omitempty"`
+}
+
+type runExecutionResult struct {
+	Success      bool                                   `json:"success"`
+	ActionsTaken []agenticv1alpha1.ExecutionAction      `json:"actionsTaken"`
+	Verification *agenticv1alpha1.ExecutionVerification `json:"verification,omitempty"`
+}
+
+func main() {
+	addr := flag.String("addr", ":8080", "listen address (e.g. :8080)")
+	flag.Parse()
+
+	listen := *addr
+	if v := os.Getenv("MOCK_AGENT_ADDR"); v != "" {
+		listen = v
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/agent/run", handleRun)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" && r.Method == http.MethodGet {
+			http.Redirect(w, r, "/healthz", http.StatusFound)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	log.Printf("mock agent listening on %s (POST /v1/agent/run, GET /healthz)", listen)
+	log.Printf("note: rebuild and restart this process after changing mock code or controller schemas")
+	if err := http.ListenAndServe(listen, logRequests(mux)); err != nil {
+		log.Fatalf("server: %v", err)
+	}
+}
+
+func logRequests(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s", r.Method, r.URL.Path)
+		next.ServeHTTP(w, r)
+	})
+}
+
+const maxRequestLogBytes = 8192
+
+func handleRun(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	ct := r.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		log.Printf("/v1/agent/run bad Content-Type remote=%s ct=%q", r.RemoteAddr, ct)
+		http.Error(w, "expected application/json", http.StatusBadRequest)
+		return
+	}
+
+	const maxBodyBytes = 10 << 20 // 10 MB
+	rawBody, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	if err != nil {
+		log.Printf("/v1/agent/run read body remote=%s err=%v", r.RemoteAddr, err)
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+	preview := string(rawBody)
+	if len(preview) > maxRequestLogBytes {
+		preview = preview[:maxRequestLogBytes] + fmt.Sprintf("… (%d bytes total)", len(rawBody))
+	}
+	log.Printf("/v1/agent/run remote=%s content-type=%q content-length=%d body_bytes=%d body=%s",
+		r.RemoteAddr, ct, r.ContentLength, len(rawBody), preview)
+
+	var req runRequest
+	if err := json.NewDecoder(bytes.NewReader(rawBody)).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid json: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	ns := pickNamespace(req.Context)
+	phase := phaseFromSchema(req.OutputSchema)
+	log.Printf("/v1/agent/run decoded query_len=%d phase=%s target_ns=%s", len(req.Query), phase, ns)
+
+	if d := phaseDelay(phase); d > 0 {
+		log.Printf("/v1/agent/run delaying %s for phase=%s", d, phase)
+		time.Sleep(d)
+	}
+
+	body := cannedResponse(phase, ns)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		log.Printf("write response: %v", err)
+	}
+}
+
+// Hardcoded per-phase delays to simulate real agent work. Gives e2e tests a
+// window to observe intermediate state (e.g. RBAC exists while execution is in-flight).
+func phaseDelay(phase string) time.Duration {
+	switch phase {
+	case "execution", "verification":
+		return 60 * time.Second
+	default:
+		return 0
+	}
+}
+
+func pickNamespace(ctx *runContext) string {
+	if ctx != nil && len(ctx.TargetNamespaces) > 0 && ctx.TargetNamespaces[0] != "" {
+		return ctx.TargetNamespaces[0]
+	}
+	return "default"
+}
+
+func compactJSON(raw json.RawMessage) []byte {
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return raw
+	}
+	return buf.Bytes()
+}
+
+func phaseFromSchema(schema json.RawMessage) string {
+	compact := compactJSON(schema)
+	switch {
+	case bytes.Equal(compact, compactJSON(proposal.ExecutionOutputSchema)):
+		return "execution"
+	case bytes.Equal(compact, compactJSON(proposal.VerificationOutputSchema)):
+		return "verification"
+	case bytes.Equal(compact, compactJSON(proposal.EscalationOutputSchema)):
+		return "escalation"
+	default:
+		return "analysis"
+	}
+}
+
+func cannedResponse(phase, targetNS string) []byte {
+	switch phase {
+	case "execution":
+		return []byte(`{
+  "success": true,
+  "actionsTaken": [
+    {
+      "type": "mock",
+      "description": "mock execution action",
+      "outcome": "Succeeded"
+    }
+  ],
+  "verification": {
+    "conditionOutcome": "Improved",
+    "summary": "mock inline verification"
+  }
+}`)
+	case "verification":
+		return []byte(`{
+  "success": true,
+  "checks": [
+    {
+      "name": "mock-check",
+      "source": "mock",
+      "value": "ok",
+      "result": "Passed"
+    }
+  ],
+  "summary": "mock verification summary"
+}`)
+	case "escalation":
+		return []byte(`{
+  "success": true,
+  "summary": "mock escalation summary",
+  "content": "mock escalation content"
+}`)
+	default:
+		// Analysis: one option with diagnosis, proposal, rbac, verification (default workflow shape).
+		return []byte(fmt.Sprintf(`{
+  "success": true,
+  "options": [
+    {
+      "title": "mock-remediation",
+      "summary": "mock option summary",
+      "diagnosis": {
+        "summary": "mock diagnosis",
+        "confidence": "High",
+        "rootCause": "mock root cause"
+      },
+      "proposal": {
+        "description": "mock proposal description",
+        "actions": [
+          { "type": "patch", "description": "mock proposed action" }
+        ],
+        "risk": "Low",
+        "reversible": "Reversible",
+        "estimatedImpact": "Brief pod restart, ~30s downtime"
+      },
+      "verification": {
+        "description": "mock verification plan",
+        "steps": [
+          {
+            "name": "mock-step",
+            "command": "true",
+            "expected": "ok",
+            "type": "command"
+          }
+        ]
+      },
+      "rbac": {
+        "namespaceScoped": [
+          {
+            "namespace": %q,
+            "apiGroups": [""],
+            "resources": ["configmaps"],
+            "verbs": ["get", "list"],
+            "justification": "mock e2e RBAC"
+          }
+        ],
+        "clusterScoped": []
+      }
+    }
+  ]
+}`, targetNS))
+	}
+}

--- a/test/agent/sandboxtemplate/sandboxtemplate.yaml
+++ b/test/agent/sandboxtemplate/sandboxtemplate.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lightspeed-agent
+  namespace: default
+automountServiceAccountToken: false
+---
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: lightspeed-agent
+  namespace: default
+spec:
+  networkPolicyManagement: Unmanaged
+  podTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/name: lightspeed-mock-agent
+    spec:
+      serviceAccountName: lightspeed-agent
+      automountServiceAccountToken: false
+      containers:
+        - name: agent
+          image: quay.io/openshift-lightspeed/ols-qe:lightspeed-mock-agent
+          args: ["-addr", ":8080"]
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: skills
+          image:
+            reference: placeholder:latest

--- a/test/e2e/analysis_execution_test.go
+++ b/test/e2e/analysis_execution_test.go
@@ -1,0 +1,119 @@
+//go:build e2e
+
+// Package e2e contains black-box tests that run against a live cluster with
+// the operator already running. The tests create CRs and poll for expected
+// status updates — they never import or instantiate operator internals.
+//
+// Prerequisites:
+//   - Operator deployed in-cluster (make deploy IMG=...)
+//   - Mock agent SandboxTemplate applied: kubectl apply -f test/agent/sandboxtemplate/sandboxtemplate.yaml
+//   - Operator SA has cluster-admin (for RBAC escalation): kubectl create clusterrolebinding e2e-operator-admin --clusterrole=cluster-admin --serviceaccount=default:controller-manager
+//   - KUBECONFIG pointing at the cluster
+//
+// Run: make test-e2e
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+// TestAnalysisFlow_ProposalToProposed validates the first step of the proposal workflow:
+//
+//  1. Create prerequisite CRDs (LLMProvider, Agent, ApprovalPolicy, Secret)
+//  2. Create a Proposal CR
+//  3. Wait for the operator to reconcile through analysis
+//  4. Assert: ProposalApproval exists, AnalysisResult exists, Proposal phase = Proposed
+//  5. Delete Proposal and verify sandbox released (finalizer completes)
+func TestAnalysisFlow_ProposalToProposed(t *testing.T) {
+	c := newClient(t)
+	ctx := context.Background()
+
+	createFixtures(t, c)
+	prop := createProposal(t, c, "e2e-analysis-flow")
+
+	// Wait for analysis to complete.
+	updated := waitForPhase(t, c, prop.Name, agenticv1alpha1.ProposalPhaseProposed)
+
+	// --- Verify outcomes ---
+
+	// Condition: Analyzed=True
+	var analyzedFound bool
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == agenticv1alpha1.ProposalConditionAnalyzed {
+			analyzedFound = true
+			if cond.Status != metav1.ConditionTrue {
+				t.Errorf("Analyzed condition status = %s, want True", cond.Status)
+			}
+		}
+	}
+	if !analyzedFound {
+		t.Error("Analyzed condition not found on Proposal status")
+	}
+
+	// ProposalApproval exists with owner reference.
+	var approval agenticv1alpha1.ProposalApproval
+	if err := c.Get(ctx, types.NamespacedName{Name: prop.Name, Namespace: testNS}, &approval); err != nil {
+		t.Fatalf("get ProposalApproval: %v", err)
+	}
+	if len(approval.OwnerReferences) == 0 {
+		t.Error("ProposalApproval has no owner references")
+	} else if approval.OwnerReferences[0].Name != prop.Name {
+		t.Errorf("ProposalApproval owner = %q, want %q", approval.OwnerReferences[0].Name, prop.Name)
+	}
+
+	// AnalysisResult exists with owner reference and options.
+	var analysisList agenticv1alpha1.AnalysisResultList
+	if err := c.List(ctx, &analysisList, client.InNamespace(testNS), client.MatchingLabels{"agentic.openshift.io/proposal": prop.Name}); err != nil {
+		t.Fatalf("list AnalysisResult: %v", err)
+	}
+	if len(analysisList.Items) == 0 {
+		t.Fatal("no AnalysisResult found for proposal")
+	}
+	ar := analysisList.Items[0]
+	if len(ar.OwnerReferences) == 0 {
+		t.Error("AnalysisResult has no owner references")
+	}
+	if len(ar.Status.Options) == 0 {
+		t.Fatal("AnalysisResult has no options")
+	}
+	opt := ar.Status.Options[0]
+	if opt.Title == "" {
+		t.Error("option title is empty")
+	}
+	if opt.Diagnosis.Summary == "" {
+		t.Error("option diagnosis summary is empty")
+	}
+	if opt.Proposal.Description == "" {
+		t.Error("option proposal description is empty")
+	}
+
+	// Sandbox info recorded.
+	if updated.Status.Steps.Analysis.Sandbox.ClaimName == "" {
+		t.Error("status.steps.analysis.sandbox.claimName is empty")
+	}
+
+	// Results tracked.
+	if len(updated.Status.Steps.Analysis.Results) == 0 {
+		t.Fatal("status.steps.analysis.results is empty")
+	}
+	if updated.Status.Steps.Analysis.Results[0].Name == "" {
+		t.Error("analysis result ref name is empty")
+	}
+
+	// --- Delete Proposal and verify sandbox released ---
+	claimName := updated.Status.Steps.Analysis.Sandbox.ClaimName
+	if err := c.Delete(ctx, prop); err != nil {
+		t.Fatalf("delete Proposal: %v", err)
+	}
+	waitForDeletion(t, c, prop.Name)
+
+	t.Logf("PASS: phase=Proposed, analysisResult=%s, sandbox=%s (released after deletion)",
+		ar.Name, claimName)
+}

--- a/test/e2e/denial_test.go
+++ b/test/e2e/denial_test.go
@@ -1,0 +1,57 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+// TestDenialFlow_ProposedToDenied validates that denying execution terminates the proposal:
+//
+//  1. Create Proposal, wait for Proposed (analysis complete)
+//  2. Deny execution on ProposalApproval
+//  3. Wait for phase = Denied (terminal)
+//  4. Assert: Denied condition present, sandboxes released on deletion
+func TestDenialFlow_ProposedToDenied(t *testing.T) {
+	c := newClient(t)
+	ctx := context.Background()
+
+	createFixtures(t, c)
+	prop := createProposal(t, c, "e2e-denial-flow")
+
+	// Drive to Proposed (analysis complete).
+	waitForPhase(t, c, prop.Name, agenticv1alpha1.ProposalPhaseProposed)
+
+	// Deny execution.
+	denyStage(t, c, prop.Name, agenticv1alpha1.ApprovalStageExecution)
+
+	// Wait for Denied (terminal).
+	updated := waitForPhase(t, c, prop.Name, agenticv1alpha1.ProposalPhaseDenied)
+
+	// --- Verify: Denied condition ---
+	var deniedFound bool
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == agenticv1alpha1.ProposalConditionDenied {
+			deniedFound = true
+			if cond.Status != metav1.ConditionTrue {
+				t.Errorf("Denied condition status = %s, want True", cond.Status)
+			}
+		}
+	}
+	if !deniedFound {
+		t.Error("Denied condition not found")
+	}
+
+	// --- Cleanup ---
+	if err := c.Delete(ctx, prop); err != nil {
+		t.Fatalf("delete Proposal: %v", err)
+	}
+	waitForDeletion(t, c, prop.Name)
+
+	t.Logf("PASS: execution denied, phase=Denied (terminal)")
+}

--- a/test/e2e/execution_test.go
+++ b/test/e2e/execution_test.go
@@ -1,0 +1,108 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+// TestExecutionFlow_ProposedToVerifying validates the execution phase:
+//
+//  1. Create Proposal, wait for Proposed (analysis complete)
+//  2. Approve execution (select option 0)
+//  3. Wait for phase = Executing — assert RBAC exists (mock has 60s delay)
+//  4. Wait for phase = Verifying (execution complete)
+//  5. Assert: ExecutionResult exists, Executed=True, sandbox info, RBAC annotation
+//  6. Delete Proposal, verify RBAC cleaned up
+func TestExecutionFlow_ProposedToVerifying(t *testing.T) {
+	c := newClient(t)
+	ctx := context.Background()
+
+	createFixtures(t, c)
+	prop := createProposal(t, c, "e2e-execution-flow")
+
+	// Drive to Proposed (analysis complete).
+	waitForPhase(t, c, prop.Name, agenticv1alpha1.ProposalPhaseProposed)
+
+	// Approve execution with option 0.
+	approveExecution(t, c, prop.Name, 0)
+
+	// Wait for Executing phase — RBAC should exist during this window (mock delays 60s).
+	waitForPhase(t, c, prop.Name, agenticv1alpha1.ProposalPhaseExecuting)
+
+	// --- Verify: RBAC created ---
+	roleName := "ls-exec-" + prop.Name
+	var role rbacv1.Role
+	if err := c.Get(ctx, types.NamespacedName{Name: roleName, Namespace: "staging"}, &role); err != nil {
+		t.Fatalf("get Role %s in staging: %v", roleName, err)
+	}
+	t.Logf("RBAC Role %s exists in staging namespace", roleName)
+
+	var binding rbacv1.RoleBinding
+	if err := c.Get(ctx, types.NamespacedName{Name: roleName, Namespace: "staging"}, &binding); err != nil {
+		t.Fatalf("get RoleBinding %s in staging: %v", roleName, err)
+	}
+
+	// Verify annotation on Proposal.
+	var current agenticv1alpha1.Proposal
+	if err := c.Get(ctx, types.NamespacedName{Name: prop.Name, Namespace: testNS}, &current); err != nil {
+		t.Fatalf("get Proposal: %v", err)
+	}
+	if current.Annotations["agentic.openshift.io/rbac-namespaces"] == "" {
+		t.Error("rbac-namespaces annotation is empty")
+	}
+
+	// Wait for execution to complete → Verifying phase.
+	updated := waitForPhase(t, c, prop.Name, agenticv1alpha1.ProposalPhaseVerifying)
+
+	// --- Verify: Executed condition ---
+	var executedFound bool
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == agenticv1alpha1.ProposalConditionExecuted {
+			executedFound = true
+			if cond.Status != metav1.ConditionTrue {
+				t.Errorf("Executed condition status = %s, want True", cond.Status)
+			}
+		}
+	}
+	if !executedFound {
+		t.Error("Executed condition not found")
+	}
+
+	// --- Verify: ExecutionResult exists ---
+	var execList agenticv1alpha1.ExecutionResultList
+	if err := c.List(ctx, &execList, client.InNamespace(testNS), client.MatchingLabels{"agentic.openshift.io/proposal": prop.Name}); err != nil {
+		t.Fatalf("list ExecutionResult: %v", err)
+	}
+	if len(execList.Items) == 0 {
+		t.Fatal("no ExecutionResult found")
+	}
+	if len(execList.Items[0].OwnerReferences) == 0 {
+		t.Error("ExecutionResult has no owner references")
+	}
+
+	// --- Verify: execution sandbox info ---
+	if updated.Status.Steps.Execution.Sandbox.ClaimName == "" {
+		t.Error("status.steps.execution.sandbox.claimName is empty")
+	}
+
+	// --- Cleanup and verify RBAC removed ---
+	if err := c.Delete(ctx, prop); err != nil {
+		t.Fatalf("delete Proposal: %v", err)
+	}
+	waitForDeletion(t, c, prop.Name)
+
+	if err := c.Get(ctx, types.NamespacedName{Name: roleName, Namespace: "staging"}, &role); err == nil {
+		t.Errorf("Role %s still exists after Proposal deletion — RBAC not cleaned up", roleName)
+	}
+
+	t.Logf("PASS: execution complete, RBAC created and cleaned up")
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,0 +1,323 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+const (
+	pollInterval = 2 * time.Second
+	pollTimeout  = 10 * time.Minute
+	testNS       = "default"
+)
+
+// --- Client ---
+
+func newClient(t *testing.T) client.Client {
+	t.Helper()
+
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		home, _ := os.UserHomeDir()
+		kubeconfig = home + "/.kube/config"
+	}
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("build kubeconfig: %v", err)
+	}
+
+	s := scheme.Scheme
+	_ = agenticv1alpha1.AddToScheme(s)
+
+	c, err := client.New(cfg, client.Options{Scheme: s})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	return c
+}
+
+// --- Pointer helpers ---
+
+func ptrBool(v bool) *bool   { return &v }
+func ptrInt32(v int32) *int32 { return &v }
+
+// --- Cleanup ---
+
+// cleanup deletes objects, stripping finalizers if needed. Order: delete (sets DeletionTimestamp
+// so the operator won't re-add finalizers), then patch finalizers to nil so deletion completes.
+// Logs each action and verifies the object is gone.
+func cleanup(t *testing.T, c client.Client, objs ...client.Object) {
+	t.Helper()
+	ctx := context.Background()
+	for _, obj := range objs {
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
+		if kind == "" {
+			kind = fmt.Sprintf("%T", obj)
+		}
+		name := obj.GetName()
+		ns := obj.GetNamespace()
+		key := types.NamespacedName{Name: name, Namespace: ns}
+
+		if err := c.Get(ctx, key, obj); err != nil {
+			t.Logf("cleanup: %s/%s not found (already clean)", kind, name)
+			continue
+		}
+		_ = c.Delete(ctx, obj)
+		if err := c.Get(ctx, key, obj); err != nil {
+			t.Logf("cleanup: %s/%s deleted", kind, name)
+			continue
+		}
+		if len(obj.GetFinalizers()) > 0 {
+			t.Logf("cleanup: %s/%s stripping finalizers %v", kind, name, obj.GetFinalizers())
+			obj.SetFinalizers(nil)
+			_ = c.Update(ctx, obj)
+		}
+		if err := c.Get(ctx, key, obj); err != nil {
+			t.Logf("cleanup: %s/%s deleted", kind, name)
+		} else {
+			t.Logf("cleanup: WARNING %s/%s still exists after cleanup", kind, name)
+		}
+	}
+}
+
+// deleteSandboxClaim removes a SandboxClaim by name (no typed Go struct in this repo).
+func deleteSandboxClaim(t *testing.T, c client.Client, name, namespace string) {
+	t.Helper()
+	obj := &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+			Kind:       "SandboxClaim",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	_ = c.Delete(context.Background(), obj)
+}
+
+// --- Fixture builders ---
+
+// e2eFixtures holds the prerequisite CRs needed for any proposal flow.
+type e2eFixtures struct {
+	LLM       *agenticv1alpha1.LLMProvider
+	Agent     *agenticv1alpha1.Agent
+	Policy    *agenticv1alpha1.ApprovalPolicy
+	LLMSecret *corev1.Secret
+}
+
+// createFixtures creates the prerequisite chain (LLMProvider, Agent, ApprovalPolicy, Secret)
+// and registers cleanup. Cleans up leftovers from previous failed runs first.
+func createFixtures(t *testing.T, c client.Client) *e2eFixtures {
+	t.Helper()
+	ctx := context.Background()
+
+	f := &e2eFixtures{
+		LLM: &agenticv1alpha1.LLMProvider{
+			ObjectMeta: metav1.ObjectMeta{Name: "e2e-llm"},
+			Spec: agenticv1alpha1.LLMProviderSpec{
+				Type: agenticv1alpha1.LLMProviderGoogleCloudVertex,
+				GoogleCloudVertex: agenticv1alpha1.GoogleCloudVertexConfig{
+					CredentialsSecret: agenticv1alpha1.SecretReference{Name: "e2e-llm-secret"},
+					ProjectID:         "e2e-project",
+					Region:            "us-central1",
+				},
+			},
+		},
+		Agent: &agenticv1alpha1.Agent{
+			ObjectMeta: metav1.ObjectMeta{Name: "e2e-agent"},
+			Spec: agenticv1alpha1.AgentSpec{
+				LLMProvider: agenticv1alpha1.LLMProviderReference{Name: "e2e-llm"},
+				Model:       "claude-opus-4-6",
+			},
+		},
+		Policy: &agenticv1alpha1.ApprovalPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Spec: agenticv1alpha1.ApprovalPolicySpec{
+				Stages: []agenticv1alpha1.ApprovalPolicyStage{
+					{Name: agenticv1alpha1.SandboxStepAnalysis, Approval: agenticv1alpha1.ApprovalModeAutomatic},
+					{Name: agenticv1alpha1.SandboxStepVerification, Approval: agenticv1alpha1.ApprovalModeAutomatic},
+				},
+			},
+		},
+		LLMSecret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "e2e-llm-secret", Namespace: testNS},
+			Data:       map[string][]byte{"credentials.json": []byte(`{"fake":"creds"}`)},
+		},
+	}
+
+	// Ensure target namespace exists (used by RBAC tests).
+	stagingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "staging"}}
+	_ = c.Create(ctx, stagingNS) // ignore AlreadyExists
+
+	all := []client.Object{f.LLM, f.Agent, f.Policy, f.LLMSecret}
+	cleanup(t, c, all...)
+	for _, obj := range all {
+		obj.SetResourceVersion("")
+		obj.SetUID("")
+		if err := c.Create(ctx, obj); err != nil {
+			t.Fatalf("create %T %s: %v", obj, obj.GetName(), err)
+		}
+	}
+	t.Cleanup(func() { cleanup(t, c, all...) })
+	return f
+}
+
+// createProposal creates a Proposal + pre-created ProposalApproval (CEL workaround).
+// Cleans up leftovers from previous runs. Returns the created Proposal.
+func createProposal(t *testing.T, c client.Client, name string) *agenticv1alpha1.Proposal {
+	t.Helper()
+	ctx := context.Background()
+
+	prop := &agenticv1alpha1.Proposal{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS},
+		Spec: agenticv1alpha1.ProposalSpec{
+			Request:          "Pod crash-looping in staging namespace",
+			TargetNamespaces: []string{"staging"},
+			Tools:            agenticv1alpha1.ToolsSpec{Skills: []agenticv1alpha1.SkillsSource{{Image: "quay.io/openshift-lightspeed/ols-qe:lightspeed-mock-agent"}}},
+			Analysis:         agenticv1alpha1.ProposalStep{Agent: "e2e-agent"},
+			Execution:        agenticv1alpha1.ProposalStep{Agent: "e2e-agent"},
+			Verification:     agenticv1alpha1.ProposalStep{Agent: "e2e-agent"},
+		},
+	}
+
+	// Clean leftovers.
+	cleanup(t, c, &agenticv1alpha1.Proposal{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS}})
+	cleanup(t, c, &agenticv1alpha1.ProposalApproval{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS}})
+	deleteSandboxClaim(t, c, "ls-analysis-"+name, testNS)
+	deleteSandboxClaim(t, c, "ls-execution-"+name, testNS)
+	deleteSandboxClaim(t, c, "ls-verification-"+name, testNS)
+
+	if err := c.Create(ctx, prop); err != nil {
+		t.Fatalf("create Proposal: %v", err)
+	}
+	t.Cleanup(func() { cleanup(t, c, prop) })
+
+
+	return prop
+}
+
+// waitForPhase polls until the Proposal reaches the target phase or times out.
+func waitForPhase(t *testing.T, c client.Client, name string, target agenticv1alpha1.ProposalPhase) agenticv1alpha1.Proposal {
+	t.Helper()
+	ctx := context.Background()
+	var updated agenticv1alpha1.Proposal
+
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+		if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: testNS}, &updated); err != nil {
+			return false, nil
+		}
+		phase := agenticv1alpha1.DerivePhase(updated.Status.Conditions)
+		t.Logf("polling %s: phase=%s conditions=%d", name, phase, len(updated.Status.Conditions))
+		return phase == target, nil
+	})
+	if err != nil {
+		phase := agenticv1alpha1.DerivePhase(updated.Status.Conditions)
+		t.Fatalf("timed out waiting for phase %s; current=%s conditions=%v", target, phase, updated.Status.Conditions)
+	}
+	return updated
+}
+
+// waitForDeletion polls until the Proposal is gone (finalizer completed).
+func waitForDeletion(t *testing.T, c client.Client, name string) {
+	t.Helper()
+	ctx := context.Background()
+
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+		var gone agenticv1alpha1.Proposal
+		if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: testNS}, &gone); err != nil {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("timed out waiting for Proposal %s deletion (finalizer may be stuck)", name)
+	}
+}
+
+// denyStage patches the ProposalApproval to deny the given stage.
+func denyStage(t *testing.T, c client.Client, name string, stageType agenticv1alpha1.ApprovalStageType) {
+	t.Helper()
+	ctx := context.Background()
+
+	var approval agenticv1alpha1.ProposalApproval
+	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: testNS}, &approval); err != nil {
+		t.Fatalf("get ProposalApproval for denial: %v", err)
+	}
+
+	base := approval.DeepCopy()
+	found := false
+	for i, s := range approval.Spec.Stages {
+		if s.Type == stageType {
+			approval.Spec.Stages[i].Decision = agenticv1alpha1.ApprovalDecisionDenied
+			found = true
+			break
+		}
+	}
+	if !found {
+		stage := agenticv1alpha1.ApprovalStage{
+			Type:     stageType,
+			Decision: agenticv1alpha1.ApprovalDecisionDenied,
+		}
+		switch stageType {
+		case agenticv1alpha1.ApprovalStageExecution:
+			stage.Execution = agenticv1alpha1.ExecutionApproval{Agent: "e2e-agent"}
+		case agenticv1alpha1.ApprovalStageVerification:
+			stage.Verification = agenticv1alpha1.VerificationApproval{Agent: "e2e-agent"}
+		case agenticv1alpha1.ApprovalStageEscalation:
+			stage.Escalation = agenticv1alpha1.EscalationApproval{Agent: "e2e-agent"}
+		}
+		approval.Spec.Stages = append(approval.Spec.Stages, stage)
+	}
+	if err := c.Patch(ctx, &approval, client.MergeFrom(base)); err != nil {
+		t.Fatalf("deny stage %s: %v", stageType, err)
+	}
+	t.Logf("denied stage %s", stageType)
+}
+
+// approveExecution patches the ProposalApproval to approve execution with the given option index.
+func approveExecution(t *testing.T, c client.Client, name string, optionIdx int32) {
+	t.Helper()
+	ctx := context.Background()
+
+	var approval agenticv1alpha1.ProposalApproval
+	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: testNS}, &approval); err != nil {
+		t.Fatalf("get ProposalApproval for execution approval: %v", err)
+	}
+
+	base := approval.DeepCopy()
+	found := false
+	for i, s := range approval.Spec.Stages {
+		if s.Type == agenticv1alpha1.ApprovalStageExecution {
+			approval.Spec.Stages[i].Execution = agenticv1alpha1.ExecutionApproval{
+				Agent:  "e2e-agent",
+				Option: ptrInt32(optionIdx),
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		approval.Spec.Stages = append(approval.Spec.Stages, agenticv1alpha1.ApprovalStage{
+			Type:      agenticv1alpha1.ApprovalStageExecution,
+			Execution: agenticv1alpha1.ExecutionApproval{Agent: "e2e-agent", Option: ptrInt32(optionIdx)},
+		})
+	}
+	if err := c.Patch(ctx, &approval, client.MergeFrom(base)); err != nil {
+		t.Fatalf("approve execution: %v", err)
+	}
+	t.Logf("approved execution with option %d", optionIdx)
+}

--- a/test/e2e/verification_test.go
+++ b/test/e2e/verification_test.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+// TestVerificationFlow_VerifyingToCompleted validates the verification phase:
+//
+//  1. Create Proposal, drive through analysis + execution to Verifying
+//  2. Wait for phase = Completed (verification auto-approved, runs, passes)
+//  3. Assert: VerificationResult exists, Verified=True, terminal state
+//  4. Delete Proposal, verify RBAC cleaned up
+func TestVerificationFlow_VerifyingToCompleted(t *testing.T) {
+	c := newClient(t)
+	ctx := context.Background()
+
+	createFixtures(t, c)
+	prop := createProposal(t, c, "e2e-verification-flow")
+
+	// Drive to Proposed.
+	waitForPhase(t, c, prop.Name, agenticv1alpha1.ProposalPhaseProposed)
+
+	// Approve execution.
+	approveExecution(t, c, prop.Name, 0)
+
+	// Wait for Completed (execution + verification both finish).
+	updated := waitForPhase(t, c, prop.Name, agenticv1alpha1.ProposalPhaseCompleted)
+
+	// --- Verify: Verified condition ---
+	var verifiedFound bool
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == agenticv1alpha1.ProposalConditionVerified {
+			verifiedFound = true
+			if cond.Status != metav1.ConditionTrue {
+				t.Errorf("Verified condition status = %s, want True", cond.Status)
+			}
+		}
+	}
+	if !verifiedFound {
+		t.Error("Verified condition not found")
+	}
+
+	// --- Verify: VerificationResult exists ---
+	var verifyList agenticv1alpha1.VerificationResultList
+	if err := c.List(ctx, &verifyList, client.InNamespace(testNS), client.MatchingLabels{"agentic.openshift.io/proposal": prop.Name}); err != nil {
+		t.Fatalf("list VerificationResult: %v", err)
+	}
+	if len(verifyList.Items) == 0 {
+		t.Fatal("no VerificationResult found")
+	}
+	if len(verifyList.Items[0].OwnerReferences) == 0 {
+		t.Error("VerificationResult has no owner references")
+	}
+
+	// --- Verify: verification sandbox info ---
+	if updated.Status.Steps.Verification.Sandbox.ClaimName == "" {
+		t.Error("status.steps.verification.sandbox.claimName is empty")
+	}
+
+	// --- Cleanup and verify RBAC removed ---
+	roleName := "ls-exec-" + prop.Name
+	if err := c.Delete(ctx, prop); err != nil {
+		t.Fatalf("delete Proposal: %v", err)
+	}
+	waitForDeletion(t, c, prop.Name)
+
+	var role rbacv1.Role
+	if err := c.Get(ctx, types.NamespacedName{Name: roleName, Namespace: "staging"}, &role); err == nil {
+		t.Errorf("Role %s still exists after deletion — RBAC not cleaned up", roleName)
+	}
+
+	t.Logf("PASS: verification complete, phase=Completed, RBAC cleaned after deletion")
+}


### PR DESCRIPTION
address https://redhat.atlassian.net/browse/OLS-3036 and https://redhat.atlassian.net/browse/OLS-3037


**Summary**

Add an HTTP mock agent (test/agent/) that implements the POST /v1/agent/run contract used by the operator's SandboxAgentCaller, with canned responses per workflow phase (analysis, execution, verification, escalation).

Add a black-box e2e test (test/e2e/) that validates the full analysis flow: Proposal creation → operator reconciliation → sandbox claim → agent HTTP call → AnalysisResult CR → Proposal phase = Proposed → sandbox released on deletion.
Add a kustomize-based SandboxTemplate bundle (test/agent/sandboxtemplate/) with image override support (local tag or Quay).

Add Dockerfile, Makefile, and schemadump CLI helper for building/pushing the mock image and manual curl testing.

What it does NOT change
No operator source code is modified. All changes are under test/, plus docs (README.md, CLAUDE.md) and Makefile targets (test-e2e).

**How to run**

# Terminal 1: apply mock template + start operator
kubectl apply -k test/agent/sandboxtemplate
make run TEMPLATE_NAME=lightspeed-agent-mock

# Terminal 2: run e2e tests
make test-e2e
Test plan

 go build ./... passes

 make test passes (e2e excluded via build tag)

 go vet -tags=e2e ./test/e2e/... clean

 make test-e2e passes against running operator + mock agent sandbox

 Verify on CI (build tag e2e ensures no impact on existing make test)