### PR TITLE
OLS-3215: Inject sandbox readiness and liveness probes

### DIFF
--- a/.ai/spec/how/reconciler.md
+++ b/.ai/spec/how/reconciler.md
@@ -29,7 +29,7 @@ Audience: AI agents. Behavioral rules and phase semantics live in **what/** spec
 | `agent.go` | `AgentCaller`, `StubAgentCaller`; `AnalysisOutput`, `ExecutionOutput`, `VerificationOutput`, `EscalationOutput` | Interface methods on `StubAgentCaller` |
 | `sandbox.go` | `SandboxProvider`, `SandboxManager` | `NewSandboxManager`, `Claim`, `WaitReady`, `Release`, `buildClaim` |
 | `sandbox_agent.go` | `SandboxAgentCaller`; private JSON DTOs for unmarshaling agent responses local to this file | `NewSandboxAgentCaller`, `Analyze`, `Execute`, `Verify`, `Escalate`, `ReleaseSandboxes`, `callWithSandbox`, `patchSandboxInfo`, `buildAgentContext`, `collectFailedResults`, `stepString` |
-| `sandbox_templates.go` | `templateHashInput`; label constants (`LabelManaged`, `LabelProposal`, etc.); MCP env DTOs | `EnsureAgentTemplate`, `SandboxTemplateServiceAccount`, `computeTemplateHash`, `agentTemplateName`, `gcOldTemplates`, `patchLLMCredentials`, `credentialsSecretName`, `providerURL`, `patchRequiredSecrets`, `patchMCPServers`, `patchSkillsImage`, `patchSkillsPaths`, `patchAgentMode`, unstructured helpers (`firstContainer`, `setEnvVar`, `addEnvFromSecret`, …) |
+| `sandbox_templates.go` | `templateHashInput`; label constants (`LabelManaged`, `LabelProposal`, etc.); MCP env DTOs | `EnsureAgentTemplate`, `SandboxTemplateServiceAccount`, `computeTemplateHash`, `agentTemplateName`, `gcOldTemplates`, `patchLLMCredentials`, `credentialsSecretName`, `providerURL`, `patchRequiredSecrets`, `patchMCPServers`, `patchSkillsImage`, `patchSkillsPaths`, `patchAgentMode`, `patchProbes`, unstructured helpers (`firstContainer`, `setEnvVar`, `addEnvFromSecret`, …) |
 | `client.go` | `AgentHTTPClientInterface`, `AgentHTTPClient`; `agentRunRequest`, `agentContext`, `agentExecutionResult`, `agentPreviousAttempt`, `agentRunResponse` | `NewAgentHTTPClient`, `(*AgentHTTPClient).Run`, `executionOutputToAgentResult` |
 | `schemas.go` | Package vars: default/minimal analysis schemas, execution/verification/escalation schemas; `defaultOutputSchemas`, `builtInPropertyJSON` | `init` (precompute property JSON), `injectBuiltInProperty`, `outputSchemaForStep` |
 | `rbac.go` | — | `ensureExecutionRBAC`, `cleanupExecutionRBAC`, `annotatedRBACNamespaces`, `deleteIfExists`, `rbacTargetNamespaces`, `truncateK8sName`, `executionRoleName`, `clusterRoleName`, `rbacLabels`, `rbacRulesToPolicyRules`, `normalizeCoreAPIGroup` |
@@ -47,7 +47,7 @@ Audience: AI agents. Behavioral rules and phase semantics live in **what/** spec
 | `rbac_test.go` | RBAC ensure/cleanup tests | — |
 | `sandbox_test.go` | Sandbox manager tests | — |
 | `sandbox_agent_test.go` | Agent caller tests | — |
-| `sandbox_templates_test.go` | Template ensure/GC tests | — |
+| `sandbox_templates_test.go` | Template ensure/GC tests; `TestPatchProbes` (rule 30 in `what/sandbox-execution.md`) | — |
 | `schemas_test.go` | Output schema assembly tests | — |
 
 ---

--- a/.ai/spec/what/sandbox-execution.md
+++ b/.ai/spec/what/sandbox-execution.md
@@ -54,6 +54,7 @@ Behavioral specification for how workflow steps run inside ephemeral **sandboxes
 27. **Retry index**: `ExecutionResult` and `VerificationResult` MUST record the current execution retry index in spec for correlation with `status.steps.execution.retryCount`.
 28. **Sandbox release**: On proposal deletion and on terminal phases (`Completed`, `Denied`, `Escalated`), the controller MUST delete known sandbox claims recorded under `status.steps.*.sandbox` (best-effort aggregation; first error MAY be returned for visibility).
 29. **Concurrency cap**: Maximum concurrent proposal reconciles SHOULD respect `ApprovalPolicy.spec.maxConcurrentProposals` when present (see `crd-api.md`).
+30. **Container probes**: The controller MUST set `readinessProbe` (HTTP GET `/ready` on port 8080) and `livenessProbe` (HTTP GET `/health` on port 8080) on the first container of every derived `SandboxTemplate`. This ensures Kubernetes does not mark pods as Ready until the agent HTTP server is actually serving, preventing race conditions between `WaitReady()` and `POST /v1/agent/run`.
 
 ## Configuration Surface
 

--- a/controller/proposal/sandbox_templates.go
+++ b/controller/proposal/sandbox_templates.go
@@ -188,6 +188,10 @@ func EnsureAgentTemplate(
 		}
 	}
 
+	if err := patchProbes(derived); err != nil {
+		return "", fmt.Errorf("patch probes: %w", err)
+	}
+
 	if err := c.Create(ctx, derived); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return name, nil
@@ -355,6 +359,35 @@ func patchRequiredSecrets(tmpl *unstructured.Unstructured, secrets []agenticv1al
 		}
 	}
 	return nil
+}
+
+func patchProbes(tmpl *unstructured.Unstructured) error {
+	container, containers, err := firstContainer(tmpl)
+	if err != nil {
+		return fmt.Errorf("patchProbes: %w", err)
+	}
+
+	container["readinessProbe"] = map[string]any{
+		"httpGet": map[string]any{
+			"path": "/ready",
+			"port": int64(8080),
+		},
+		"initialDelaySeconds": int64(3),
+		"periodSeconds":       int64(10),
+		"failureThreshold":    int64(3),
+	}
+
+	container["livenessProbe"] = map[string]any{
+		"httpGet": map[string]any{
+			"path": "/health",
+			"port": int64(8080),
+		},
+		"initialDelaySeconds": int64(10),
+		"periodSeconds":       int64(30),
+		"failureThreshold":    int64(3),
+	}
+
+	return writeContainers(tmpl, container, containers)
 }
 
 func gcOldTemplates(

--- a/controller/proposal/sandbox_templates_test.go
+++ b/controller/proposal/sandbox_templates_test.go
@@ -657,3 +657,75 @@ func TestComputeTemplateHash_SameBaseResourceVersion(t *testing.T) {
 		t.Error("same base template resourceVersion should produce same hash")
 	}
 }
+
+func TestPatchProbes(t *testing.T) {
+	t.Run("sets readiness and liveness probes on first container", func(t *testing.T) {
+		tmpl := emptyTemplate()
+		if err := patchProbes(tmpl); err != nil {
+			t.Fatalf("patchProbes: %v", err)
+		}
+
+		containers, _, _ := unstructured.NestedSlice(tmpl.Object, "spec", "podTemplate", "spec", "containers")
+		container := containers[0].(map[string]any)
+
+		// Readiness probe
+		rp, ok := container["readinessProbe"].(map[string]any)
+		if !ok {
+			t.Fatal("readinessProbe not set")
+		}
+		httpGet, _ := rp["httpGet"].(map[string]any)
+		if httpGet["path"] != "/ready" {
+			t.Errorf("readinessProbe path = %v, want /ready", httpGet["path"])
+		}
+		if httpGet["port"] != int64(8080) {
+			t.Errorf("readinessProbe port = %v, want 8080", httpGet["port"])
+		}
+		if rp["initialDelaySeconds"] != int64(3) {
+			t.Errorf("readinessProbe initialDelaySeconds = %v, want 3", rp["initialDelaySeconds"])
+		}
+		if rp["periodSeconds"] != int64(10) {
+			t.Errorf("readinessProbe periodSeconds = %v, want 10", rp["periodSeconds"])
+		}
+		if rp["failureThreshold"] != int64(3) {
+			t.Errorf("readinessProbe failureThreshold = %v, want 3", rp["failureThreshold"])
+		}
+
+		// Liveness probe
+		lp, ok := container["livenessProbe"].(map[string]any)
+		if !ok {
+			t.Fatal("livenessProbe not set")
+		}
+		httpGetL, _ := lp["httpGet"].(map[string]any)
+		if httpGetL["path"] != "/health" {
+			t.Errorf("livenessProbe path = %v, want /health", httpGetL["path"])
+		}
+		if httpGetL["port"] != int64(8080) {
+			t.Errorf("livenessProbe port = %v, want 8080", httpGetL["port"])
+		}
+		if lp["initialDelaySeconds"] != int64(10) {
+			t.Errorf("livenessProbe initialDelaySeconds = %v, want 10", lp["initialDelaySeconds"])
+		}
+		if lp["periodSeconds"] != int64(30) {
+			t.Errorf("livenessProbe periodSeconds = %v, want 30", lp["periodSeconds"])
+		}
+		if lp["failureThreshold"] != int64(3) {
+			t.Errorf("livenessProbe failureThreshold = %v, want 3", lp["failureThreshold"])
+		}
+	})
+
+	t.Run("fails on template with no containers", func(t *testing.T) {
+		tmpl := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "extensions.agents.x-k8s.io/v1alpha1",
+			"kind":       "SandboxTemplate",
+			"metadata":   map[string]any{"name": "empty"},
+			"spec": map[string]any{
+				"podTemplate": map[string]any{
+					"spec": map[string]any{},
+				},
+			},
+		}}
+		if err := patchProbes(tmpl); err == nil {
+			t.Fatal("expected error for template with no containers")
+		}
+	})
+}

--- a/test/agent/main.go
+++ b/test/agent/main.go
@@ -78,6 +78,14 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" && r.Method == http.MethodGet {
 			http.Redirect(w, r, "/healthz", http.StatusFound)
@@ -86,7 +94,7 @@ func main() {
 		http.NotFound(w, r)
 	})
 
-	log.Printf("mock agent listening on %s (POST /v1/agent/run, GET /healthz)", listen)
+	log.Printf("mock agent listening on %s (POST /v1/agent/run, GET /healthz, GET /health, GET /ready)", listen)
 	log.Printf("note: rebuild and restart this process after changing mock code or controller schemas")
 	if err := http.ListenAndServe(listen, logRequests(mux)); err != nil {
 		log.Fatalf("server: %v", err)


### PR DESCRIPTION
## Summary

- Inject `readinessProbe` (`GET /ready:8080`) and `livenessProbe` (`GET /health:8080`) on the first container of every derived `SandboxTemplate` via `patchProbes` in `EnsureAgentTemplate`.
- Add `/health` and `/ready` handlers to the mock agent so in-cluster e2e pods satisfy the new probes once the mock image is rebuilt.
- Document behavioral rule 30 in `.ai/spec/what/sandbox-execution.md` and update the reconciler source map.

Fixes the race where `WaitReady()` could succeed before uvicorn was serving, causing `connection refused` on `POST /v1/agent/run` (especially on cold clusters).

Design: `docs/superpowers/specs/2026-06-03-sandbox-probes-design.md`

## Testing

- [x] `make vet`
- [x] `make api-lint`
- [x] `make test` (includes `TestPatchProbes`)
- [ ] `make test-e2e` — not run to green: cluster tests fail on pre-existing Proposal validation (`spec.tools.skills[0].paths: Required value`), unrelated to this PR. Mock-agent image on Quay must be rebuilt/pushed before e2e can exercise probes end-to-end.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added readiness and liveness health checks to sandbox containers
  * Extended mock agent server with health check endpoints

* **Tests**
  * Added comprehensive test coverage for health check configuration

* **Documentation**
  * Updated reconciler architecture and sandbox execution specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->