### PR TITLE
OLS-3150: Add googleCloudVertex.modelProvider to LLMProvider CRD

### DIFF
--- a/api/v1alpha1/llmprovider_types.go
+++ b/api/v1alpha1/llmprovider_types.go
@@ -72,6 +72,20 @@ type AnthropicConfig struct {
 	URL string `json:"url,omitempty"`
 }
 
+// GoogleCloudVertexRuntime selects which SDK talks to Vertex AI.
+//
+// +kubebuilder:validation:Enum=Claude;Gemini;OpenAI
+type GoogleCloudVertexRuntime string
+
+const (
+	// GoogleCloudVertexRuntimeClaude uses Anthropic-on-Vertex (Claude SDK).
+	GoogleCloudVertexRuntimeClaude GoogleCloudVertexRuntime = "Claude"
+	// GoogleCloudVertexRuntimeGemini uses Google GenAI on Vertex.
+	GoogleCloudVertexRuntimeGemini GoogleCloudVertexRuntime = "Gemini"
+	// GoogleCloudVertexRuntimeOpenAI uses the OpenAI SDK against Vertex's OpenAI-compatible endpoint.
+	GoogleCloudVertexRuntimeOpenAI GoogleCloudVertexRuntime = "OpenAI"
+)
+
 // GoogleCloudVertexConfig contains configuration for the Google Cloud Vertex AI provider.
 type GoogleCloudVertexConfig struct {
 	// credentialsSecret references a Secret in the operator namespace
@@ -99,6 +113,13 @@ type GoogleCloudVertexConfig struct {
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z][a-z0-9-]*[a-z0-9]$')",message="region must contain only lowercase letters, digits, and hyphens, start with a letter, and not end with a hyphen"
 	Region string `json:"region,omitempty"`
+
+	// runtime selects which SDK talks to Vertex AI (required).
+	// "Claude" uses Anthropic-on-Vertex; "Gemini" uses Google GenAI on Vertex;
+	// "OpenAI" uses the OpenAI SDK against Vertex's OpenAI-compatible API.
+	// Enum is defined on GoogleCloudVertexRuntime.
+	// +required
+	Runtime GoogleCloudVertexRuntime `json:"runtime"`
 
 	// url is an optional override for the Vertex AI API endpoint.
 	// Only needed for custom deployments or API proxies.
@@ -312,6 +333,7 @@ type LLMProviderSpec struct {
 //	      name: llm-credentials
 //	    projectID: my-gcp-project
 //	    region: us-central1
+//	    runtime: Claude
 type LLMProvider struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/api/v1alpha1/llmprovider_types.go
+++ b/api/v1alpha1/llmprovider_types.go
@@ -72,18 +72,18 @@ type AnthropicConfig struct {
 	URL string `json:"url,omitempty"`
 }
 
-// GoogleCloudVertexRuntime selects which SDK talks to Vertex AI.
+// GoogleCloudVertexModelProvider selects which model provider stack talks to Vertex AI.
 //
-// +kubebuilder:validation:Enum=Claude;Gemini;OpenAI
-type GoogleCloudVertexRuntime string
+// +kubebuilder:validation:Enum=Anthropic;Google;OpenAI
+type GoogleCloudVertexModelProvider string
 
 const (
-	// GoogleCloudVertexRuntimeClaude uses Anthropic-on-Vertex (Claude SDK).
-	GoogleCloudVertexRuntimeClaude GoogleCloudVertexRuntime = "Claude"
-	// GoogleCloudVertexRuntimeGemini uses Google GenAI on Vertex.
-	GoogleCloudVertexRuntimeGemini GoogleCloudVertexRuntime = "Gemini"
-	// GoogleCloudVertexRuntimeOpenAI uses the OpenAI SDK against Vertex's OpenAI-compatible endpoint.
-	GoogleCloudVertexRuntimeOpenAI GoogleCloudVertexRuntime = "OpenAI"
+	// GoogleCloudVertexModelProviderAnthropic uses Anthropic models on Vertex (Claude SDK).
+	GoogleCloudVertexModelProviderAnthropic GoogleCloudVertexModelProvider = "Anthropic"
+	// GoogleCloudVertexModelProviderGoogle uses Google models on Vertex (GenAI SDK).
+	GoogleCloudVertexModelProviderGoogle GoogleCloudVertexModelProvider = "Google"
+	// GoogleCloudVertexModelProviderOpenAI uses OpenAI-compatible models on Vertex (OpenAI SDK).
+	GoogleCloudVertexModelProviderOpenAI GoogleCloudVertexModelProvider = "OpenAI"
 )
 
 // GoogleCloudVertexConfig contains configuration for the Google Cloud Vertex AI provider.
@@ -114,12 +114,12 @@ type GoogleCloudVertexConfig struct {
 	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z][a-z0-9-]*[a-z0-9]$')",message="region must contain only lowercase letters, digits, and hyphens, start with a letter, and not end with a hyphen"
 	Region string `json:"region,omitempty"`
 
-	// runtime selects which SDK talks to Vertex AI (required).
-	// "Claude" uses Anthropic-on-Vertex; "Gemini" uses Google GenAI on Vertex;
-	// "OpenAI" uses the OpenAI SDK against Vertex's OpenAI-compatible API.
-	// Enum is defined on GoogleCloudVertexRuntime.
+	// modelProvider selects which model provider stack talks to Vertex AI (required).
+	// "Anthropic" uses Anthropic models on Vertex; "Google" uses Google models on Vertex;
+	// "OpenAI" uses OpenAI-compatible models on Vertex.
+	// Enum is defined on GoogleCloudVertexModelProvider.
 	// +required
-	Runtime GoogleCloudVertexRuntime `json:"runtime"`
+	ModelProvider GoogleCloudVertexModelProvider `json:"modelProvider,omitempty"`
 
 	// url is an optional override for the Vertex AI API endpoint.
 	// Only needed for custom deployments or API proxies.
@@ -333,7 +333,7 @@ type LLMProviderSpec struct {
 //	      name: llm-credentials
 //	    projectID: my-gcp-project
 //	    region: us-central1
-//	    runtime: Claude
+//	    modelProvider: Anthropic
 type LLMProvider struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/crd/bases/agentic.openshift.io_llmproviders.yaml
+++ b/config/crd/bases/agentic.openshift.io_llmproviders.yaml
@@ -36,8 +36,8 @@ spec:
           AI provider (model specified on Agent, not here):\n\n\tapiVersion: agentic.openshift.io/v1alpha1\n\tkind:
           LLMProvider\n\tmetadata:\n\t  name: vertex-ai\n\tspec:\n\t  type: GoogleCloudVertex\n\t
           \ googleCloudVertex:\n\t    credentialsSecret:\n\t      name: llm-credentials\n\t
-          \   projectID: my-gcp-project\n\t    region: us-central1\n\t    runtime:
-          Claude"
+          \   projectID: my-gcp-project\n\t    region: us-central1\n\t    modelProvider:
+          Anthropic"
         properties:
           apiVersion:
             description: |-
@@ -269,6 +269,17 @@ spec:
                     required:
                     - name
                     type: object
+                  modelProvider:
+                    description: |-
+                      modelProvider selects which model provider stack talks to Vertex AI (required).
+                      "Anthropic" uses Anthropic models on Vertex; "Google" uses Google models on Vertex;
+                      "OpenAI" uses OpenAI-compatible models on Vertex.
+                      Enum is defined on GoogleCloudVertexModelProvider.
+                    enum:
+                    - Anthropic
+                    - Google
+                    - OpenAI
+                    type: string
                   projectID:
                     description: |-
                       projectID is the Google Cloud Project ID where Vertex AI is enabled.
@@ -296,17 +307,6 @@ spec:
                     - message: region must contain only lowercase letters, digits,
                         and hyphens, start with a letter, and not end with a hyphen
                       rule: self.matches('^[a-z][a-z0-9-]*[a-z0-9]$')
-                  runtime:
-                    description: |-
-                      runtime selects which SDK talks to Vertex AI (required).
-                      "Claude" uses Anthropic-on-Vertex; "Gemini" uses Google GenAI on Vertex;
-                      "OpenAI" uses the OpenAI SDK against Vertex's OpenAI-compatible API.
-                      Enum is defined on GoogleCloudVertexRuntime.
-                    enum:
-                    - Claude
-                    - Gemini
-                    - OpenAI
-                    type: string
                   url:
                     description: |-
                       url is an optional override for the Vertex AI API endpoint.
@@ -328,9 +328,9 @@ spec:
                       rule: '!self.contains(''#'')'
                 required:
                 - credentialsSecret
+                - modelProvider
                 - projectID
                 - region
-                - runtime
                 type: object
               openAI:
                 description: |-

--- a/config/crd/bases/agentic.openshift.io_llmproviders.yaml
+++ b/config/crd/bases/agentic.openshift.io_llmproviders.yaml
@@ -36,7 +36,8 @@ spec:
           AI provider (model specified on Agent, not here):\n\n\tapiVersion: agentic.openshift.io/v1alpha1\n\tkind:
           LLMProvider\n\tmetadata:\n\t  name: vertex-ai\n\tspec:\n\t  type: GoogleCloudVertex\n\t
           \ googleCloudVertex:\n\t    credentialsSecret:\n\t      name: llm-credentials\n\t
-          \   projectID: my-gcp-project\n\t    region: us-central1"
+          \   projectID: my-gcp-project\n\t    region: us-central1\n\t    runtime:
+          Claude"
         properties:
           apiVersion:
             description: |-
@@ -295,6 +296,17 @@ spec:
                     - message: region must contain only lowercase letters, digits,
                         and hyphens, start with a letter, and not end with a hyphen
                       rule: self.matches('^[a-z][a-z0-9-]*[a-z0-9]$')
+                  runtime:
+                    description: |-
+                      runtime selects which SDK talks to Vertex AI (required).
+                      "Claude" uses Anthropic-on-Vertex; "Gemini" uses Google GenAI on Vertex;
+                      "OpenAI" uses the OpenAI SDK against Vertex's OpenAI-compatible API.
+                      Enum is defined on GoogleCloudVertexRuntime.
+                    enum:
+                    - Claude
+                    - Gemini
+                    - OpenAI
+                    type: string
                   url:
                     description: |-
                       url is an optional override for the Vertex AI API endpoint.
@@ -318,6 +330,7 @@ spec:
                 - credentialsSecret
                 - projectID
                 - region
+                - runtime
                 type: object
               openAI:
                 description: |-

--- a/controller/proposal/reconciler_test.go
+++ b/controller/proposal/reconciler_test.go
@@ -106,7 +106,7 @@ func testLLM(name string) *agenticv1alpha1.LLMProvider {
 				CredentialsSecret: agenticv1alpha1.SecretReference{Name: "llm-secret"},
 				ProjectID:         "test-project",
 				Region:            "us-central1",
-				Runtime:           agenticv1alpha1.GoogleCloudVertexRuntimeClaude,
+				ModelProvider:     agenticv1alpha1.GoogleCloudVertexModelProviderAnthropic,
 			},
 		},
 	}

--- a/controller/proposal/reconciler_test.go
+++ b/controller/proposal/reconciler_test.go
@@ -106,6 +106,7 @@ func testLLM(name string) *agenticv1alpha1.LLMProvider {
 				CredentialsSecret: agenticv1alpha1.SecretReference{Name: "llm-secret"},
 				ProjectID:         "test-project",
 				Region:            "us-central1",
+				Runtime:           agenticv1alpha1.GoogleCloudVertexRuntimeClaude,
 			},
 		},
 	}

--- a/examples/setup/00-llm-providers.yaml
+++ b/examples/setup/00-llm-providers.yaml
@@ -20,3 +20,4 @@ spec:
       name: llm-credentials
     projectID: my-gcp-project
     region: us-central1
+    runtime: Claude

--- a/examples/setup/00-llm-providers.yaml
+++ b/examples/setup/00-llm-providers.yaml
@@ -20,4 +20,4 @@ spec:
       name: llm-credentials
     projectID: my-gcp-project
     region: us-central1
-    runtime: Claude
+    modelProvider: Anthropic

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -134,7 +134,7 @@ func createFixtures(t *testing.T, c client.Client) *e2eFixtures {
 					CredentialsSecret: agenticv1alpha1.SecretReference{Name: "e2e-llm-secret"},
 					ProjectID:         "e2e-project",
 					Region:            "us-central1",
-					Runtime:           agenticv1alpha1.GoogleCloudVertexRuntimeClaude,
+					ModelProvider:       agenticv1alpha1.GoogleCloudVertexModelProviderAnthropic,
 				},
 			},
 		},

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -134,6 +134,7 @@ func createFixtures(t *testing.T, c client.Client) *e2eFixtures {
 					CredentialsSecret: agenticv1alpha1.SecretReference{Name: "e2e-llm-secret"},
 					ProjectID:         "e2e-project",
 					Region:            "us-central1",
+					Runtime:           agenticv1alpha1.GoogleCloudVertexRuntimeClaude,
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- Add `GoogleCloudVertexModelProvider` enum (`Anthropic`, `Google`, `OpenAI`) to distinguish which model provider stack a Vertex `LLMProvider` uses
- Add required `googleCloudVertex.modelProvider` field on `LLMProvider` (CRD validation enforces presence and enum values)
- Update example manifest and test fixtures to set `modelProvider: Anthropic`

This PR is **API/CRD only** and should merge first. Operator routing that maps `modelProvider` to sandbox SDK env vars will land in [OLS-3126 / PR #13](https://github.com/openshift/lightspeed-agentic-operator/pull/13), which consumes this field once the CRD is available.

Fixes [OLS-3150](https://redhat.atlassian.net/browse/OLS-3150) (CRD half).

## modelProvider values

| `modelProvider` | Vertex stack (operator mapping in PR #13) |
|-----------------|-------------------------------------------|
| `Anthropic` | Claude SDK (`LIGHTSPEED_AGENT_PROVIDER=claude`) |
| `Google` | Google GenAI (`LIGHTSPEED_AGENT_PROVIDER=gemini`) |
| `OpenAI` | OpenAI-compatible API (`LIGHTSPEED_AGENT_PROVIDER=openai`) |

## Example

```yaml
spec:
  type: GoogleCloudVertex
  googleCloudVertex:
    credentialsSecret:
      name: llm-credentials
    projectID: my-gcp-project
    region: us-central1
    modelProvider: Anthropic
```

## Test plan

- [x] `make manifests`
- [x] `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Google Cloud Vertex AI configuration now requires specifying the model provider (Anthropic, Google, or OpenAI).

* **Documentation**
  * Updated example configurations to include the new model provider selection requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->