### PR TITLE
fix: use operator namespace for RBAC execution subject

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,9 +80,10 @@ func main() {
 	)
 
 	reconciler := &proposal.ProposalReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Proposal"),
-		Agent:  agentCaller,
+		Client:    mgr.GetClient(),
+		Log:       ctrl.Log.WithName("controllers").WithName("Proposal"),
+		Agent:     agentCaller,
+		Namespace: namespace,
 	}
 
 	if err := reconciler.SetupWithManager(mgr); err != nil {

--- a/controller/proposal/handlers.go
+++ b/controller/proposal/handlers.go
@@ -213,7 +213,7 @@ func (r *ProposalReconciler) handleExecution(
 
 	base := proposal.DeepCopy()
 	if selectedOption != nil && (len(selectedOption.RBAC.NamespaceScoped) > 0 || len(selectedOption.RBAC.ClusterScoped) > 0) {
-		if err := ensureExecutionRBAC(ctx, r.Client, proposal, &selectedOption.RBAC, defaultSandboxSA, proposal.Namespace); err != nil {
+		if err := ensureExecutionRBAC(ctx, r.Client, proposal, &selectedOption.RBAC, defaultSandboxSA, r.Namespace); err != nil {
 			return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionExecuted, fmt.Errorf("ensure execution RBAC: %w", err))
 		}
 		if err := r.Patch(ctx, proposal, client.MergeFrom(base)); err != nil {

--- a/controller/proposal/handlers_test.go
+++ b/controller/proposal/handlers_test.go
@@ -96,7 +96,7 @@ func TestReconcile_WorkflowVariants(t *testing.T) {
 				WithObjects(objs...).
 				WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-			r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller()}
+			r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
 
 			if _, err := reconcileOnce(r, "fix-crash"); err != nil {
 				t.Fatalf("analysis reconcile: %v", err)
@@ -127,7 +127,7 @@ func TestReconcile_HappyPath_FullLifecycle(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Reconcile 1: Pending → Proposed (analysis complete)
 	result, err := reconcileOnce(r, "fix-crash")
@@ -215,7 +215,7 @@ func TestReconcile_AnalysisSystemFailure_Terminal(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Reconcile 1: Pending → Failed (system failure)
 	result, err := reconcileOnce(r, "fix-crash")
@@ -254,7 +254,7 @@ func TestReconcile_VerificationObjectiveFailure_RetriesExecution(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Analysis → approve → execution → verifying
 	reconcileOnce(r, "fix-crash")
@@ -320,7 +320,7 @@ func TestReconcile_SystemFailure_Execution_Terminal(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Analysis → approve
 	reconcileOnce(r, "fix-crash")
@@ -357,7 +357,7 @@ func TestReconcile_SystemFailure_Verification_Terminal(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Analysis → approve → execution → verifying
 	reconcileOnce(r, "fix-crash")
@@ -396,7 +396,7 @@ func TestReconcile_ObjectiveFailure_ThenRevise(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Full lifecycle to verification failure, retries exhausted → Analyzing
 	reconcileOnce(r, "fix-crash")
@@ -455,7 +455,7 @@ func TestReconcile_RevisionHappyPath(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Reconcile 1: Pending → Executing (analysis complete)
 	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
@@ -504,7 +504,7 @@ func TestReconcile_RevisionMultipleRounds(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Initial analysis
 	reconcileOnce(r, "fix-crash")
@@ -542,7 +542,7 @@ func TestReconcile_RevisionNoOp_WhenObserved(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Initial analysis
 	reconcileOnce(r, "fix-crash")
@@ -591,7 +591,7 @@ func TestReconcile_RevisionReanalysis(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Analysis → Executing
 	reconcileOnce(r, "fix-crash")
@@ -612,7 +612,7 @@ func TestReconcile_RevisionAnalysisFailure(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Initial analysis succeeds
 	reconcileOnce(r, "fix-crash")
@@ -655,7 +655,7 @@ func TestReconcile_RevisionWithFeedback(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Initial analysis
 	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
@@ -721,7 +721,7 @@ func TestReconcile_ExecutionRBACCreatedOnApproval(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Pending → Proposed (analysis complete)
 	reconcileOnce(r, "fix-crash")
@@ -813,7 +813,7 @@ func TestReconcile_ExecutionRBACCleanedOnFailure(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Analysis → approve
 	reconcileOnce(r, "fix-crash")
@@ -909,7 +909,7 @@ func TestFullLifecycle_WithSandboxAgent(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: sandboxAgent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: sandboxAgent, Namespace: "default"}
 
 	// Reconcile 1: Pending → Executing (via sandbox analysis)
 	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
@@ -1011,7 +1011,7 @@ func TestReconcile_ExecutingPhase_DoesNotReExecute(t *testing.T) {
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
 	agent := newTestAgentCaller()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Run analysis
 	reconcileOnce(r, "fix-crash")
@@ -1058,7 +1058,7 @@ func TestReconcile_ExecutionOutcomeFailed_FailsStep(t *testing.T) {
 		Success:      false,
 		ActionsTaken: []agenticv1alpha1.ExecutionAction{{Type: "patch", Description: "Failed patch", Outcome: agenticv1alpha1.ActionOutcomeFailed}},
 	}
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Analysis → Executing
 	reconcileOnce(r, "fix-crash")
@@ -1087,7 +1087,7 @@ func TestReconcile_VerificationOutcomeFailed_RetriesExecution(t *testing.T) {
 		Checks:  []agenticv1alpha1.VerifyCheck{{Name: "health", Result: agenticv1alpha1.CheckResultFailed}},
 		Summary: "Health check failed",
 	}
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Analysis → Executing → Approve → Execute → Verify (fail) → retry
 	reconcileOnce(r, "fix-crash")
@@ -1121,7 +1121,7 @@ func TestReconcile_ExecutionSelectsOption(t *testing.T) {
 			{Title: "Option C", Diagnosis: agenticv1alpha1.DiagnosisResult{Summary: "diag-C"}},
 		},
 	}
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Analysis
 	reconcileOnce(r, "fix-crash")
@@ -1164,7 +1164,7 @@ func TestReconcile_ExecutionSingleOption(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Analysis (default stub returns 1 option)
 	reconcileOnce(r, "fix-crash")
@@ -1203,7 +1203,7 @@ func TestReconcile_TrimOptionsOnExecution(t *testing.T) {
 		Checks:  []agenticv1alpha1.VerifyCheck{{Name: "health", Result: agenticv1alpha1.CheckResultFailed}},
 		Summary: "Health check failed",
 	}
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Analysis
 	reconcileOnce(r, "fix-crash")
@@ -1296,7 +1296,7 @@ func TestResultCR_FailureConditions(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	reconcileOnce(r, "fix-crash")
 	p, _ := getProposal(r, "fix-crash")

--- a/controller/proposal/helpers_test.go
+++ b/controller/proposal/helpers_test.go
@@ -30,7 +30,7 @@ func TestSelectedOption_ReturnsFirstOption(t *testing.T) {
 	}
 
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(analysisResult).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Namespace: "default"}
 
 	got, err := r.selectedOption(context.Background(), proposal)
 	if err != nil {
@@ -52,7 +52,7 @@ func TestSelectedOption_NoResults(t *testing.T) {
 	proposal.Namespace = "default"
 
 	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Namespace: "default"}
 
 	got, err := r.selectedOption(context.Background(), proposal)
 	if err != nil {
@@ -88,7 +88,7 @@ func TestTrimNonSelectedOptions_SingleOptionNoop(t *testing.T) {
 	}
 
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(analysisResult).WithStatusSubresource(analysisResult).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Namespace: "default"}
 
 	got, err := r.trimNonSelectedOptions(context.Background(), proposal, approval, nil)
 	if err != nil {
@@ -137,7 +137,7 @@ func TestTrimThenSelectedOption_EndToEnd(t *testing.T) {
 			}
 
 			fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(analysisResult).WithStatusSubresource(analysisResult).Build()
-			r := &ProposalReconciler{Client: fc, Log: logr.Discard()}
+			r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Namespace: "default"}
 
 			got, err := r.trimNonSelectedOptions(context.Background(), proposal, approval, nil)
 			if err != nil {
@@ -224,7 +224,7 @@ func TestTrimNonSelectedOptions_OutOfRange(t *testing.T) {
 	}
 
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(analysisResult).WithStatusSubresource(analysisResult).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Namespace: "default"}
 
 	_, err := r.trimNonSelectedOptions(context.Background(), proposal, approval, nil)
 	if err == nil {

--- a/controller/proposal/reconciler.go
+++ b/controller/proposal/reconciler.go
@@ -21,8 +21,9 @@ import (
 // Agent must be set before calling SetupWithManager.
 type ProposalReconciler struct {
 	client.Client
-	Log   logr.Logger
-	Agent AgentCaller
+	Log       logr.Logger
+	Agent     AgentCaller
+	Namespace string
 }
 
 // +kubebuilder:rbac:groups=agentic.openshift.io,resources=proposals,verbs=get;list;watch;create;update;patch;delete

--- a/controller/proposal/reconciler_test.go
+++ b/controller/proposal/reconciler_test.go
@@ -279,7 +279,7 @@ func TestReconcile_StatusInitialization(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
 
 	_, err := reconcileOnce(r, "fresh")
 	if err != nil {
@@ -305,7 +305,7 @@ func TestReconcile_Denied_Terminal(t *testing.T) {
 	}
 
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(proposal).WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller()}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
 
 	result, err := reconcileOnce(r, "fix-crash")
 	if err != nil {

--- a/controller/proposal/state_machine_test.go
+++ b/controller/proposal/state_machine_test.go
@@ -54,7 +54,7 @@ func newReconcilerWithPolicy(t *testing.T, proposal *agenticv1alpha1.Proposal, a
 	objs = append(objs, extraObjs...)
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 	// Initial reconcile creates ProposalApproval (auto-approved stages based on policy).
 	reconcileOnce(r, proposal.Name)
 	return r, fc
@@ -507,7 +507,7 @@ func TestNoPolicy_DefaultsToManual(t *testing.T) {
 	objs := []client.Object{proposal, testDefaultAgent(), testLLM("smart")}
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent}
+	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
 
 	// Initial reconcile creates ProposalApproval; analysis should wait for approval
 	reconcileOnce(r, "fix-crash")


### PR DESCRIPTION
 ## Summary
Fix `RoleBinding` subject pointing to the wrong namespace when a `Proposal` lives outside the operator namespace.

## Problem
`ensureExecutionRBAC` used `proposal.Namespace` as the` ServiceAccount` namespace in `RoleBinding` subjects. The lightspeed-agent service account only exists in the operator namespace (openshift-lightspeed), so sandbox pods got
  no permissions when the `Proposal` is created in different namespace.
  
## Fix

Added `Namespace` field to `ProposalReconciler` and passed `r.Namespace` instead of `proposal.Namespace` when creating `RoleBinding` subjects — consistent with how `SandboxManager` and `SandboxAgentCaller` already track
  the operator namespace.
