### PR TITLE
Fix result CR status not updated on retry

### DIFF
--- a/controller/proposal/results.go
+++ b/controller/proposal/results.go
@@ -255,18 +255,67 @@ type statusHolder interface {
 	SetConditions([]metav1.Condition)
 }
 
+// copyResultStatus copies result-specific status fields from src to dst.
+// Both must be the same concrete type (guaranteed by callers which derive
+// both from the same obj via DeepCopyObject).
+func copyResultStatus(dst, src client.Object) {
+	switch d := dst.(type) {
+	case *agenticv1alpha1.AnalysisResult:
+		if s, ok := src.(*agenticv1alpha1.AnalysisResult); ok {
+			d.Status.Options = s.Status.Options
+			d.Status.FailureReason = s.Status.FailureReason
+			d.Status.Sandbox = s.Status.Sandbox
+		}
+	case *agenticv1alpha1.ExecutionResult:
+		if s, ok := src.(*agenticv1alpha1.ExecutionResult); ok {
+			d.Status.ActionsTaken = s.Status.ActionsTaken
+			d.Status.Verification = s.Status.Verification
+			d.Status.FailureReason = s.Status.FailureReason
+			d.Status.Sandbox = s.Status.Sandbox
+		}
+	case *agenticv1alpha1.VerificationResult:
+		if s, ok := src.(*agenticv1alpha1.VerificationResult); ok {
+			d.Status.Checks = s.Status.Checks
+			d.Status.Summary = s.Status.Summary
+			d.Status.FailureReason = s.Status.FailureReason
+			d.Status.Sandbox = s.Status.Sandbox
+		}
+	case *agenticv1alpha1.EscalationResult:
+		if s, ok := src.(*agenticv1alpha1.EscalationResult); ok {
+			d.Status.Summary = s.Status.Summary
+			d.Status.Content = s.Status.Content
+			d.Status.FailureReason = s.Status.FailureReason
+			d.Status.Sandbox = s.Status.Sandbox
+		}
+	}
+}
+
 // createIdempotent creates obj then patches its full status. The Create
 // call writes identity fields (proposalName, etc.) but the API
 // server ignores .status on Create (status subresource). A follow-up
 // Status().Patch writes the complete status including result data and
-// conditions. On AlreadyExists the CR is assumed to already have its
-// status from the original create.
+// conditions. On AlreadyExists the existing CR's status is updated
+// to reflect the latest result.
 func createIdempotent(ctx context.Context, c client.Client, obj client.Object, kind string) error {
 	// Save full object with status before Create strips it.
 	withStatus := obj.DeepCopyObject().(client.Object)
 
 	if err := c.Create(ctx, obj); err != nil {
 		if apierrors.IsAlreadyExists(err) {
+			existing := obj.DeepCopyObject().(client.Object)
+			if getErr := c.Get(ctx, client.ObjectKeyFromObject(obj), existing); getErr != nil {
+				return fmt.Errorf("get existing %s %s: %w", kind, obj.GetName(), getErr)
+			}
+			patched := existing.DeepCopyObject().(client.Object)
+			if sh, ok := patched.(statusHolder); ok {
+				if src, ok := withStatus.(statusHolder); ok {
+					sh.SetConditions(src.GetConditions())
+				}
+			}
+			copyResultStatus(patched, withStatus)
+			if patchErr := c.Status().Patch(ctx, patched, client.MergeFrom(existing)); patchErr != nil {
+				return fmt.Errorf("update existing %s %s status: %w", kind, obj.GetName(), patchErr)
+			}
 			return nil
 		}
 		return fmt.Errorf("create %s %s: %w", kind, obj.GetName(), err)

--- a/controller/proposal/results_test.go
+++ b/controller/proposal/results_test.go
@@ -95,7 +95,7 @@ func TestCreateIdempotent_AlreadyExists(t *testing.T) {
 		},
 		Status: agenticv1alpha1.AnalysisResultStatus{
 			Options: []agenticv1alpha1.RemediationOption{
-				{Title: "Should not overwrite"},
+				{Title: "Updated option from retry"},
 			},
 		},
 	}
@@ -109,8 +109,70 @@ func TestCreateIdempotent_AlreadyExists(t *testing.T) {
 		t.Fatalf("Get: %v", err)
 	}
 
-	if len(got.Status.Options) != 0 {
-		t.Error("AlreadyExists should not overwrite status")
+	if len(got.Status.Options) != 1 || got.Status.Options[0].Title != "Updated option from retry" {
+		t.Error("AlreadyExists should update status with latest result")
+	}
+}
+
+func TestCreateIdempotent_AlreadyExists_OverwritesStaleFailure(t *testing.T) {
+	scheme := testScheme()
+
+	existing := &agenticv1alpha1.AnalysisResult{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-analysis-1",
+			Namespace: "default",
+		},
+		Spec: agenticv1alpha1.AnalysisResultSpec{
+			ProposalName: "test-proposal",
+		},
+		Status: agenticv1alpha1.AnalysisResultStatus{
+			Conditions: []metav1.Condition{
+				{Type: "Completed", Status: metav1.ConditionTrue, Reason: "Failed", LastTransitionTime: metav1.Now()},
+			},
+			FailureReason: "sandbox DNS unreachable",
+		},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(existing).
+		WithStatusSubresource(&agenticv1alpha1.AnalysisResult{}).Build()
+
+	cr := &agenticv1alpha1.AnalysisResult{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-analysis-1",
+			Namespace: "default",
+		},
+		Spec: agenticv1alpha1.AnalysisResultSpec{
+			ProposalName: "test-proposal",
+		},
+		Status: agenticv1alpha1.AnalysisResultStatus{
+			Conditions: []metav1.Condition{
+				{Type: "Completed", Status: metav1.ConditionTrue, Reason: "Succeeded", LastTransitionTime: metav1.Now()},
+			},
+			Options: []agenticv1alpha1.RemediationOption{
+				{Title: "Increase memory limit"},
+			},
+			FailureReason: "",
+		},
+	}
+
+	if err := createIdempotent(context.Background(), fc, cr, "AnalysisResult"); err != nil {
+		t.Fatalf("createIdempotent: %v", err)
+	}
+
+	var got agenticv1alpha1.AnalysisResult
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: "test-analysis-1", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if len(got.Status.Options) != 1 || got.Status.Options[0].Title != "Increase memory limit" {
+		t.Errorf("expected success options, got %v", got.Status.Options)
+	}
+	if got.Status.FailureReason != "" {
+		t.Errorf("stale FailureReason not cleared: %q", got.Status.FailureReason)
+	}
+	if len(got.Status.Conditions) != 1 || got.Status.Conditions[0].Reason != "Succeeded" {
+		t.Errorf("condition not updated: %v", got.Status.Conditions)
 	}
 }
 


### PR DESCRIPTION
## Summary
- When a proposal step was retried and the result CR already existed (same name from `resultCRName`), `createIdempotent` silently returned `nil` on `AlreadyExists`, leaving stale failure data in the CR
- This caused `AnalysisResult` (and other result types) to show failed status/conditions even when the retry succeeded — the proposal would show `Analyzed: True (Complete)` but the result CR still contained the old failure reason
- Now on `AlreadyExists`, the existing CR is fetched and its status is patched with the latest result data (options, actions, checks, conditions, sandbox info, failure reason)

## Test plan
- [ ] `TestCreateIdempotent_AlreadyExists` updated to verify status is updated (not skipped)
- [ ] All existing tests pass: `go test ./controller/proposal/... -count=1`
- [ ] End-to-end verified: proposal failed on first attempt (local operator, DNS unreachable), succeeded on retry (in-cluster operator) — result CR now reflects success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Existing result records now update their status with the latest remediation options and properly overwrite stale failure states, clearing failure reasons when a success is applied.
* **Tests**
  * Updated test to expect the revised remediation option behavior; added a new test validating overwrite of stale failure state and clearing of failure details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->