### PR TITLE
Add risk level rubric to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,31 +2,4 @@
 
 ## Risk Levels
 
-When creating Jira tickets for this repo, assign a risk level in the description.
-
-| Level | Customer Impact | Review Requirements | Automation |
-|-------|----------------|---------------------|------------|
-| Risk 1 | Very little impact if change goes wrong | No human code review required | Fully automated implementation |
-| Risk 2 | Medium impact if change causes problems | 1 human reviewer required | Automated implementation with human review gate |
-| Risk 3 | Major impact — risk of losing customers if a bug is introduced | 2+ human reviewers required | Human-driven implementation |
-
-### Classification Examples
-
-| Change Type | Risk Level |
-|-------------|------------|
-| Dependency version bump | 1 |
-| Metadata-only changes | 1 |
-| Controller logic changes | 2 |
-| CRD schema changes | 3 |
-| RBAC/permissions changes | 3 |
-
-### Jira Description Format
-
-Include this section in every ticket description:
-
-```
-## Risk Level
-
-Risk {1|2|3} — {one-line impact summary}
-Rationale: {why this classification, referencing the rubric}
-```
+Risk levels are enforced via a PreToolUse hook before every Jira create/edit call. The rubric and classification examples live in [lightspeed-team-harness/hooks/risk-rubric.md](https://github.com/openshift/lightspeed-team-harness/blob/main/hooks/risk-rubric.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# OpenShift Lightspeed Agentic Operator - Development Guide for AI
+
+## Risk Levels
+
+When creating Jira tickets for this repo, assign a risk level in the description.
+
+| Level | Customer Impact | Review Requirements | Automation |
+|-------|----------------|---------------------|------------|
+| Risk 1 | Very little impact if change goes wrong | No human code review required | Fully automated implementation |
+| Risk 2 | Medium impact if change causes problems | 1 human reviewer required | Automated implementation with human review gate |
+| Risk 3 | Major impact — risk of losing customers if a bug is introduced | 2+ human reviewers required | Human-driven implementation |
+
+### Classification Examples
+
+| Change Type | Risk Level |
+|-------------|------------|
+| Dependency version bump | 1 |
+| Metadata-only changes | 1 |
+| Controller logic changes | 2 |
+| CRD schema changes | 3 |
+| RBAC/permissions changes | 3 |
+
+### Jira Description Format
+
+Include this section in every ticket description:
+
+```
+## Risk Level
+
+Risk {1|2|3} — {one-line impact summary}
+Rationale: {why this classification, referencing the rubric}
+```


### PR DESCRIPTION
Adds a Risk Levels section to AGENTS.md defining risk 1/2/3 classification with repo-specific examples and Jira description format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a development guide introducing Risk Levels and how they are applied to Jira create/edit operations, with detailed risk rubrics and classification examples in an external reference.
  * Clarified change-classification expectations, review guidance, standardized Jira ticket format, and related documentation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->