### PR TITLE
chore: add onmete to OWNERS approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 approvers:
   - xrajesh
   - joshuawilson
+  - onmete
   - raptorsun
   - blublinsky
   - harche


### PR DESCRIPTION
## Summary

- Add `onmete` to the `approvers` list in `OWNERS`.

## Test plan

- [ ] N/A — metadata-only change


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project approvers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->