### PR TITLE
OLS-3237: Bootstrap base SandboxTemplate on operator startup

### DIFF
--- a/.ai/spec/how/project-structure.md
+++ b/.ai/spec/how/project-structure.md
@@ -12,6 +12,7 @@
 | `controller/setup.go` | `Setup`, `Options` | Wires proposal controller + console plugin into manager |
 | `controller/proposal/` | `ProposalReconciler`, `SandboxAgentCaller`, `SandboxManager` | Proposal reconciler, sandbox management, agent HTTP client, RBAC, results, templates |
 | `controller/console/` | `EnsureAgenticConsole`, `AgenticConsoleConfig` | Console plugin deployment (Deployment, Service, ConfigMap, ConsolePlugin CR) |
+| `controller/sandbox/` | `EnsureBaseSandboxTemplate`, `BaseSandboxConfig` | Bootstrap base SandboxTemplate + ServiceAccount at startup |
 | `cli/` | `NewRootCmd` | CLI root command |
 | `cli/proposal/` | `CreateOptions`, `ListOptions`, `GetOptions`, `ApproveOptions`, `DenyOptions`, `WatchOptions`, `LogsOptions`, `DeleteOptions` | CLI subcommands for proposal lifecycle operations |
 | `config/crd/bases/` | Generated YAML | CRD manifests (regenerate with `make manifests`) |
@@ -40,6 +41,7 @@
 - Creates `SandboxManager` and `SandboxAgentCaller` with dependency injection
 - Registers `ProposalReconciler` via `SetupWithManager`
 - Registers `EnsureAgenticConsole` as a `RunnableFunc`
+- Registers `EnsureBaseSandboxTemplate` as a `RunnableFunc`
 
 ## Naming Conventions
 

--- a/controller/sandbox/bootstrap.go
+++ b/controller/sandbox/bootstrap.go
@@ -1,0 +1,140 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const templateName = "lightspeed-agent"
+
+var sandboxTemplateGVK = schema.GroupVersionKind{
+	Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Kind: "SandboxTemplate",
+}
+
+type BaseSandboxConfig struct {
+	Image     string
+	Namespace string
+}
+
+func EnsureBaseSandboxTemplate(ctx context.Context, c client.Client, cfg BaseSandboxConfig) error {
+	log := logf.FromContext(ctx).WithName("sandbox-bootstrap")
+
+	if cfg.Image == "" {
+		log.Info("No agentic sandbox image configured — skipping base SandboxTemplate creation")
+		return nil
+	}
+
+	log.Info("Ensuring base SandboxTemplate", "image", cfg.Image, "namespace", cfg.Namespace)
+
+	if err := ensureServiceAccount(ctx, c, cfg); err != nil {
+		return fmt.Errorf("ensure ServiceAccount: %w", err)
+	}
+	log.V(1).Info("ServiceAccount ready")
+
+	if err := ensureSandboxTemplate(ctx, c, cfg); err != nil {
+		return fmt.Errorf("ensure SandboxTemplate: %w", err)
+	}
+	log.V(1).Info("SandboxTemplate ready")
+
+	log.Info("Base SandboxTemplate bootstrap complete")
+	return nil
+}
+
+func labels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":       templateName,
+		"app.kubernetes.io/component":  "sandbox",
+		"app.kubernetes.io/managed-by": "lightspeed-operator",
+	}
+}
+
+func ensureServiceAccount(ctx context.Context, c client.Client, cfg BaseSandboxConfig) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      templateName,
+			Namespace: cfg.Namespace,
+			Labels:    labels(),
+		},
+		AutomountServiceAccountToken: ptr.To(false),
+	}
+	if err := c.Create(ctx, sa); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func ensureSandboxTemplate(ctx context.Context, c client.Client, cfg BaseSandboxConfig) error {
+	tmpl := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": sandboxTemplateGVK.Group + "/" + sandboxTemplateGVK.Version,
+			"kind":       sandboxTemplateGVK.Kind,
+			"metadata": map[string]any{
+				"name":      templateName,
+				"namespace": cfg.Namespace,
+				"labels":    labelsAny(),
+			},
+			"spec": map[string]any{
+				"networkPolicyManagement": "Unmanaged",
+				"podTemplate": map[string]any{
+					"metadata": map[string]any{
+						"labels": map[string]any{
+							"app.kubernetes.io/name": templateName,
+						},
+					},
+					"spec": map[string]any{
+						"serviceAccountName":           templateName,
+						"automountServiceAccountToken": false,
+						"containers": []any{
+							map[string]any{
+								"name":  "agent",
+								"image": cfg.Image,
+								"ports": []any{
+									map[string]any{
+										"name":          "http",
+										"containerPort": int64(8080),
+										"protocol":      "TCP",
+									},
+								},
+								"securityContext": map[string]any{
+									"allowPrivilegeEscalation": false,
+									"capabilities": map[string]any{
+										"drop": []any{"ALL"},
+									},
+								},
+							},
+						},
+						"volumes": []any{
+							map[string]any{
+								"name": "skills",
+								"image": map[string]any{
+									"reference": "placeholder:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := c.Create(ctx, tmpl); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func labelsAny() map[string]any {
+	return map[string]any{
+		"app.kubernetes.io/name":       templateName,
+		"app.kubernetes.io/component":  "sandbox",
+		"app.kubernetes.io/managed-by": "lightspeed-operator",
+	}
+}

--- a/controller/sandbox/bootstrap_test.go
+++ b/controller/sandbox/bootstrap_test.go
@@ -1,0 +1,141 @@
+package sandbox
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+func testConfig() BaseSandboxConfig {
+	return BaseSandboxConfig{
+		Image:     "quay.io/test/agentic-sandbox:latest",
+		Namespace: "openshift-lightspeed",
+	}
+}
+
+func TestEnsureBaseSandboxTemplate_CreatesResources(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+	cfg := testConfig()
+
+	if err := EnsureBaseSandboxTemplate(context.Background(), fc, cfg); err != nil {
+		t.Fatalf("EnsureBaseSandboxTemplate: %v", err)
+	}
+
+	var sa corev1.ServiceAccount
+	if err := fc.Get(context.Background(), types.NamespacedName{
+		Name: templateName, Namespace: cfg.Namespace,
+	}, &sa); err != nil {
+		t.Errorf("ServiceAccount not created: %v", err)
+	}
+	if sa.AutomountServiceAccountToken != nil && *sa.AutomountServiceAccountToken {
+		t.Error("ServiceAccount should not automount token")
+	}
+
+	tmpl := &unstructured.Unstructured{}
+	tmpl.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Kind: "SandboxTemplate",
+	})
+	if err := fc.Get(context.Background(), types.NamespacedName{
+		Name: templateName, Namespace: cfg.Namespace,
+	}, tmpl); err != nil {
+		t.Fatalf("SandboxTemplate not created: %v", err)
+	}
+
+	containers, _, _ := unstructured.NestedSlice(tmpl.Object, "spec", "podTemplate", "spec", "containers")
+	if len(containers) == 0 {
+		t.Fatal("SandboxTemplate has no containers")
+	}
+	container := containers[0].(map[string]any)
+	if container["image"] != cfg.Image {
+		t.Errorf("container image = %q, want %q", container["image"], cfg.Image)
+	}
+
+	saName, _, _ := unstructured.NestedString(tmpl.Object, "spec", "podTemplate", "spec", "serviceAccountName")
+	if saName != templateName {
+		t.Errorf("serviceAccountName = %q, want %q", saName, templateName)
+	}
+
+	volumes, _, _ := unstructured.NestedSlice(tmpl.Object, "spec", "podTemplate", "spec", "volumes")
+	foundSkills := false
+	for _, v := range volumes {
+		vol := v.(map[string]any)
+		if vol["name"] == "skills" {
+			foundSkills = true
+		}
+	}
+	if !foundSkills {
+		t.Error("SandboxTemplate missing skills volume")
+	}
+
+	lbls := tmpl.GetLabels()
+	if lbls["app.kubernetes.io/managed-by"] != "lightspeed-operator" {
+		t.Errorf("missing managed-by label, got %v", lbls)
+	}
+}
+
+func TestEnsureBaseSandboxTemplate_Idempotent(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+	cfg := testConfig()
+
+	if err := EnsureBaseSandboxTemplate(context.Background(), fc, cfg); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := EnsureBaseSandboxTemplate(context.Background(), fc, cfg); err != nil {
+		t.Fatalf("second call (idempotent): %v", err)
+	}
+}
+
+func TestEnsureBaseSandboxTemplate_SkipsWhenNoImage(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+	cfg := BaseSandboxConfig{Namespace: "openshift-lightspeed"}
+
+	if err := EnsureBaseSandboxTemplate(context.Background(), fc, cfg); err != nil {
+		t.Fatalf("should not error with empty image: %v", err)
+	}
+
+	tmpl := &unstructured.Unstructured{}
+	tmpl.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Kind: "SandboxTemplate",
+	})
+	err := fc.Get(context.Background(), types.NamespacedName{
+		Name: templateName, Namespace: "openshift-lightspeed",
+	}, tmpl)
+	if err == nil {
+		t.Error("SandboxTemplate should not be created when image is empty")
+	}
+}
+
+func TestEnsureBaseSandboxTemplate_PartialExists(t *testing.T) {
+	sa := &corev1.ServiceAccount{}
+	sa.Name = templateName
+	sa.Namespace = "openshift-lightspeed"
+
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(sa).Build()
+	cfg := testConfig()
+
+	if err := EnsureBaseSandboxTemplate(context.Background(), fc, cfg); err != nil {
+		t.Fatalf("should succeed when SA exists: %v", err)
+	}
+
+	tmpl := &unstructured.Unstructured{}
+	tmpl.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Kind: "SandboxTemplate",
+	})
+	if err := fc.Get(context.Background(), types.NamespacedName{
+		Name: templateName, Namespace: cfg.Namespace,
+	}, tmpl); err != nil {
+		t.Errorf("SandboxTemplate not created: %v", err)
+	}
+}

--- a/controller/setup.go
+++ b/controller/setup.go
@@ -8,6 +8,7 @@ import (
 
 	agenticconsole "github.com/openshift/lightspeed-agentic-operator/controller/console"
 	"github.com/openshift/lightspeed-agentic-operator/controller/proposal"
+	agenticsandbox "github.com/openshift/lightspeed-agentic-operator/controller/sandbox"
 )
 
 type Options struct {
@@ -46,6 +47,16 @@ func Setup(mgr ctrl.Manager, opts Options) error {
 		return err
 	}
 	log.Info("Agentic console runnable registered")
+
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		return agenticsandbox.EnsureBaseSandboxTemplate(ctx, mgr.GetClient(), agenticsandbox.BaseSandboxConfig{
+			Image:     opts.AgenticSandboxImage,
+			Namespace: opts.Namespace,
+		})
+	})); err != nil {
+		return err
+	}
+	log.Info("Sandbox template bootstrap runnable registered")
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `controller/sandbox/` package with `EnsureBaseSandboxTemplate()` — a one-shot startup function that creates the base `lightspeed-agent` ServiceAccount and SandboxTemplate when the operator starts.
- Follows the same `manager.RunnableFunc` pattern as `EnsureAgenticConsole`.
- Uses `Create` + `AlreadyExists` for idempotency; skips when `--agentic-sandbox-image` is empty.

## Motivation

Without this, every Proposal fails immediately with "failed to read base sandbox template" unless an admin manually applies the test fixture. This automates the creation.

## Files changed

| File | Change |
|------|--------|
| `controller/sandbox/bootstrap.go` | New — bootstrap implementation |
| `controller/sandbox/bootstrap_test.go` | New — 4 unit tests |
| `controller/setup.go` | Wire bootstrap as `RunnableFunc` |
| `.ai/spec/how/project-structure.md` | Document new package |

## Testing

- [x] `go test ./controller/sandbox/ -v` — 4/4 PASS
- [x] `go test ./...` — all PASS
- [x] `go vet ./...` — clean
- [x] `make api-lint` — 0 issues
- [ ] E2E (requires live cluster — implicit validation via Proposal lifecycle tests)

## Risk

Risk level 2 — internal refactor automating creation of a resource that was already required.

Design spec: `docs/superpowers/specs/2025-06-05-sandbox-template-bootstrap-design.md`

Made with [Cursor](https://cursor.com)