### PR TITLE
OLS-3240: Add missing RBAC markers for core API resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ build: fmt vet ## Build manager binary to bin/manager.
 
 .PHONY: manifests
 manifests: controller-gen ## Regenerate CRD YAML and RBAC ClusterRole (do not edit role.yaml by hand).
-	$(CONTROLLER_GEN) rbac:roleName=agentic-operator-manager-role crd paths=./api/v1alpha1/... paths=./controller/proposal/... output:crd:artifacts:config=config/crd/bases output:rbac:artifacts:config=config/rbac
+	$(CONTROLLER_GEN) rbac:roleName=agentic-operator-manager-role crd paths=./api/v1alpha1/... paths=./controller/... output:crd:artifacts:config=config/crd/bases output:rbac:artifacts:config=config/rbac
 
 ##@ Deployment
 # Same pattern as lightspeed-operator: `kustomize build config/crd | kubectl apply`

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,21 @@ metadata:
   name: agentic-operator-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
   - agentic.openshift.io
   resources:
   - agents
@@ -67,6 +82,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - consoleplugins
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - extensions.agents.x-k8s.io
   resources:
   - sandboxclaims
@@ -87,6 +118,13 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - consoles
+  verbs:
+  - get
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/controller/console/reconciler.go
+++ b/controller/console/reconciler.go
@@ -1,5 +1,12 @@
 package console
 
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;create;update
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;create;update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;create;update
+// +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;create;update
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;update
+
 import (
 	"context"
 	"fmt"

--- a/controller/sandbox/bootstrap.go
+++ b/controller/sandbox/bootstrap.go
@@ -1,5 +1,7 @@
 package sandbox
 
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create
+
 import (
 	"context"
 	"fmt"


### PR DESCRIPTION
## Summary

- Added `+kubebuilder:rbac` markers for core Kubernetes resources (`ServiceAccounts`, `ConfigMaps`, `Services`, `Deployments`) and OpenShift resources (`ConsolePlugins`, `Consoles`) to `controller/sandbox/bootstrap.go` and `controller/console/reconciler.go`
- Widened `make manifests` controller-gen path from `controller/proposal/...` to `controller/...` so all controller packages are scanned
- Regenerated `config/rbac/role.yaml` with the complete set of permissions

## Context

The generated `ClusterRole` in `config/rbac/role.yaml` was missing permissions for resources the operator creates at runtime (`EnsureBaseSandboxTemplate` creates ServiceAccounts, `EnsureAgenticConsole` creates Deployments/Services/ConfigMaps/ConsolePlugins). This was masked by `cluster-admin` granted via `hack/agentic/deploy.sh`, but would cause `Forbidden` errors under least-privilege RBAC.

## Testing

- [x] `make vet` — passed
- [x] `make api-lint` — passed  
- [x] `make test` — passed
- [x] `make manifests` — regenerated role.yaml verified
- [x] **Cluster verification** — deployed operator with generated role.yaml only (no cluster-admin) on ROSA cluster, confirmed:
  - Old role.yaml: `serviceaccounts is forbidden` → operator crashes
  - New role.yaml: `ServiceAccount ready` / `SandboxTemplate ready` / `Base SandboxTemplate bootstrap complete` → operator 1/1 Running
- [x] `make test-e2e` — pre-existing failures (`spec.tools.skills[0].paths: Required value`), unrelated to this change

Fixes: https://issues.redhat.com/browse/OLS-3240

Made with [Cursor](https://cursor.com)