### PR TITLE
fix: remove stale --template-name flag references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,6 @@ help: ## Display this help.
 # Deployment/RBAC from make deploy / make undeploy.
 OPERATOR_NAMESPACE ?= default
 
-# Name of the base SandboxTemplate the reconciler resolves per step
-# (flag --template-name in cmd/main.go).
-TEMPLATE_NAME ?= lightspeed-agent
-
 # Local `make run` defaults avoid clashing with other processes on :8080/:8081.
 METRICS_BIND_ADDRESS ?= :18080
 HEALTH_PROBE_BIND_ADDRESS ?= :18081
@@ -243,7 +239,6 @@ run: install install-agent-sandbox vet ## install + install-agent-sandbox (no-op
 	# Same kubeconfig discovery as other controller-runtime apps (see README.md).
 	go run ./cmd/main.go \
 		--namespace=$(OPERATOR_NAMESPACE) \
-		--template-name=$(TEMPLATE_NAME) \
 		--metrics-bind-address=$(METRICS_BIND_ADDRESS) \
 		--health-probe-bind-address=$(HEALTH_PROBE_BIND_ADDRESS)
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,6 @@ spec:
           command:
             - /manager
           args:
-            - --template-name=lightspeed-agent
             - --metrics-bind-address=:8080
             - --health-probe-bind-address=:8081
           env:


### PR DESCRIPTION
  The --template-name flag was removed from cmd/main.go but remained
  in the Makefile and config/manager/manager.yaml, preventing the
  operator from starting.

  Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed hardcoded template defaults from build and deployment configurations. Template selection now relies on application-provided defaults instead of build-time settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->