### PR TITLE
Fix required fields losing values during JSON marshaling

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -21,6 +21,7 @@ linters:
             disable:
               - statusoptional # Legacy, not recommended
               - nonpointerstructs # Intended for native types, not CRD types
+              - requiredfields # Incompatible with CRDs - omitempty on required fields breaks JSON marshaling
           lintersConfig:
             conditions:
               isFirstField: Warn
@@ -38,7 +39,7 @@ linters:
               pointers:
                 policy: SuggestFix
               omitempty:
-                policy: SuggestFix
+                policy: Ignore  # Required fields must not use omitempty - it causes JSON marshaler to drop empty values, breaking CRD validation
               omitzero:
                 policy: SuggestFix
             preferredmarkers:

--- a/api/v1alpha1/proposal_analysis_types.go
+++ b/api/v1alpha1/proposal_analysis_types.go
@@ -65,19 +65,19 @@ type DiagnosisResult struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=8192
-	Summary string `json:"summary,omitempty"`
+	Summary string `json:"summary"`
 	// confidence is the agent's self-assessed confidence in its diagnosis.
 	// Higher confidence generally correlates with clearer symptoms and
 	// more deterministic root causes.
 	// +required
-	Confidence ConfidenceLevel `json:"confidence,omitempty"`
+	Confidence ConfidenceLevel `json:"confidence"`
 	// rootCause is a concise Markdown-formatted description of the identified
 	// root cause (e.g., "OOMKilled due to memory limit of 256Mi").
 	// Maximum 1024 characters.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=1024
-	RootCause string `json:"rootCause,omitempty"`
+	RootCause string `json:"rootCause"`
 }
 
 // ProposedAction describes a single discrete action the analysis agent
@@ -90,14 +90,14 @@ type ProposedAction struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Type string `json:"type,omitempty"`
+	Type string `json:"type"`
 	// description is a Markdown-formatted explanation of what this action
 	// will do (e.g., "Increase memory limit from 256Mi to 512Mi").
 	// Maximum 4096 characters.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=4096
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 }
 
 // Reversibility indicates whether a remediation can be rolled back.
@@ -120,18 +120,18 @@ type ProposalResult struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=8192
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	// actions is the ordered list of discrete actions the agent proposes.
 	// Maximum 50 items.
 	// +required
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=50
-	Actions []ProposedAction `json:"actions,omitempty"`
+	Actions []ProposedAction `json:"actions"`
 	// risk is the agent's assessment of how risky the remediation is.
 	// Critical-risk proposals typically require explicit human review.
 	// +required
-	Risk RiskLevel `json:"risk,omitempty"`
+	Risk RiskLevel `json:"risk"`
 	// reversible indicates whether the remediation can be rolled back
 	// if something goes wrong. See rollbackPlan for details.
 	// Must be one of: Reversible, Irreversible, Partial.
@@ -144,7 +144,7 @@ type ProposalResult struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=1024
-	EstimatedImpact string `json:"estimatedImpact,omitempty"`
+	EstimatedImpact string `json:"estimatedImpact"`
 	// rollbackPlan describes how to undo the remediation if execution fails
 	// or causes unexpected issues. Only the execution step mutates cluster
 	// state, so rollback lives here alongside the actions it would undo.
@@ -161,7 +161,7 @@ type VerificationStep struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 	// command is the command or API call to run for this check
 	// (e.g., "oc get pod -n production -l app=web -o jsonpath='{.items[0].status.phase}'").
 	// Maximum 4096 characters.
@@ -180,7 +180,7 @@ type VerificationStep struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Type string `json:"type,omitempty"`
+	Type string `json:"type"`
 }
 
 // RollbackPlan describes how to undo the remediation if execution fails
@@ -191,7 +191,7 @@ type RollbackPlan struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=4096
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	// command is the rollback command or steps to execute.
 	// Maximum 4096 characters.
 	// +optional
@@ -210,7 +210,7 @@ type VerificationPlan struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=4096
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	// steps is the ordered list of verification checks to run.
 	// Maximum 20 items.
 	// +optional
@@ -243,7 +243,7 @@ type RBACRule struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=20
 	// +kubebuilder:validation:items:MaxLength=253
-	APIGroups []string `json:"apiGroups,omitempty"` //nolint:kubeapilinter // empty string "" is a valid core API group
+	APIGroups []string `json:"apiGroups"` //nolint:kubeapilinter // empty string "" is a valid core API group
 	// resources are the resource types (e.g., "pods", "deployments").
 	// Maximum 20 items.
 	// +required
@@ -252,7 +252,7 @@ type RBACRule struct {
 	// +kubebuilder:validation:MaxItems=20
 	// +kubebuilder:validation:items:MinLength=1
 	// +kubebuilder:validation:items:MaxLength=253
-	Resources []string `json:"resources,omitempty"`
+	Resources []string `json:"resources"`
 	// resourceNames restricts the rule to specific named resources.
 	// When empty, the rule applies to all resources of the given type.
 	// Maximum 50 items.
@@ -271,7 +271,7 @@ type RBACRule struct {
 	// +kubebuilder:validation:MaxItems=10
 	// +kubebuilder:validation:items:MinLength=1
 	// +kubebuilder:validation:items:MaxLength=63
-	Verbs []string `json:"verbs,omitempty"`
+	Verbs []string `json:"verbs"`
 	// justification is a Markdown-formatted explanation of why this
 	// permission is needed for the remediation
 	// (e.g., "Need to patch deployment to increase memory limit").
@@ -279,7 +279,7 @@ type RBACRule struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=1024
-	Justification string `json:"justification,omitempty"`
+	Justification string `json:"justification"`
 }
 
 // RBACResult contains the RBAC permissions requested by the analysis agent
@@ -330,7 +330,7 @@ type RemediationOption struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Title string `json:"title,omitempty"`
+	Title string `json:"title"`
 	// summary is an optional Markdown-formatted one-line summary for
 	// collapsed views in the console UI. Maximum 1024 characters.
 	// +optional


### PR DESCRIPTION
## Problem

LLM-generated responses could fail CRD validation when the operator patched AnalysisResult CRs. When the LLM returned empty values for required fields (e.g., `title: ""`), Go's JSON marshaler with `omitempty` would drop those fields entirely from the JSON, causing CRD validation to reject the patch for missing required fields.

## Root Cause

The `kubeapilinter`'s `requiredfields` linter enforced `omitempty` on all required fields via the `SuggestFix` policy. This is a Kubernetes API convention that works for native types (where the apiserver fills defaults) but **breaks for CRDs** where:
1. No server-side defaulting occurs for string fields
2. Empty values get silently dropped by Go's JSON marshaler
3. CRD validation then fails on missing required fields

## Changes

### 1. Disabled `requiredfields` linter in `.golangci-kal.yml`
This linter rule is fundamentally incompatible with how CRDs + Go JSON marshaling work.

### 2. Removed `omitempty` from 18 required fields in `api/v1alpha1/proposal_analysis_types.go`
- **DiagnosisResult**: Summary, Confidence, RootCause
- **ProposedAction**: Type, Description
- **ProposalResult**: Description, Actions, Risk, EstimatedImpact
- **VerificationStep**: Name, Type
- **RollbackPlan**: Description
- **VerificationPlan**: Description
- **RBACRule**: APIGroups, Resources, Verbs, Justification
- **RemediationOption**: Title

## Impact

This ensures required fields are always present in JSON output, even when empty, allowing proper CRD validation errors instead of silent field omission. The LLM's JSON schema already enforces these fields are required, so this change aligns the Go types with that contract.

## Testing

- ✅ `make api-lint` passes with no issues
- ✅ `make manifests` regenerates CRDs correctly with required fields in schema