### PR TITLE
OLS-3190: activate hermetic build on both x86_64 and ARM platforms

### DIFF
--- a/.tekton/lightspeed-agentic-operator-pull-request.yaml
+++ b/.tekton/lightspeed-agentic-operator-pull-request.yaml
@@ -29,8 +29,15 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/lightspeed-agentic-operator-push.yaml
+++ b/.tekton/lightspeed-agentic-operator-push.yaml
@@ -26,8 +26,15 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: Dockerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ARM64 (linux/arm64) architecture builds in addition to existing x86_64 support.

* **Chores**
  * Updated build pipeline configurations to enhance build reliability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->