### PR TITLE
OLS-3200: implement generic LIGHTSPEED_* env var contract (operator)

### DIFF
--- a/.ai/spec/what/sandbox-execution.md
+++ b/.ai/spec/what/sandbox-execution.md
@@ -25,13 +25,12 @@ Behavioral specification for how workflow steps run inside ephemeral **sandboxes
     | Env var | Required | Source |
     |---|---|---|
     | `LIGHTSPEED_PROVIDER` | Yes | `LLMProvider.spec.type` mapped to: `anthropic`, `vertex`, `openai`, `azure`, `bedrock` |
-    | `LIGHTSPEED_MODEL` | Yes | `Agent.spec.model` |
-    | `LIGHTSPEED_MODEL_PROVIDER` | When provider=`vertex` | `googleCloudVertex.modelProvider` (`Anthropic`, `Google`, `OpenAI`) |
-    | `LIGHTSPEED_MODE` | Yes | Workflow step name |
-    | `LIGHTSPEED_PROVIDER_URL` | When URL set on provider config | URL override from active provider config branch |
-    | `LIGHTSPEED_PROVIDER_PROJECT` | When applicable | `googleCloudVertex.projectID` |
-    | `LIGHTSPEED_PROVIDER_REGION` | When applicable | `googleCloudVertex.region` or `awsBedrock.region` |
-    | `LIGHTSPEED_PROVIDER_API_VERSION` | When applicable | `azureOpenAI.apiVersion` |
+    | `LIGHTSPEED_MODEL` | Yes | `Agent.spec.model` (passed as-is) |
+    | `LIGHTSPEED_MODEL_PROVIDER` | When provider=`vertex` | `googleCloudVertex.modelProvider` lowercased: `anthropic`, `google`, `openai` |
+    | `LIGHTSPEED_PROVIDER_URL` | When URL set on provider config | URL override from active provider config branch (passed as-is) |
+    | `LIGHTSPEED_PROVIDER_PROJECT` | When provider=`vertex` | `googleCloudVertex.projectID` (passed as-is) |
+    | `LIGHTSPEED_PROVIDER_REGION` | When provider=`vertex` or `bedrock` | `googleCloudVertex.region` or `awsBedrock.region` (passed as-is) |
+    | `LIGHTSPEED_PROVIDER_API_VERSION` | When provider=`azure` | `azureOpenAI.apiVersion` (passed as-is) |
 
     Provider type mapping from CRD `spec.type`:
 

--- a/.ai/spec/what/sandbox-execution.md
+++ b/.ai/spec/what/sandbox-execution.md
@@ -78,5 +78,5 @@ Behavioral specification for how workflow steps run inside ephemeral **sandboxes
 
 - [PLANNED: OLS-2957] **Sandbox template management** UX and CRD ergonomics (base/derived lifecycle, versioning) may change operator/template coupling described in rules 2–4.
 - [PLANNED: OLS-3038] **TLS verification and network policy** for agent traffic may replace permissive internal TLS client behavior.
-- [OLS-3153] **Operator-sandbox env var contract**: SDK-specific env vars removed from operator; replaced by generic `LIGHTSPEED_*` vars (rule 16a). Sandbox handles all SDK-specific mapping internally. Supersedes OLS-3044 and OLS-3051.
+- [OLS-3153] ~~IMPLEMENTED~~ Operator-sandbox env var contract: SDK-specific env vars removed from operator; replaced by generic `LIGHTSPEED_*` vars (rule 16a). Sandbox handles all SDK-specific mapping internally. Supersedes OLS-3044 and OLS-3051.
 - [PLANNED: OLS-2894] Support **multiple concurrent skills images** in template derivation beyond the first `skills` entry if product requires composite skill bundles.

--- a/.ai/spec/what/sandbox-execution.md
+++ b/.ai/spec/what/sandbox-execution.md
@@ -78,5 +78,4 @@ Behavioral specification for how workflow steps run inside ephemeral **sandboxes
 
 - [PLANNED: OLS-2957] **Sandbox template management** UX and CRD ergonomics (base/derived lifecycle, versioning) may change operator/template coupling described in rules 2–4.
 - [PLANNED: OLS-3038] **TLS verification and network policy** for agent traffic may replace permissive internal TLS client behavior.
-- [OLS-3153] ~~IMPLEMENTED~~ Operator-sandbox env var contract: SDK-specific env vars removed from operator; replaced by generic `LIGHTSPEED_*` vars (rule 16a). Sandbox handles all SDK-specific mapping internally. Supersedes OLS-3044 and OLS-3051.
 - [PLANNED: OLS-2894] Support **multiple concurrent skills images** in template derivation beyond the first `skills` entry if product requires composite skill bundles.

--- a/controller/proposal/sandbox_templates.go
+++ b/controller/proposal/sandbox_templates.go
@@ -289,7 +289,7 @@ func patchLLMCredentials(tmpl *unstructured.Unstructured, llm *agenticv1alpha1.L
 		}
 	case agenticv1alpha1.LLMProviderGoogleCloudVertex:
 		cfg := llm.Spec.GoogleCloudVertex
-		if err := setEnvVar(tmpl, "LIGHTSPEED_MODEL_PROVIDER", string(cfg.ModelProvider)); err != nil {
+		if err := setEnvVar(tmpl, "LIGHTSPEED_MODEL_PROVIDER", strings.ToLower(string(cfg.ModelProvider))); err != nil {
 			return fmt.Errorf("set LIGHTSPEED_MODEL_PROVIDER: %w", err)
 		}
 		if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_PROJECT", cfg.ProjectID); err != nil {

--- a/controller/proposal/sandbox_templates.go
+++ b/controller/proposal/sandbox_templates.go
@@ -28,11 +28,10 @@ var sandboxTemplateGVK = schema.GroupVersionKind{
 const (
 	agentModeEnvVar = "LIGHTSPEED_MODE"
 
-	vertexCredsMountPath = "/var/secrets/google"
-	vertexCredsFileName  = "credentials.json"
-	llmCredsVolumeName   = "llm-credentials"
-	mcpHeadersMountRoot  = "/var/secrets/mcp"
-	mcpServersEnvVar     = "LIGHTSPEED_MCP_SERVERS"
+	llmCredsMountPath   = "/var/run/secrets/llm-credentials"
+	llmCredsVolumeName  = "llm-credentials"
+	mcpHeadersMountRoot = "/var/secrets/mcp"
+	mcpServersEnvVar    = "LIGHTSPEED_MCP_SERVERS"
 
 	LabelManaged      = "agentic.openshift.io/managed"
 	LabelBaseTemplate = "agentic.openshift.io/base-template"
@@ -245,74 +244,97 @@ func providerURL(llm *agenticv1alpha1.LLMProvider) string {
 	}
 }
 
+func providerTypeString(t agenticv1alpha1.LLMProviderType) string {
+	switch t {
+	case agenticv1alpha1.LLMProviderAnthropic:
+		return "anthropic"
+	case agenticv1alpha1.LLMProviderGoogleCloudVertex:
+		return "vertex"
+	case agenticv1alpha1.LLMProviderOpenAI:
+		return "openai"
+	case agenticv1alpha1.LLMProviderAzureOpenAI:
+		return "azure"
+	case agenticv1alpha1.LLMProviderAWSBedrock:
+		return "bedrock"
+	default:
+		return strings.ToLower(string(t))
+	}
+}
+
 func patchLLMCredentials(tmpl *unstructured.Unstructured, llm *agenticv1alpha1.LLMProvider, model string) error {
 	secretName := credentialsSecretName(llm)
 
+	if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER", providerTypeString(llm.Spec.Type)); err != nil {
+		return fmt.Errorf("set LIGHTSPEED_PROVIDER: %w", err)
+	}
+	if err := setEnvVar(tmpl, "LIGHTSPEED_MODEL", model); err != nil {
+		return fmt.Errorf("set LIGHTSPEED_MODEL: %w", err)
+	}
 	if err := addEnvFromSecret(tmpl, secretName); err != nil {
 		return fmt.Errorf("add credentials envFrom: %w", err)
 	}
-	if err := setEnvVar(tmpl, "ANTHROPIC_MODEL", model); err != nil {
-		return fmt.Errorf("set ANTHROPIC_MODEL: %w", err)
+	if err := addSecretVolume(tmpl, llmCredsVolumeName, secretName); err != nil {
+		return fmt.Errorf("add credentials volume: %w", err)
 	}
-
-	if u := providerURL(llm); u != "" {
-		if err := setEnvVar(tmpl, providerURLEnvVar(llm.Spec.Type), u); err != nil {
-			return fmt.Errorf("set provider URL: %w", err)
-		}
+	if err := addVolumeMount(tmpl, llmCredsVolumeName, llmCredsMountPath, true); err != nil {
+		return fmt.Errorf("mount credentials: %w", err)
 	}
 
 	switch llm.Spec.Type {
+	case agenticv1alpha1.LLMProviderAnthropic:
+		if u := providerURL(llm); u != "" {
+			if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_URL", u); err != nil {
+				return fmt.Errorf("set LIGHTSPEED_PROVIDER_URL: %w", err)
+			}
+		}
 	case agenticv1alpha1.LLMProviderGoogleCloudVertex:
 		cfg := llm.Spec.GoogleCloudVertex
-		if err := setEnvVar(tmpl, "CLAUDE_CODE_USE_VERTEX", "1"); err != nil {
-			return fmt.Errorf("set CLAUDE_CODE_USE_VERTEX: %w", err)
+		if err := setEnvVar(tmpl, "LIGHTSPEED_MODEL_PROVIDER", string(cfg.ModelProvider)); err != nil {
+			return fmt.Errorf("set LIGHTSPEED_MODEL_PROVIDER: %w", err)
 		}
-		if err := setEnvVar(tmpl, "GCP_PROJECT", cfg.ProjectID); err != nil {
-			return fmt.Errorf("set GCP_PROJECT: %w", err)
+		if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_PROJECT", cfg.ProjectID); err != nil {
+			return fmt.Errorf("set LIGHTSPEED_PROVIDER_PROJECT: %w", err)
 		}
-		if err := setEnvVar(tmpl, "GCP_REGION", cfg.Region); err != nil {
-			return fmt.Errorf("set GCP_REGION: %w", err)
+		if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_REGION", cfg.Region); err != nil {
+			return fmt.Errorf("set LIGHTSPEED_PROVIDER_REGION: %w", err)
 		}
-		if err := setEnvVar(tmpl, "GOOGLE_APPLICATION_CREDENTIALS", vertexCredsMountPath+"/"+vertexCredsFileName); err != nil {
-			return fmt.Errorf("set GOOGLE_APPLICATION_CREDENTIALS: %w", err)
+		if u := providerURL(llm); u != "" {
+			if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_URL", u); err != nil {
+				return fmt.Errorf("set LIGHTSPEED_PROVIDER_URL: %w", err)
+			}
 		}
-		if err := addSecretVolume(tmpl, llmCredsVolumeName, secretName); err != nil {
-			return fmt.Errorf("add Vertex credentials volume: %w", err)
-		}
-		if err := addVolumeMount(tmpl, llmCredsVolumeName, vertexCredsMountPath, true); err != nil {
-			return fmt.Errorf("mount Vertex credentials: %w", err)
+	case agenticv1alpha1.LLMProviderOpenAI:
+		if u := providerURL(llm); u != "" {
+			if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_URL", u); err != nil {
+				return fmt.Errorf("set LIGHTSPEED_PROVIDER_URL: %w", err)
+			}
 		}
 	case agenticv1alpha1.LLMProviderAzureOpenAI:
 		cfg := llm.Spec.AzureOpenAI
-		if err := setEnvVar(tmpl, "AZURE_OPENAI_ENDPOINT", cfg.Endpoint); err != nil {
-			return fmt.Errorf("set AZURE_OPENAI_ENDPOINT: %w", err)
+		providerURLValue := cfg.Endpoint
+		if u := cfg.URL; u != "" {
+			providerURLValue = u
+		}
+		if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_URL", providerURLValue); err != nil {
+			return fmt.Errorf("set LIGHTSPEED_PROVIDER_URL: %w", err)
 		}
 		if cfg.APIVersion != "" {
-			if err := setEnvVar(tmpl, "AZURE_OPENAI_API_VERSION", cfg.APIVersion); err != nil {
-				return fmt.Errorf("set AZURE_OPENAI_API_VERSION: %w", err)
+			if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_API_VERSION", cfg.APIVersion); err != nil {
+				return fmt.Errorf("set LIGHTSPEED_PROVIDER_API_VERSION: %w", err)
 			}
 		}
 	case agenticv1alpha1.LLMProviderAWSBedrock:
 		cfg := llm.Spec.AWSBedrock
-		if err := setEnvVar(tmpl, "CLAUDE_CODE_USE_BEDROCK", "1"); err != nil {
-			return fmt.Errorf("set CLAUDE_CODE_USE_BEDROCK: %w", err)
+		if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_REGION", cfg.Region); err != nil {
+			return fmt.Errorf("set LIGHTSPEED_PROVIDER_REGION: %w", err)
 		}
-		if err := setEnvVar(tmpl, "AWS_REGION", cfg.Region); err != nil {
-			return fmt.Errorf("set AWS_REGION: %w", err)
+		if u := providerURL(llm); u != "" {
+			if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_URL", u); err != nil {
+				return fmt.Errorf("set LIGHTSPEED_PROVIDER_URL: %w", err)
+			}
 		}
 	}
 	return nil
-}
-
-func providerURLEnvVar(t agenticv1alpha1.LLMProviderType) string {
-	switch t {
-	case agenticv1alpha1.LLMProviderOpenAI:
-		return "OPENAI_BASE_URL"
-	case agenticv1alpha1.LLMProviderAzureOpenAI:
-		return "AZURE_OPENAI_ENDPOINT"
-	default:
-		return "ANTHROPIC_BASE_URL"
-	}
 }
 
 func patchRequiredSecrets(tmpl *unstructured.Unstructured, secrets []agenticv1alpha1.SecretRequirement) error {

--- a/controller/proposal/sandbox_templates_test.go
+++ b/controller/proposal/sandbox_templates_test.go
@@ -242,8 +242,11 @@ func TestComputeTemplateHash_DifferentRequiredSecrets(t *testing.T) {
 
 // --- patchLLMCredentials tests ---
 
-func assertCredentialVolumeMount(t *testing.T, tmpl *unstructured.Unstructured) {
+func assertCredentialMounts(t *testing.T, tmpl *unstructured.Unstructured) {
 	t.Helper()
+	if !hasSecretEnvFrom(tmpl, "my-llm-secret") {
+		t.Error("missing envFrom secretRef for my-llm-secret")
+	}
 	containers, _, _ := unstructured.NestedSlice(tmpl.Object, "spec", "podTemplate", "spec", "containers")
 	if len(containers) == 0 {
 		t.Fatal("no containers")
@@ -276,10 +279,7 @@ func TestPatchLLMCredentials_Anthropic(t *testing.T) {
 		t.Fatalf("patchLLMCredentials: %v", err)
 	}
 
-	if !hasSecretEnvFrom(tmpl, "my-llm-secret") {
-		t.Error("missing envFrom secretRef for my-llm-secret")
-	}
-	assertCredentialVolumeMount(t, tmpl)
+	assertCredentialMounts(t, tmpl)
 
 	envs := getEnvVars(tmpl)
 	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
@@ -309,10 +309,7 @@ func TestPatchLLMCredentials_Vertex(t *testing.T) {
 		t.Fatalf("patchLLMCredentials: %v", err)
 	}
 
-	if !hasSecretEnvFrom(tmpl, "my-llm-secret") {
-		t.Error("missing envFrom secretRef for my-llm-secret")
-	}
-	assertCredentialVolumeMount(t, tmpl)
+	assertCredentialMounts(t, tmpl)
 
 	envs := getEnvVars(tmpl)
 	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
@@ -352,7 +349,7 @@ func TestPatchLLMCredentials_Bedrock(t *testing.T) {
 		t.Fatalf("patchLLMCredentials: %v", err)
 	}
 
-	assertCredentialVolumeMount(t, tmpl)
+	assertCredentialMounts(t, tmpl)
 
 	envs := getEnvVars(tmpl)
 	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
@@ -382,7 +379,7 @@ func TestPatchLLMCredentials_OpenAI(t *testing.T) {
 		t.Fatalf("patchLLMCredentials: %v", err)
 	}
 
-	assertCredentialVolumeMount(t, tmpl)
+	assertCredentialMounts(t, tmpl)
 
 	envs := getEnvVars(tmpl)
 	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
@@ -412,7 +409,7 @@ func TestPatchLLMCredentials_Azure(t *testing.T) {
 		t.Fatalf("patchLLMCredentials: %v", err)
 	}
 
-	assertCredentialVolumeMount(t, tmpl)
+	assertCredentialMounts(t, tmpl)
 
 	envs := getEnvVars(tmpl)
 	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {

--- a/controller/proposal/sandbox_templates_test.go
+++ b/controller/proposal/sandbox_templates_test.go
@@ -327,7 +327,7 @@ func TestPatchLLMCredentials_Vertex(t *testing.T) {
 	}
 	if e, ok := findEnv(envs, "LIGHTSPEED_MODEL_PROVIDER"); !ok {
 		t.Error("missing LIGHTSPEED_MODEL_PROVIDER")
-	} else if e["value"] != string(agenticv1alpha1.GoogleCloudVertexModelProviderAnthropic) {
+	} else if e["value"] != "anthropic" {
 		t.Errorf("LIGHTSPEED_MODEL_PROVIDER = %q", e["value"])
 	}
 	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER_PROJECT"); !ok {

--- a/controller/proposal/sandbox_templates_test.go
+++ b/controller/proposal/sandbox_templates_test.go
@@ -15,11 +15,20 @@ func testLLMProvider(providerType agenticv1alpha1.LLMProviderType) *agenticv1alp
 	case agenticv1alpha1.LLMProviderAnthropic:
 		spec.Anthropic = agenticv1alpha1.AnthropicConfig{CredentialsSecret: creds}
 	case agenticv1alpha1.LLMProviderGoogleCloudVertex:
-		spec.GoogleCloudVertex = agenticv1alpha1.GoogleCloudVertexConfig{CredentialsSecret: creds, ProjectID: "test-project", Region: "us-central1"}
+		spec.GoogleCloudVertex = agenticv1alpha1.GoogleCloudVertexConfig{
+			CredentialsSecret: creds,
+			ProjectID:         "test-project",
+			Region:            "us-central1",
+			ModelProvider:     agenticv1alpha1.GoogleCloudVertexModelProviderAnthropic,
+		}
 	case agenticv1alpha1.LLMProviderOpenAI:
 		spec.OpenAI = agenticv1alpha1.OpenAIConfig{CredentialsSecret: creds}
 	case agenticv1alpha1.LLMProviderAzureOpenAI:
-		spec.AzureOpenAI = agenticv1alpha1.AzureOpenAIConfig{CredentialsSecret: creds, Endpoint: "https://test.openai.azure.com"}
+		spec.AzureOpenAI = agenticv1alpha1.AzureOpenAIConfig{
+			CredentialsSecret: creds,
+			Endpoint:          "https://test.openai.azure.com",
+			APIVersion:        "2024-02-01",
+		}
 	case agenticv1alpha1.LLMProviderAWSBedrock:
 		spec.AWSBedrock = agenticv1alpha1.AWSBedrockConfig{CredentialsSecret: creds, Region: "us-east-1"}
 	}
@@ -233,6 +242,45 @@ func TestComputeTemplateHash_DifferentRequiredSecrets(t *testing.T) {
 
 // --- patchLLMCredentials tests ---
 
+var sdkSpecificEnvVars = []string{
+	"ANTHROPIC_MODEL", "CLAUDE_CODE_USE_VERTEX", "GCP_PROJECT", "GCP_REGION",
+	"GOOGLE_APPLICATION_CREDENTIALS", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_API_VERSION",
+	"CLAUDE_CODE_USE_BEDROCK", "AWS_REGION", "OPENAI_BASE_URL", "ANTHROPIC_BASE_URL",
+}
+
+func assertNoSDKEnvVars(t *testing.T, envs []map[string]any) {
+	t.Helper()
+	for _, name := range sdkSpecificEnvVars {
+		if _, ok := findEnv(envs, name); ok {
+			t.Errorf("unexpected SDK-specific env var %s", name)
+		}
+	}
+}
+
+func assertCredentialVolumeMount(t *testing.T, tmpl *unstructured.Unstructured) {
+	t.Helper()
+	containers, _, _ := unstructured.NestedSlice(tmpl.Object, "spec", "podTemplate", "spec", "containers")
+	if len(containers) == 0 {
+		t.Fatal("no containers")
+	}
+	container := containers[0].(map[string]any)
+	mounts, _, _ := unstructured.NestedSlice(container, "volumeMounts")
+	found := false
+	for _, m := range mounts {
+		mount := m.(map[string]any)
+		if mount["name"] == llmCredsVolumeName && mount["mountPath"] == llmCredsMountPath {
+			found = true
+			if mount["readOnly"] != true {
+				t.Error("credential volume mount should be readOnly")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("missing credential volume mount at %s", llmCredsMountPath)
+	}
+}
+
 func TestPatchLLMCredentials_Anthropic(t *testing.T) {
 	tmpl := emptyTemplate()
 	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderAnthropic, "https://custom.api")
@@ -244,18 +292,25 @@ func TestPatchLLMCredentials_Anthropic(t *testing.T) {
 	if !hasSecretEnvFrom(tmpl, "my-llm-secret") {
 		t.Error("missing envFrom secretRef for my-llm-secret")
 	}
+	assertCredentialVolumeMount(t, tmpl)
 
 	envs := getEnvVars(tmpl)
-	if e, ok := findEnv(envs, "ANTHROPIC_MODEL"); !ok {
-		t.Error("missing ANTHROPIC_MODEL")
-	} else if e["value"] != "claude-opus-4-6" {
-		t.Errorf("ANTHROPIC_MODEL = %q", e["value"])
-	}
+	assertNoSDKEnvVars(t, envs)
 
-	if e, ok := findEnv(envs, "ANTHROPIC_BASE_URL"); !ok {
-		t.Error("missing ANTHROPIC_BASE_URL")
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER")
+	} else if e["value"] != "anthropic" {
+		t.Errorf("LIGHTSPEED_PROVIDER = %q, want anthropic", e["value"])
+	}
+	if e, ok := findEnv(envs, "LIGHTSPEED_MODEL"); !ok {
+		t.Error("missing LIGHTSPEED_MODEL")
+	} else if e["value"] != "claude-opus-4-6" {
+		t.Errorf("LIGHTSPEED_MODEL = %q", e["value"])
+	}
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER_URL"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER_URL")
 	} else if e["value"] != "https://custom.api" {
-		t.Errorf("ANTHROPIC_BASE_URL = %q", e["value"])
+		t.Errorf("LIGHTSPEED_PROVIDER_URL = %q", e["value"])
 	}
 }
 
@@ -270,29 +325,35 @@ func TestPatchLLMCredentials_Vertex(t *testing.T) {
 	if !hasSecretEnvFrom(tmpl, "my-llm-secret") {
 		t.Error("missing envFrom secretRef for my-llm-secret")
 	}
+	assertCredentialVolumeMount(t, tmpl)
 
 	envs := getEnvVars(tmpl)
-	if e, ok := findEnv(envs, "CLAUDE_CODE_USE_VERTEX"); !ok {
-		t.Error("missing CLAUDE_CODE_USE_VERTEX")
-	} else if e["value"] != "1" {
-		t.Errorf("CLAUDE_CODE_USE_VERTEX = %q", e["value"])
-	}
+	assertNoSDKEnvVars(t, envs)
 
-	if e, ok := findEnv(envs, "GOOGLE_APPLICATION_CREDENTIALS"); !ok {
-		t.Error("missing GOOGLE_APPLICATION_CREDENTIALS")
-	} else if e["value"] != vertexCredsMountPath+"/"+vertexCredsFileName {
-		t.Errorf("GOOGLE_APPLICATION_CREDENTIALS = %q", e["value"])
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER")
+	} else if e["value"] != "vertex" {
+		t.Errorf("LIGHTSPEED_PROVIDER = %q, want vertex", e["value"])
 	}
-
-	containers, _, _ := unstructured.NestedSlice(tmpl.Object, "spec", "podTemplate", "spec", "containers")
-	container := containers[0].(map[string]any)
-	mounts, _, _ := unstructured.NestedSlice(container, "volumeMounts")
-	if len(mounts) != 1 {
-		t.Fatalf("expected 1 volume mount, got %d", len(mounts))
+	if e, ok := findEnv(envs, "LIGHTSPEED_MODEL"); !ok {
+		t.Error("missing LIGHTSPEED_MODEL")
+	} else if e["value"] != "claude-opus-4-6" {
+		t.Errorf("LIGHTSPEED_MODEL = %q", e["value"])
 	}
-	mount := mounts[0].(map[string]any)
-	if mount["name"] != llmCredsVolumeName || mount["mountPath"] != vertexCredsMountPath {
-		t.Errorf("mount = %v", mount)
+	if e, ok := findEnv(envs, "LIGHTSPEED_MODEL_PROVIDER"); !ok {
+		t.Error("missing LIGHTSPEED_MODEL_PROVIDER")
+	} else if e["value"] != string(agenticv1alpha1.GoogleCloudVertexModelProviderAnthropic) {
+		t.Errorf("LIGHTSPEED_MODEL_PROVIDER = %q", e["value"])
+	}
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER_PROJECT"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER_PROJECT")
+	} else if e["value"] != "test-project" {
+		t.Errorf("LIGHTSPEED_PROVIDER_PROJECT = %q", e["value"])
+	}
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER_REGION"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER_REGION")
+	} else if e["value"] != "us-central1" {
+		t.Errorf("LIGHTSPEED_PROVIDER_REGION = %q", e["value"])
 	}
 }
 
@@ -304,11 +365,101 @@ func TestPatchLLMCredentials_Bedrock(t *testing.T) {
 		t.Fatalf("patchLLMCredentials: %v", err)
 	}
 
+	assertCredentialVolumeMount(t, tmpl)
+
 	envs := getEnvVars(tmpl)
-	if e, ok := findEnv(envs, "CLAUDE_CODE_USE_BEDROCK"); !ok {
-		t.Error("missing CLAUDE_CODE_USE_BEDROCK")
-	} else if e["value"] != "1" {
-		t.Errorf("CLAUDE_CODE_USE_BEDROCK = %q", e["value"])
+	assertNoSDKEnvVars(t, envs)
+
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER")
+	} else if e["value"] != "bedrock" {
+		t.Errorf("LIGHTSPEED_PROVIDER = %q, want bedrock", e["value"])
+	}
+	if e, ok := findEnv(envs, "LIGHTSPEED_MODEL"); !ok {
+		t.Error("missing LIGHTSPEED_MODEL")
+	} else if e["value"] != "claude-opus-4-6" {
+		t.Errorf("LIGHTSPEED_MODEL = %q", e["value"])
+	}
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER_REGION"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER_REGION")
+	} else if e["value"] != "us-east-1" {
+		t.Errorf("LIGHTSPEED_PROVIDER_REGION = %q", e["value"])
+	}
+}
+
+func TestPatchLLMCredentials_OpenAI(t *testing.T) {
+	tmpl := emptyTemplate()
+	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderOpenAI, "https://api.example.com")
+
+	if err := patchLLMCredentials(tmpl, llm, "gpt-4.1"); err != nil {
+		t.Fatalf("patchLLMCredentials: %v", err)
+	}
+
+	assertCredentialVolumeMount(t, tmpl)
+
+	envs := getEnvVars(tmpl)
+	assertNoSDKEnvVars(t, envs)
+
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER")
+	} else if e["value"] != "openai" {
+		t.Errorf("LIGHTSPEED_PROVIDER = %q, want openai", e["value"])
+	}
+	if e, ok := findEnv(envs, "LIGHTSPEED_MODEL"); !ok {
+		t.Error("missing LIGHTSPEED_MODEL")
+	} else if e["value"] != "gpt-4.1" {
+		t.Errorf("LIGHTSPEED_MODEL = %q", e["value"])
+	}
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER_URL"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER_URL")
+	} else if e["value"] != "https://api.example.com" {
+		t.Errorf("LIGHTSPEED_PROVIDER_URL = %q", e["value"])
+	}
+}
+
+func TestPatchLLMCredentials_Azure(t *testing.T) {
+	tmpl := emptyTemplate()
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAzureOpenAI)
+
+	if err := patchLLMCredentials(tmpl, llm, "gpt-4"); err != nil {
+		t.Fatalf("patchLLMCredentials: %v", err)
+	}
+
+	assertCredentialVolumeMount(t, tmpl)
+
+	envs := getEnvVars(tmpl)
+	assertNoSDKEnvVars(t, envs)
+
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER")
+	} else if e["value"] != "azure" {
+		t.Errorf("LIGHTSPEED_PROVIDER = %q, want azure", e["value"])
+	}
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER_URL"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER_URL")
+	} else if e["value"] != "https://test.openai.azure.com" {
+		t.Errorf("LIGHTSPEED_PROVIDER_URL = %q", e["value"])
+	}
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER_API_VERSION"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER_API_VERSION")
+	} else if e["value"] != "2024-02-01" {
+		t.Errorf("LIGHTSPEED_PROVIDER_API_VERSION = %q", e["value"])
+	}
+}
+
+func TestPatchLLMCredentials_AzureURLOverridesEndpoint(t *testing.T) {
+	tmpl := emptyTemplate()
+	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderAzureOpenAI, "https://override.example.com")
+
+	if err := patchLLMCredentials(tmpl, llm, "gpt-4"); err != nil {
+		t.Fatalf("patchLLMCredentials: %v", err)
+	}
+
+	envs := getEnvVars(tmpl)
+	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER_URL"); !ok {
+		t.Error("missing LIGHTSPEED_PROVIDER_URL")
+	} else if e["value"] != "https://override.example.com" {
+		t.Errorf("LIGHTSPEED_PROVIDER_URL = %q, want override URL", e["value"])
 	}
 }
 

--- a/controller/proposal/sandbox_templates_test.go
+++ b/controller/proposal/sandbox_templates_test.go
@@ -242,21 +242,6 @@ func TestComputeTemplateHash_DifferentRequiredSecrets(t *testing.T) {
 
 // --- patchLLMCredentials tests ---
 
-var sdkSpecificEnvVars = []string{
-	"ANTHROPIC_MODEL", "CLAUDE_CODE_USE_VERTEX", "GCP_PROJECT", "GCP_REGION",
-	"GOOGLE_APPLICATION_CREDENTIALS", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_API_VERSION",
-	"CLAUDE_CODE_USE_BEDROCK", "AWS_REGION", "OPENAI_BASE_URL", "ANTHROPIC_BASE_URL",
-}
-
-func assertNoSDKEnvVars(t *testing.T, envs []map[string]any) {
-	t.Helper()
-	for _, name := range sdkSpecificEnvVars {
-		if _, ok := findEnv(envs, name); ok {
-			t.Errorf("unexpected SDK-specific env var %s", name)
-		}
-	}
-}
-
 func assertCredentialVolumeMount(t *testing.T, tmpl *unstructured.Unstructured) {
 	t.Helper()
 	containers, _, _ := unstructured.NestedSlice(tmpl.Object, "spec", "podTemplate", "spec", "containers")
@@ -281,6 +266,8 @@ func assertCredentialVolumeMount(t *testing.T, tmpl *unstructured.Unstructured) 
 	}
 }
 
+// Anthropic LLMProvider: sets LIGHTSPEED_PROVIDER=anthropic, model, URL, plus
+// unconditional envFrom and credential volume mount.
 func TestPatchLLMCredentials_Anthropic(t *testing.T) {
 	tmpl := emptyTemplate()
 	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderAnthropic, "https://custom.api")
@@ -295,8 +282,6 @@ func TestPatchLLMCredentials_Anthropic(t *testing.T) {
 	assertCredentialVolumeMount(t, tmpl)
 
 	envs := getEnvVars(tmpl)
-	assertNoSDKEnvVars(t, envs)
-
 	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
 		t.Error("missing LIGHTSPEED_PROVIDER")
 	} else if e["value"] != "anthropic" {
@@ -314,6 +299,8 @@ func TestPatchLLMCredentials_Anthropic(t *testing.T) {
 	}
 }
 
+// GoogleCloudVertex LLMProvider: sets LIGHTSPEED_PROVIDER=vertex, model,
+// model provider, project, region, plus unconditional credential mounts.
 func TestPatchLLMCredentials_Vertex(t *testing.T) {
 	tmpl := emptyTemplate()
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex)
@@ -328,8 +315,6 @@ func TestPatchLLMCredentials_Vertex(t *testing.T) {
 	assertCredentialVolumeMount(t, tmpl)
 
 	envs := getEnvVars(tmpl)
-	assertNoSDKEnvVars(t, envs)
-
 	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
 		t.Error("missing LIGHTSPEED_PROVIDER")
 	} else if e["value"] != "vertex" {
@@ -357,6 +342,8 @@ func TestPatchLLMCredentials_Vertex(t *testing.T) {
 	}
 }
 
+// AWSBedrock LLMProvider: sets LIGHTSPEED_PROVIDER=bedrock, model, region,
+// plus unconditional credential mounts.
 func TestPatchLLMCredentials_Bedrock(t *testing.T) {
 	tmpl := emptyTemplate()
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAWSBedrock)
@@ -368,8 +355,6 @@ func TestPatchLLMCredentials_Bedrock(t *testing.T) {
 	assertCredentialVolumeMount(t, tmpl)
 
 	envs := getEnvVars(tmpl)
-	assertNoSDKEnvVars(t, envs)
-
 	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
 		t.Error("missing LIGHTSPEED_PROVIDER")
 	} else if e["value"] != "bedrock" {
@@ -387,6 +372,8 @@ func TestPatchLLMCredentials_Bedrock(t *testing.T) {
 	}
 }
 
+// OpenAI LLMProvider: sets LIGHTSPEED_PROVIDER=openai, model, URL,
+// plus unconditional credential mounts.
 func TestPatchLLMCredentials_OpenAI(t *testing.T) {
 	tmpl := emptyTemplate()
 	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderOpenAI, "https://api.example.com")
@@ -398,8 +385,6 @@ func TestPatchLLMCredentials_OpenAI(t *testing.T) {
 	assertCredentialVolumeMount(t, tmpl)
 
 	envs := getEnvVars(tmpl)
-	assertNoSDKEnvVars(t, envs)
-
 	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
 		t.Error("missing LIGHTSPEED_PROVIDER")
 	} else if e["value"] != "openai" {
@@ -417,6 +402,8 @@ func TestPatchLLMCredentials_OpenAI(t *testing.T) {
 	}
 }
 
+// AzureOpenAI LLMProvider: sets LIGHTSPEED_PROVIDER=azure, URL from endpoint,
+// API version, plus unconditional credential mounts.
 func TestPatchLLMCredentials_Azure(t *testing.T) {
 	tmpl := emptyTemplate()
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAzureOpenAI)
@@ -428,8 +415,6 @@ func TestPatchLLMCredentials_Azure(t *testing.T) {
 	assertCredentialVolumeMount(t, tmpl)
 
 	envs := getEnvVars(tmpl)
-	assertNoSDKEnvVars(t, envs)
-
 	if e, ok := findEnv(envs, "LIGHTSPEED_PROVIDER"); !ok {
 		t.Error("missing LIGHTSPEED_PROVIDER")
 	} else if e["value"] != "azure" {
@@ -447,6 +432,8 @@ func TestPatchLLMCredentials_Azure(t *testing.T) {
 	}
 }
 
+// AzureOpenAI with explicit URL: url field takes precedence over endpoint
+// for LIGHTSPEED_PROVIDER_URL.
 func TestPatchLLMCredentials_AzureURLOverridesEndpoint(t *testing.T) {
 	tmpl := emptyTemplate()
 	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderAzureOpenAI, "https://override.example.com")


### PR DESCRIPTION
## Summary

- Rewrites `patchLLMCredentials` to set only generic `LIGHTSPEED_*` env vars instead of SDK-specific vars
- Operator now sets: `LIGHTSPEED_PROVIDER`, `LIGHTSPEED_MODEL`, plus optional `LIGHTSPEED_MODEL_PROVIDER`, `LIGHTSPEED_PROVIDER_URL`, `LIGHTSPEED_PROVIDER_PROJECT`, `LIGHTSPEED_PROVIDER_REGION`, `LIGHTSPEED_PROVIDER_API_VERSION`
- Credentials mounted unconditionally for all providers via `envFrom` + volume at `/var/run/secrets/llm-credentials/` (previously Vertex-only at `/var/secrets/google`)
- Removes all SDK-specific env vars: `ANTHROPIC_MODEL`, `CLAUDE_CODE_USE_VERTEX`, `GCP_PROJECT`, `GCP_REGION`, `GOOGLE_APPLICATION_CREDENTIALS`, `AZURE_OPENAI_ENDPOINT`, `OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, etc.
- Azure URL resolution: `url` overrides `endpoint` for `LIGHTSPEED_PROVIDER_URL`

**Companion PR:** sandbox env var mapping in openshift/lightspeed-agentic-sandbox#62 (must merge together)

Jira: [OLS-3200](https://redhat.atlassian.net/browse/OLS-3200)
Supersedes: OLS-3044, [OLS-3051](https://redhat.atlassian.net/browse/OLS-3051)

## Test plan

- [x] Updated tests for Anthropic, Vertex, Bedrock providers
- [x] Added tests for OpenAI, Azure, Azure URL override providers
- [x] All tests assert `LIGHTSPEED_*` vars and absence of SDK-specific vars
- [x] All tests assert unconditional credential volume mount
- [x] Full operator test suite passes
- [ ] Coordinated merge with sandbox companion PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified sandbox environment variable specifications for LLM provider configuration and removed outdated configuration options.

* **Refactor**
  * Standardized credential mounting and environment variable handling across all supported LLM providers with improved consistency.

* **Tests**
  * Expanded test coverage for LLM provider credential configurations, environment variables, and provider-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->