### PR TITLE
OLS-3200: spec: define generic operator-sandbox env var contract

### DIFF
--- a/.ai/spec/what/sandbox-execution.md
+++ b/.ai/spec/what/sandbox-execution.md
@@ -6,7 +6,7 @@ Behavioral specification for how workflow steps run inside ephemeral **sandboxes
 
 1. **Sandbox API objects**: For each step invocation, the controller MUST create a namespaced **SandboxClaim** (API group `extensions.agents.x-k8s.io`, `v1alpha1`) that references a **SandboxTemplate** by name and uses a shutdown policy that deletes the sandbox when released.
 2. **Operator namespace**: Sandbox claims and sandbox workloads MUST reside in the **operator’s configured namespace** (process flag `namespace` or equivalent environment substitution), not necessarily the `Proposal` namespace.
-3. **Template selection**: Before claiming, the controller MUST ensure a **derived** `SandboxTemplate` exists: it clones a **base** template identified by configured default template name, patches it with resolved LLM credentials, model id, tools (skills, MCP, required secrets), and step mode, and names it deterministically using a hash of relevant inputs so identical configurations reuse the same template.
+3. **Template selection**: Before claiming, the controller MUST ensure a **derived** `SandboxTemplate` exists: it clones a **base** template identified by configured default template name, patches it with generic LLM configuration env vars (see rule 16a), credential mounts, tools (skills, MCP, required secrets), and step mode, and names it deterministically using a hash of relevant inputs so identical configurations reuse the same template. The operator MUST NOT set SDK-specific env vars (e.g. `ANTHROPIC_MODEL`, `CLAUDE_CODE_USE_VERTEX`, `OPENAI_BASE_URL`); all SDK-specific mapping is the sandbox's responsibility.
 4. **Template immutability & GC**: If a derived template for the same agent + step + hash already exists, creation MUST be a no-op. Older derived templates for the same agent+step with different names SHOULD be garbage-collected after successful creation of the newest.
 5. **Claim naming**: Claim names MUST be derived from proposal name and step label, truncated to valid Kubernetes name length limits.
 6. **Readiness**: The controller MUST poll sandbox/claim status until the backing `Sandbox` reports `Ready=True` (standard condition pattern) and exposes a **service FQDN** for in-cluster HTTP, or until a configurable **sandbox wait budget** elapses (error path).
@@ -19,7 +19,29 @@ Behavioral specification for how workflow steps run inside ephemeral **sandboxes
 13. **Verification query payload**: The `query` MUST include the approved option JSON and a JSON description of the latest execution output (actions and inline verification) when available.
 14. **Context envelope**: The `context` object MUST include `targetNamespaces` from `spec.targetNamespaces`, synthesized `previousAttempts` from failed prior `status.steps.*.results` entries, `approvedOption` when executing/verifying, and `executionResult` when verifying. Note: the sandbox context prefix formatter (see sandbox `run-api.md`) only expands `targetNamespaces`, `attempt`, `previousAttempts`, and `approvedOption` into the model prompt; `executionResult` is carried in `context` for tracing but verification execution details are primarily conveyed to the model via the `query` body (rendered from the verification template).
 15. **Secrets — proposal** `spec.tools.requiredSecrets` / per-step tools: Secret objects MUST live in the **same namespace as the `Proposal`**. Mounting into sandbox MUST honor `SecretMountSpec`: environment variable injection OR file mount at configured absolute path.
-16. **Secrets — LLM credentials**: LLM provider credentials MUST be loaded from secret names declared on the `LLMProvider` and wired into the derived template via env/volumes per provider type (including optional file mounts for provider types that require file-based credentials).
+16. **Secrets — LLM credentials**: LLM provider credentials MUST be loaded from secret names declared on the `LLMProvider` and wired into the derived template via `envFrom` (all secret keys as env vars) AND a read-only volume mount at `/var/run/secrets/llm-credentials/`. Both mounts MUST be unconditional regardless of provider type — the sandbox uses whichever form its SDK requires. The operator MUST NOT set individual credential env vars by name.
+16a. **LLM configuration env vars**: The operator MUST set the following generic env vars on the derived template. The operator MUST NOT set any SDK-specific env vars — the sandbox maps these generic vars to SDK-specific vars internally.
+
+    | Env var | Required | Source |
+    |---|---|---|
+    | `LIGHTSPEED_PROVIDER` | Yes | `LLMProvider.spec.type` mapped to: `anthropic`, `vertex`, `openai`, `azure`, `bedrock` |
+    | `LIGHTSPEED_MODEL` | Yes | `Agent.spec.model` |
+    | `LIGHTSPEED_MODEL_PROVIDER` | When provider=`vertex` | `googleCloudVertex.modelProvider` (`Anthropic`, `Google`, `OpenAI`) |
+    | `LIGHTSPEED_MODE` | Yes | Workflow step name |
+    | `LIGHTSPEED_PROVIDER_URL` | When URL set on provider config | URL override from active provider config branch |
+    | `LIGHTSPEED_PROVIDER_PROJECT` | When applicable | `googleCloudVertex.projectID` |
+    | `LIGHTSPEED_PROVIDER_REGION` | When applicable | `googleCloudVertex.region` or `awsBedrock.region` |
+    | `LIGHTSPEED_PROVIDER_API_VERSION` | When applicable | `azureOpenAI.apiVersion` |
+
+    Provider type mapping from CRD `spec.type`:
+
+    | CRD `spec.type` | `LIGHTSPEED_PROVIDER` value |
+    |---|---|
+    | `anthropic` | `anthropic` |
+    | `googleCloudVertex` | `vertex` |
+    | `openAI` | `openai` |
+    | `azureOpenAI` | `azure` |
+    | `awsBedrock` | `bedrock` |
 17. **Secrets — MCP headers**: When an MCP header sources a Secret, the template MUST mount that secret on a dedicated read-only path suitable for header injection configuration.
 18. **Skills volumes**: Skills MUST be conveyed as OCI image volume(s) on the sandbox pod template; when `SkillsSource.paths` is set, the controller MUST mount each path as a `subPath` under the configured skills mount root using stable mount naming derived from the path’s final segment. When multiple `skills` entries exist in `ToolsSpec`, template derivation MUST apply image/path patching based on the **first** non-empty skills source (current behavior).
 19. **MCP servers**: MCP configuration MUST be serialized to an environment variable payload listing servers, URLs, timeouts, and header sources so the agent runtime can open MCP connections without CR-specific code in the agent.
@@ -42,7 +64,7 @@ Behavioral specification for how workflow steps run inside ephemeral **sandboxes
 - `spec.tools`, per-step `spec.*.tools` (`SkillsSource`, `MCPServerConfig`, `SecretRequirement`)
 - `spec.targetNamespaces` and RBAC materialization targets
 - `spec.analysisOutput` (analysis schema behavior)
-- `Agent.spec.model`, `LLMProvider.spec.*` (credentials secret names, endpoints, regional fields)
+- `Agent.spec.model` → `LIGHTSPEED_MODEL`, `LLMProvider.spec.type` → `LIGHTSPEED_PROVIDER`, `LLMProvider.spec.*.credentialsSecret` (envFrom + volume mount), optional `LIGHTSPEED_PROVIDER_URL`, `LIGHTSPEED_PROVIDER_PROJECT`, `LIGHTSPEED_PROVIDER_REGION`, `LIGHTSPEED_PROVIDER_API_VERSION`, `LIGHTSPEED_MODEL_PROVIDER` (see rule 16a)
 - `Proposal` annotation `agentic.openshift.io/rbac-namespaces` (RBAC scope for cleanup)
 - `Proposal` finalizer string `agentic.openshift.io/execution-rbac-cleanup`
 
@@ -56,5 +78,5 @@ Behavioral specification for how workflow steps run inside ephemeral **sandboxes
 
 - [PLANNED: OLS-2957] **Sandbox template management** UX and CRD ergonomics (base/derived lifecycle, versioning) may change operator/template coupling described in rules 2–4.
 - [PLANNED: OLS-3038] **TLS verification and network policy** for agent traffic may replace permissive internal TLS client behavior.
-- [PLANNED: OLS-3044] **Provider parity**: environment variable contract for non-Claude providers in templates MUST track sandbox image capabilities.
+- [OLS-3153] **Operator-sandbox env var contract**: SDK-specific env vars removed from operator; replaced by generic `LIGHTSPEED_*` vars (rule 16a). Sandbox handles all SDK-specific mapping internally. Supersedes OLS-3044 and OLS-3051.
 - [PLANNED: OLS-2894] Support **multiple concurrent skills images** in template derivation beyond the first `skills` entry if product requires composite skill bundles.


### PR DESCRIPTION
## Summary

- Updates `.ai/spec/what/sandbox-execution.md` to define the generic `LIGHTSPEED_*` env var contract between operator and sandbox (rule 16a)
- Operator MUST NOT set SDK-specific env vars (`ANTHROPIC_MODEL`, `CLAUDE_CODE_USE_VERTEX`, `OPENAI_BASE_URL`, etc.) — all SDK-specific mapping is the sandbox's responsibility
- Credentials mounted unconditionally via `envFrom` + volume at `/var/run/secrets/llm-credentials/`
- Provider type mapping: CRD `spec.type` → simple strings (`anthropic`, `vertex`, `openai`, `azure`, `bedrock`)
- Supersedes [OLS-3044](https://redhat.atlassian.net/browse/OLS-3044) and [OLS-3051](https://redhat.atlassian.net/browse/OLS-3051)

Companion PR: sandbox spec updates in openshift/lightspeed-agentic-sandbox

## Test plan

- [ ] Review spec changes for consistency with sandbox companion PR
- [ ] Verify env var contract table matches sandbox configuration mapping table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated sandbox execution specification with refined requirements for template creation, environment variable configuration, and credential management.
  * Clarified LLM credential injection mechanism including volume mount and secret sourcing requirements.
  * Added explicit rules for operator-managed environment variable mapping and updated configuration surface documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->