### PR TITLE
Add prodsec-recommended CodeRabbit security rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,10 +27,10 @@ reviews:
     - '!api/go.sum'
     - '!vendor/**'
     # Prodsec recommended exclusions
-    - '!node_modules/**'
-    - '!dist/**'
-    - '!*.min.js'
-    - '!yarn.lock'
+    - '!**/node_modules/**'
+    - '!**/dist/**'
+    - '!**/*.min.js'
+    - '!**/yarn.lock'
 
   # Review output — keep signal, kill noise
   high_level_summary: true
@@ -237,7 +237,7 @@ reviews:
         - Guardrails: bidirectional filtering on prompts and responses
 
     # ── Supply chain & dependencies ──────────────────────────────
-    - path: "**/{requirements*.txt,Pipfile*,pyproject.toml,package*.json,go.mod,go.sum,Cargo.toml,Gemfile*,pom.xml,build.gradle*}"
+    - path: "**/{requirements*.txt,Pipfile*,pyproject.toml,package*.json,go.mod,go.sum,Cargo.toml,Cargo.lock,Gemfile*,pom.xml,build.gradle*}"
       instructions: |
         Supply chain security (prodsec-skills):
         - New deps: justify need, check license compatibility

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,4 @@
-# CodeRabbit configuration
+# CodeRabbit configuration — lightspeed-agentic-operator
 # Docs: https://docs.coderabbit.ai/guides/configure-coderabbit
 reviews:
   # Profile: "chill" generates fewer comments, focuses on significant issues
@@ -22,6 +22,12 @@ reviews:
     - '!go.sum'
     - '!api/go.sum'
     - '!vendor/**'
+    # Prodsec recommended exclusions
+    # https://github.com/RedHatProductSecurity/prodsec-skills/blob/main/.coderabbit.yaml
+    - '!node_modules/**'
+    - '!dist/**'
+    - '!*.min.js'
+    - '!yarn.lock'
 
   # Review behavior
   collapse_walkthrough: true
@@ -33,5 +39,322 @@ reviews:
   # Sequence diagrams for complex logic (chill profile limits these to significant changes)
   sequence_diagrams: true
 
+  # Prodsec recommended review instructions
+  # https://github.com/RedHatProductSecurity/prodsec-skills/blob/main/.coderabbit.yaml
+  instructions:
+    - name: "no-hardcoded-secrets"
+      instructions: |
+        Flag hardcoded secrets: API keys, tokens, passwords, private
+        keys, credentials. Also flag base64 strings >32 chars in config,
+        URLs with embedded credentials, variables named api_key/secret/
+        token/password assigned string literals.
+      mode: "error"
+
+    - name: "no-weak-crypto"
+      instructions: |
+        Flag MD5, SHA1, DES, RC4, 3DES, Blowfish, ECB mode usage.
+        Flag custom crypto implementations. Flag non-constant-time
+        comparison of secrets or tokens.
+      mode: "error"
+
+    - name: "no-injection-vectors"
+      instructions: |
+        Flag SQL string concatenation, shell=True with user input,
+        eval/exec on untrusted data, pickle.loads on untrusted input,
+        yaml.load without SafeLoader, os.system with variables,
+        dangerouslySetInnerHTML with user data.
+      mode: "error"
+
+    - name: "container-privileges"
+      instructions: |
+        Flag privileged: true, hostPID, hostNetwork, hostIPC,
+        SYS_ADMIN capability, running as root without justification,
+        allowPrivilegeEscalation: true in container/K8s manifests.
+      mode: "error"
+
+    - name: "no-sensitive-data-in-logs"
+      instructions: |
+        Flag logging that may expose passwords, tokens, API keys,
+        PII (email, SSN, credit card), session IDs, internal
+        hostnames, or customer data.
+      mode: "error"
+
+    - name: "ai-attribution"
+      instructions: |
+        If AI tools were used (mentioned in PR or commits), verify
+        Red Hat attribution: Assisted-by or Generated-by trailers.
+        Flag use of Co-Authored-By for AI tools.
+      mode: "warning"
+
+  # Prodsec recommended path-specific instructions
+  # https://github.com/RedHatProductSecurity/prodsec-skills/blob/main/.coderabbit.yaml
+  path_instructions:
+
+    # ── Injection & input validation ─────────────────────────────
+    - path: "**/*.{py,js,ts,go,rs,java,rb,php,kt,swift,cs}"
+      instructions: |
+        Injection prevention (prodsec-skills):
+        - SQL: parameterized queries only; no string concatenation
+        - Command: no shell=True, os.system, or backtick exec with user input
+        - LDAP/XPath: escape special characters in filters
+        - Path traversal: canonicalize paths, reject ../
+        - Deserialization: no pickle/yaml.load()/eval on untrusted data
+        - Prototype pollution: no recursive merge of untrusted objects
+        - Validate at trust boundaries with allow-lists, not deny-lists
+        - Normalize Unicode and anchor regexes (^$); watch for ReDoS
+
+    # ── Web & frontend security ──────────────────────────────────
+    - path: "**/*.{html,jsx,tsx,vue,svelte}"
+      instructions: |
+        Web security (prodsec-skills):
+        - No dangerouslySetInnerHTML or v-html with user data
+        - CSP: no unsafe-inline, no unsafe-eval
+        - CSRF tokens on state-changing requests
+        - Cookies: Secure, HttpOnly, SameSite=Strict
+        - No document.write, eval, new Function with user input
+        - GraphQL: depth/complexity limits, disable introspection in prod
+        - File uploads: validate by content magic, cap size, server-generate names
+        - XML: disable external entities (XXE), reject DTDs from untrusted sources
+
+    # ── Cryptography ─────────────────────────────────────────────
+    - path: "**/*{crypt,cipher,sign,hash,tls,ssl,cert,key,token}*"
+      instructions: |
+        Cryptographic security (prodsec-skills):
+        - Banned: MD5, SHA1, DES, RC4, 3DES, Blowfish, ECB mode
+        - Symmetric: AES-256-GCM or ChaCha20-Poly1305
+        - Passwords: Argon2id (not bcrypt/scrypt for new code)
+        - Signing: Ed25519 or ECDSA P-256+
+        - Key exchange: X25519 or ECDH P-256+
+        - Constant-time comparison for all secret/token data
+        - Zeroize key material after use (no garbage-collector reliance)
+        - No custom crypto; use vetted libraries only
+        - Post-quantum: flag if protecting long-lived secrets
+
+    # ── Container & image hardening ──────────────────────────────
+    - path: "**/{Dockerfile,Containerfile}*"
+      instructions: |
+        Container security (prodsec-skills):
+        - Base image: UBI minimal or distroless from catalog.redhat.com
+        - Red Hat images: use floating tags (Red Hat manages updates);
+          non-RH images: pin by digest
+        - Multi-stage builds; no build tools in final image
+        - USER non-root; never run as root
+        - COPY specific files, not entire context
+        - No secrets in ENV, ARG, or COPY
+        - Read-only rootfs where possible
+        - No package manager cache in final layer
+        - HEALTHCHECK defined
+
+    # ── Kubernetes & OpenShift ───────────────────────────────────
+    - path: "**/*.{yaml,yml}"
+      instructions: |
+        If this is a Kubernetes/OpenShift manifest or Helm template:
+        - securityContext: runAsNonRoot, readOnlyRootFilesystem,
+          allowPrivilegeEscalation: false
+        - Drop ALL capabilities, add only what is required
+        - Resource limits (cpu, memory) on every container
+        - No hostPID, hostNetwork, hostIPC, privileged: true
+        - NetworkPolicy defined for the namespace
+        - OpenShift: SCC must be restricted or custom-scoped
+        - Liveness + readiness probes defined
+        - automountServiceAccountToken: false unless needed
+        - RBAC: least privilege; no cluster-admin for workloads
+        - Helm: no .Values interpolation in shell commands
+
+    # ── MCP server security ──────────────────────────────────────
+    - path: "**/{mcp,tool_server,toolserver}/**/*"
+      instructions: |
+        MCP server review (prodsec-skills):
+        - OAuth 2.1 resource server: validate tokens per RFC 9068
+        - Enforce scope-based access per tool; no default-allow
+        - RBAC: per-tool permissions mapped to token scopes/roles
+        - Sanitize all tool inputs against declared schemas
+        - Reject path traversal in file-accessing tools
+        - No credential forwarding to downstream services
+        - Tool injection: validate registry integrity, reject dynamic
+          tool loading from untrusted sources
+        - Container isolation: unprivileged, read-only rootfs
+        - Audit log all tool invocations with caller identity
+        - Rate limiting per client/scope
+        - Reject API keys; require IdP-issued tokens
+
+    # ── MCP client ───────────────────────────────────────────────
+    - path: "**/{mcp_client,mcp-client}/**/*"
+      instructions: |
+        MCP client review (prodsec-skills):
+        - OAuth client metadata: register with minimal scopes
+        - Dynamic registration: validate server response, store
+          client_id/secret securely
+        - Protected resource metadata: discover before token request
+        - Consent: prompt user before granting tool access
+        - Discovery: validate .well-known endpoints over HTTPS only
+
+    # ── Inference engine & model serving ─────────────────────────
+    - path: "**/{inference,model,serving,predict}/**/*"
+      instructions: |
+        Inference engine review (prodsec-skills):
+        - Process isolation: container or microVM per model
+        - JWT/OIDC on all inference endpoints; no unauthenticated access
+        - Model provenance: verify signatures before loading
+        - Scan models for embedded payloads (pickle, arbitrary code)
+        - Token lifecycle: short-lived, secure storage, revocation
+        - No direct filesystem access from inference process
+        - Resource limits to prevent DoS via large inputs
+
+    # ── Agent security ───────────────────────────────────────────
+    - path: "**/{agent,agents,agentic}/**/*"
+      instructions: |
+        Agent security (prodsec-skills):
+        - Unique, verifiable identity per agent instance
+        - Agent-to-agent auth: SPIFFE/mTLS, not shared secrets
+        - Agent-to-MCP auth: OAuth 2.1 client credentials flow
+        - No ambient authority; agents present credentials per call
+        - Audit trail for all inter-agent communication
+
+    # ── LLM interaction ──────────────────────────────────────────
+    - path: "**/{llm,prompt,chat,completion}**/*"
+      instructions: |
+        LLM security (prodsec-skills):
+        - Prompt injection: separate system/user content; never
+          interpolate untrusted input into system prompts
+        - Output filtering: validate LLM output before execution
+        - File protection: restrict file access to declared paths
+        - Third-party models: evaluate trust, scan artifacts
+        - Guardrails: bidirectional filtering on prompts and responses
+
+    # ── Supply chain & dependencies ──────────────────────────────
+    - path: "**/{requirements*.txt,Pipfile*,pyproject.toml,package*.json,go.mod,go.sum,Cargo.toml,Gemfile*,pom.xml,build.gradle*}"
+      instructions: |
+        Supply chain security (prodsec-skills):
+        - New deps: justify need, check license compatibility
+        - Pin exact versions; verify hashes where supported
+        - Flag known CVEs (cross-ref osv.dev)
+        - No pre-release or yanked versions in production
+        - SBOM: ensure build produces provenance attestations
+        - Signing: artifacts signed with Sigstore/cosign
+
+    # ── CI/CD & GitHub Actions ───────────────────────────────────
+    - path: ".github/workflows/**/*"
+      instructions: |
+        CI/CD security (prodsec-skills):
+        - Pin actions by full SHA, not tag
+        - No secrets in logs; mask sensitive outputs
+        - Least privilege: minimize GITHUB_TOKEN permissions
+        - No pull_request_target with checkout of PR head
+        - SAST/SCA steps in pipeline
+        - Sign artifacts with Sigstore/cosign
+        - Agentic CI actions: audit for prompt injection via
+          issue/PR title/body flowing into LLM prompts
+
+    # ── Authentication & OAuth ───────────────────────────────────
+    - path: "**/{auth,oauth,oidc,login,session,saml}/**/*"
+      instructions: |
+        Authentication review (prodsec-skills):
+        - OAuth 2.1: PKCE required; no implicit grant
+        - JWT: verify signature, issuer, audience, expiry, nbf
+        - Sessions: secure cookie flags, regenerate ID on login
+        - Passwords: Argon2id; never plaintext or weak hashes
+        - Rate limit login attempts; account lockout policy
+        - MFA: support and encourage; never bypass silently
+        - Service-to-service: SPIFFE/mTLS, not shared secrets
+        - Avoid API keys; prefer IdP-issued short-lived tokens
+
+    # ── API gateway & rate limiting ──────────────────────────────
+    - path: "**/{gateway,proxy,ingress,route}/**/*"
+      instructions: |
+        API gateway review (prodsec-skills):
+        - Auth enforcement at gateway, not just downstream
+        - Rate limiting per client/endpoint; fail closed
+        - Request validation: size limits, content-type checks
+        - No internal-only routes exposed externally
+        - TLS termination with strong cipher suites
+
+    # ── Go ───────────────────────────────────────────────────────
+    - path: "**/*.go"
+      instructions: |
+        Go security (prodsec-skills):
+        - Never ignore error returns
+        - database/sql with placeholders; no fmt.Sprintf in queries
+        - Use stdlib crypto/* and golang.org/x/crypto (Go team maintained);
+          avoid third-party crypto libraries
+        - Integer overflow: bounds-check user-supplied sizes
+        - context.Context for cancellation and timeouts
+
+    # ── C/C++ ────────────────────────────────────────────────────
+    - path: "**/*.{c,cpp,cc,h,hpp}"
+      instructions: |
+        C/C++ security (prodsec-skills):
+        - Banned: gets, sprintf, strcpy, strcat, strtok
+        - Use strlcpy, snprintf, bounded APIs
+        - Compile: -fstack-protector-strong -fPIE -pie
+          -D_FORTIFY_SOURCE=2 -Wformat-security
+        - Nullify pointers after free; no use-after-free
+        - Integer overflow: check arithmetic on untrusted sizes
+
+    # ── Database & external data ─────────────────────────────────
+    - path: "**/{db,database,redis,cache,storage}/**/*"
+      instructions: |
+        Data store security (prodsec-skills):
+        - Auth: no default credentials; use IAM or IdP tokens
+        - Encryption: TLS in transit, encryption at rest
+        - Least privilege: app user has minimal grants
+        - Redis/ElastiCache: AUTH required, no KEYS in prod,
+          rename dangerous commands (FLUSHALL, CONFIG)
+        - Connection strings: no embedded credentials
+
+    # ── Messaging ────────────────────────────────────────────────
+    - path: "**/{kafka,amq,mqtt,messaging,broker}/**/*"
+      instructions: |
+        Messaging security (prodsec-skills):
+        - Kafka/AMQ: TLS, SASL auth, per-topic ACLs
+        - MQTT: auth required, topic ACLs, payload encryption
+        - No anonymous access in production
+
+    # ── Model registry ───────────────────────────────────────────
+    - path: "**/{model_registry,model-registry,registry}/**/*"
+      instructions: |
+        Model registry review (prodsec-skills):
+        - Admin interface: auth + RBAC, no public exposure
+        - Model scanning: check for malicious payloads before publish
+        - Model signing: verify signatures on pull
+        - Audit logging: who uploaded/downloaded/deleted what
+        - Secure storage: encrypted at rest, access-controlled
+
+  # Prodsec recommended security scanners
+  # https://github.com/RedHatProductSecurity/prodsec-skills/blob/main/.coderabbit.yaml
+  tools:
+    gitleaks:
+      enabled: true
+    semgrep:
+      enabled: true
+    checkov:
+      enabled: true
+    hadolint:
+      enabled: true
+    trivy:
+      enabled: true
+    osvScanner:
+      enabled: true
+    actionlint:
+      enabled: true
+    ast-grep:
+      essential_rules: true
+
+# Prodsec recommended knowledge base
+# https://github.com/RedHatProductSecurity/prodsec-skills/blob/main/.coderabbit.yaml
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/AGENTS.md"
+      - "**/REDHAT.md"
+      - "**/CLAUDE.md"
+      - "**/CONTRIBUTING.md"
+  issues:
+    scope: "auto"
+  pull_requests:
+    scope: "auto"
+
 chat:
-  auto_reply: false
+  auto_reply: true
+  art: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,10 +1,14 @@
 # CodeRabbit configuration — lightspeed-agentic-operator
-# Docs: https://docs.coderabbit.ai/guides/configure-coderabbit
+# Docs: https://docs.coderabbit.ai/reference/configuration
+language: "en-US"
+early_access: true
+tone_instructions: >-
+  Be direct and concise. Focus on bugs, security issues, and correctness.
+  Skip praise and pleasantries.
+
 reviews:
-  # Profile: "chill" generates fewer comments, focuses on significant issues
   profile: chill
 
-  # Auto-review settings
   auto_review:
     enabled: true
     base_branches:
@@ -23,21 +27,31 @@ reviews:
     - '!api/go.sum'
     - '!vendor/**'
     # Prodsec recommended exclusions
-    # https://github.com/RedHatProductSecurity/prodsec-skills/blob/main/.coderabbit.yaml
     - '!node_modules/**'
     - '!dist/**'
     - '!*.min.js'
     - '!yarn.lock'
 
-  # Review behavior
-  collapse_walkthrough: true
-  poem: false
+  # Review output — keep signal, kill noise
   high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  collapse_walkthrough: true
   review_status: true
   commit_status: true
-
-  # Sequence diagrams for complex logic (chill profile limits these to significant changes)
   sequence_diagrams: true
+  poem: false
+  in_progress_fortune: false
+  suggested_labels: false
+  suggested_reviewers: false
+  estimate_code_review_effort: false
+  related_prs: false
+  enable_prompt_for_ai_agents: true
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
 
   # Prodsec recommended review instructions
   # https://github.com/RedHatProductSecurity/prodsec-skills/blob/main/.coderabbit.yaml
@@ -320,8 +334,7 @@ reviews:
         - Audit logging: who uploaded/downloaded/deleted what
         - Secure storage: encrypted at rest, access-controlled
 
-  # Prodsec recommended security scanners
-  # https://github.com/RedHatProductSecurity/prodsec-skills/blob/main/.coderabbit.yaml
+  # Security scanners (prodsec) + language-specific linters
   tools:
     gitleaks:
       enabled: true
@@ -339,9 +352,13 @@ reviews:
       enabled: true
     ast-grep:
       essential_rules: true
+    shellcheck:
+      enabled: true
+    golangci-lint:
+      enabled: true
+    yamllint:
+      enabled: true
 
-# Prodsec recommended knowledge base
-# https://github.com/RedHatProductSecurity/prodsec-skills/blob/main/.coderabbit.yaml
 knowledge_base:
   code_guidelines:
     enabled: true
@@ -352,8 +369,15 @@ knowledge_base:
       - "**/CONTRIBUTING.md"
   issues:
     scope: "auto"
+  jira:
+    usage: "auto"
   pull_requests:
     scope: "auto"
+  linked_repositories:
+    - repository: "openshift/lightspeed-agentic-sandbox"
+      instructions: >-
+        Python/FastAPI agent runtime. The operator calls its
+        POST /v1/agent/run endpoint to run agent steps.
 
 chat:
   auto_reply: true


### PR DESCRIPTION
## Summary

- Adopts the Red Hat Product Security recommended CodeRabbit configuration from [openshift/coderabbit#17](https://github.com/openshift/coderabbit/pull/17), sourced from [prodsec-skills](https://github.com/RedHatProductSecurity/prodsec-skills/blob/main/.coderabbit.yaml)
- Adds 6 global review instructions (no-hardcoded-secrets, no-weak-crypto, no-injection-vectors, container-privileges, no-sensitive-data-in-logs, ai-attribution)
- Adds 18 path-specific security review blocks covering injection, web, crypto, containers, K8s/OpenShift, MCP server/client, agents, LLM, supply chain, CI/CD, auth, API gateway, Go, C/C++, database, messaging, and model registry
- Enables security scanners: gitleaks, semgrep, checkov, hadolint, trivy, osvScanner, actionlint, ast-grep
- Adds knowledge base auto-indexing of AGENTS.md, CLAUDE.md, CONTRIBUTING.md
- Adds path_filters for node_modules, dist, minified JS, yarn.lock

## Test plan

- [ ] Verify CodeRabbit picks up the new config on the next PR
- [ ] Confirm no false-positive noise from path_instructions on unrelated file types

Made with [Cursor](https://cursor.com)