### PR TITLE
Fix api-lint: pin golangci-lint and SkillsSource.paths JSON tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,11 @@ HEALTH_PROBE_BIND_ADDRESS ?= :18081
 CONTROLLER_GEN_VERSION ?= v0.19.0
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 
+# Must match version in .custom-gcl.yml (golangci-lint custom).
+GOLANGCI_LINT_VERSION ?= v2.9.0
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+GOLANGCI_LINT_KAL ?= $(LOCALBIN)/golangci-lint-kube-api-linter
+
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...
@@ -82,9 +87,9 @@ test-e2e: ## Run e2e tests against a live cluster (operator must be running). Se
 	go test -tags=e2e ./test/e2e/... -count=1 -v -timeout 30m
 
 .PHONY: api-lint
-api-lint: ## Kube API linter on api/ (needs golangci-lint on PATH; builds plugin to bin/). See README.md.
-	golangci-lint custom
-	cd api && GOWORK=off $(LOCALBIN)/golangci-lint-kube-api-linter run --config ../.golangci-kal.yml ./...
+api-lint: golangci-lint ## Kube API linter on api/ (installs golangci-lint to bin/; see README.md).
+	$(GOLANGCI_LINT) custom
+	cd api && GOWORK=off $(GOLANGCI_LINT_KAL) run --config ../.golangci-kal.yml ./...
 
 .PHONY: build
 build: fmt vet ## Build manager binary to bin/manager.
@@ -251,6 +256,16 @@ $(LOCALBIN):
 KUSTOMIZE_VERSION ?= v5.3.0
 KUBECTL ?= kubectl
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint to $(LOCALBIN) if missing or wrong version.
+
+$(GOLANGCI_LINT): $(LOCALBIN)
+	@if test -x $(GOLANGCI_LINT) && ! $(GOLANGCI_LINT) --version 2>&1 | grep -q $(GOLANGCI_LINT_VERSION); then \
+		echo "$(GOLANGCI_LINT) version is not expected $(GOLANGCI_LINT_VERSION). Removing it before installing."; \
+		rm -rf $(GOLANGCI_LINT); \
+	fi
+	test -s $(GOLANGCI_LINT) || GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen to $(LOCALBIN) if missing or wrong version.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For noisy debugging: **`go test ./controller/proposal/... -v`**, **`go test ./ap
 
 ### API lint (Kube API linter)
 
-**`make api-lint`** runs **`golangci-lint custom`** (builds **`bin/golangci-lint-kube-api-linter`** from **`.custom-gcl.yml`**), then the plugin against **`api/`** with **`GOWORK=off`** and **`.golangci-kal.yml`**. Requires **`golangci-lint`** on **`PATH`**.
+**`make api-lint`** installs **`golangci-lint`** to **`bin/`** (version from **`.custom-gcl.yml`**), runs **`golangci-lint custom`** (builds **`bin/golangci-lint-kube-api-linter`**), then lints **`api/`** with **`GOWORK=off`** and **`.golangci-kal.yml`**.
 
 ### CEL validation (`XValidation`)
 

--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -189,5 +189,5 @@ type SkillsSource struct {
 	// +kubebuilder:validation:XValidation:rule="self.all(p, p.matches('^[a-zA-Z0-9/_.-]+$'))",message="paths may only contain alphanumeric characters, '/', '_', '.', and '-'"
 	// +kubebuilder:validation:items:MinLength=2
 	// +kubebuilder:validation:items:MaxLength=512
-	Paths []string `json:"paths"`
+	Paths []string `json:"paths,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Install `golangci-lint` into `bin/` from `make api-lint` (version pinned to match `.custom-gcl.yml`) so local and CI runs do not require it on `PATH`.
- Add `omitempty` to `SkillsSource.paths` JSON tag to satisfy kube-api-linter `requiredfields`; `paths` remains `+required` in the OpenAPI schema (same pattern as `SkillsSource.image`).

## Test plan

- [x] `make api-lint` passes (0 issues)
- [ ] CI `api-lint` / verify job green on PR


Made with [Cursor](https://cursor.com)