### PR TITLE
Fix model env var to use provider-specific name

### DIFF
--- a/controller/proposal/sandbox_templates.go
+++ b/controller/proposal/sandbox_templates.go
@@ -251,8 +251,9 @@ func patchLLMCredentials(tmpl *unstructured.Unstructured, llm *agenticv1alpha1.L
 	if err := addEnvFromSecret(tmpl, secretName); err != nil {
 		return fmt.Errorf("add credentials envFrom: %w", err)
 	}
-	if err := setEnvVar(tmpl, "ANTHROPIC_MODEL", model); err != nil {
-		return fmt.Errorf("set ANTHROPIC_MODEL: %w", err)
+	modelEnvVar := modelEnvVarForProvider(llm)
+	if err := setEnvVar(tmpl, modelEnvVar, model); err != nil {
+		return fmt.Errorf("set %s: %w", modelEnvVar, err)
 	}
 
 	if u := providerURL(llm); u != "" {
@@ -302,6 +303,27 @@ func patchLLMCredentials(tmpl *unstructured.Unstructured, llm *agenticv1alpha1.L
 		}
 	}
 	return nil
+}
+
+// modelEnvVarForProvider returns the sandbox env var name for the model.
+// Stopgap until both operator and sandbox migrate to generic LIGHTSPEED_MODEL
+// per spec rule 16a (OLS-3153).
+func modelEnvVarForProvider(llm *agenticv1alpha1.LLMProvider) string {
+	switch llm.Spec.Type {
+	case agenticv1alpha1.LLMProviderOpenAI, agenticv1alpha1.LLMProviderAzureOpenAI:
+		return "OPENAI_MODEL"
+	case agenticv1alpha1.LLMProviderGoogleCloudVertex:
+		switch llm.Spec.GoogleCloudVertex.ModelProvider {
+		case agenticv1alpha1.GoogleCloudVertexModelProviderGoogle:
+			return "GEMINI_MODEL"
+		case agenticv1alpha1.GoogleCloudVertexModelProviderOpenAI:
+			return "OPENAI_MODEL"
+		default:
+			return "ANTHROPIC_MODEL"
+		}
+	default:
+		return "ANTHROPIC_MODEL"
+	}
 }
 
 func providerURLEnvVar(t agenticv1alpha1.LLMProviderType) string {

--- a/controller/proposal/sandbox_templates_test.go
+++ b/controller/proposal/sandbox_templates_test.go
@@ -312,6 +312,63 @@ func TestPatchLLMCredentials_Bedrock(t *testing.T) {
 	}
 }
 
+func TestModelEnvVarForProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		llm      *agenticv1alpha1.LLMProvider
+		expected string
+	}{
+		{"Anthropic", testLLMProvider(agenticv1alpha1.LLMProviderAnthropic), "ANTHROPIC_MODEL"},
+		{"OpenAI", testLLMProvider(agenticv1alpha1.LLMProviderOpenAI), "OPENAI_MODEL"},
+		{"AzureOpenAI", testLLMProvider(agenticv1alpha1.LLMProviderAzureOpenAI), "OPENAI_MODEL"},
+		{"Bedrock", testLLMProvider(agenticv1alpha1.LLMProviderAWSBedrock), "ANTHROPIC_MODEL"},
+		{"Vertex/Anthropic", func() *agenticv1alpha1.LLMProvider {
+			p := testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex)
+			p.Spec.GoogleCloudVertex.ModelProvider = agenticv1alpha1.GoogleCloudVertexModelProviderAnthropic
+			return p
+		}(), "ANTHROPIC_MODEL"},
+		{"Vertex/Google", func() *agenticv1alpha1.LLMProvider {
+			p := testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex)
+			p.Spec.GoogleCloudVertex.ModelProvider = agenticv1alpha1.GoogleCloudVertexModelProviderGoogle
+			return p
+		}(), "GEMINI_MODEL"},
+		{"Vertex/OpenAI", func() *agenticv1alpha1.LLMProvider {
+			p := testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex)
+			p.Spec.GoogleCloudVertex.ModelProvider = agenticv1alpha1.GoogleCloudVertexModelProviderOpenAI
+			return p
+		}(), "OPENAI_MODEL"},
+		{"Vertex/default", testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex), "ANTHROPIC_MODEL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := modelEnvVarForProvider(tt.llm)
+			if got != tt.expected {
+				t.Errorf("modelEnvVarForProvider() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPatchLLMCredentials_OpenAI(t *testing.T) {
+	tmpl := emptyTemplate()
+	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderOpenAI, "https://api.openai.com/v1")
+
+	if err := patchLLMCredentials(tmpl, llm, "gpt-5.5"); err != nil {
+		t.Fatalf("patchLLMCredentials: %v", err)
+	}
+
+	envs := getEnvVars(tmpl)
+	if e, ok := findEnv(envs, "OPENAI_MODEL"); !ok {
+		t.Error("missing OPENAI_MODEL")
+	} else if e["value"] != "gpt-5.5" {
+		t.Errorf("OPENAI_MODEL = %q, want gpt-5.5", e["value"])
+	}
+
+	if _, ok := findEnv(envs, "ANTHROPIC_MODEL"); ok {
+		t.Error("should not set ANTHROPIC_MODEL for OpenAI provider")
+	}
+}
+
 // --- patchRequiredSecrets tests ---
 
 func TestPatchRequiredSecrets_EnvVar(t *testing.T) {


### PR DESCRIPTION
## Summary
- The sandbox reads `OPENAI_MODEL` for OpenAI and `GEMINI_MODEL` for Gemini providers, but the operator always set `ANTHROPIC_MODEL` regardless of provider type
- This caused the sandbox to fall back to its default model (`claude-opus-4-6`) when using non-Anthropic providers, resulting in API errors (e.g., "model not found" when using OpenAI)
- Adds `modelEnvVarForProvider()` helper that maps `LLMProviderType` to the correct env var name

## Test plan
- [ ] Verified with OpenAI provider: `OPENAI_MODEL=gpt-5.5` correctly set in sandbox pod env
- [ ] Verified with existing Anthropic provider: `ANTHROPIC_MODEL` still used (default case)
- [ ] `go test ./controller/proposal/... -count=1` passes
- [ ] End-to-end test with GPT-5.5 SandboxAgent on Kind cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect environment variable assignment in sandbox templates that now correctly applies provider-specific variables for OpenAI, Gemini, and Anthropic LLM providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->