### PR TITLE
refactor: internalize template derivation in SandboxManager.Claim

### DIFF
--- a/controller/proposal/bare_pod_manager.go
+++ b/controller/proposal/bare_pod_manager.go
@@ -1,0 +1,145 @@
+package proposal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;delete
+
+// BarePodManager is a SandboxProvider that creates bare Pods using PodSpecBuilder
+// instead of relying on the Sandbox API (SandboxClaim/SandboxTemplate).
+type BarePodManager struct {
+	Client    client.Client
+	Builder   *PodSpecBuilder
+	Namespace string
+
+	agent *agenticv1alpha1.Agent
+	llm   *agenticv1alpha1.LLMProvider
+	tools *agenticv1alpha1.ToolsSpec
+}
+
+// NewBarePodManager creates a BarePodManager that manages bare Pods in the given namespace.
+func NewBarePodManager(c client.Client, builder *PodSpecBuilder, namespace string) *BarePodManager {
+	return &BarePodManager{
+		Client:    c,
+		Builder:   builder,
+		Namespace: namespace,
+	}
+}
+
+// SetStep stores the resolved step configuration so that the next Claim
+// call can build the correct PodSpec.
+func (m *BarePodManager) SetStep(agent *agenticv1alpha1.Agent, llm *agenticv1alpha1.LLMProvider, tools *agenticv1alpha1.ToolsSpec) {
+	m.agent = agent
+	m.llm = llm
+	m.tools = tools
+}
+
+// Claim creates a bare Pod for the given proposal step. The templateName
+// parameter is ignored (bare pods use PodSpecBuilder instead of templates).
+// Returns the pod name. Idempotent: returns the name if the pod already exists.
+func (m *BarePodManager) Claim(ctx context.Context, proposalName, step, _ string) (string, error) {
+	log := logf.FromContext(ctx)
+
+	podName := truncateK8sName(fmt.Sprintf("ls-%s-%s", step, proposalName))
+
+	podSpec, err := m.Builder.Build(m.agent, m.llm, m.tools, step)
+	if err != nil {
+		return "", fmt.Errorf("build pod spec: %w", err)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: m.Namespace,
+			Labels: map[string]string{
+				LabelProposal: proposalName,
+				LabelStep:     step,
+			},
+		},
+		Spec: *podSpec,
+	}
+
+	if err := m.Client.Create(ctx, pod); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return podName, nil
+		}
+		return "", fmt.Errorf("create pod for %s: %w", step, err)
+	}
+
+	log.Info("Created bare pod", "name", podName, "step", step)
+	return podName, nil
+}
+
+// WaitReady polls the Pod until it is Ready with a non-empty PodIP, then
+// returns the IP address. Returns an error on timeout or context cancellation.
+func (m *BarePodManager) WaitReady(ctx context.Context, podName string, timeout time.Duration) (string, error) {
+	log := logf.FromContext(ctx)
+
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	key := types.NamespacedName{Name: podName, Namespace: m.Namespace}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+			if time.Now().After(deadline) {
+				return "", fmt.Errorf("timeout waiting for pod %q after %s", podName, timeout)
+			}
+
+			var pod corev1.Pod
+			if err := m.Client.Get(ctx, key, &pod); err != nil {
+				log.V(1).Info("Waiting for pod", "name", podName)
+				continue
+			}
+
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+					if pod.Status.PodIP == "" {
+						continue
+					}
+					log.Info("Pod ready", "name", podName, "podIP", pod.Status.PodIP)
+					return pod.Status.PodIP, nil
+				}
+			}
+		}
+	}
+}
+
+// Release deletes the bare Pod. Idempotent: returns nil if the pod is
+// already gone.
+func (m *BarePodManager) Release(ctx context.Context, podName string) error {
+	log := logf.FromContext(ctx)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: m.Namespace,
+		},
+	}
+
+	if err := m.Client.Delete(ctx, pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("delete pod %q: %w", podName, err)
+	}
+
+	log.Info("Released bare pod", "name", podName)
+	return nil
+}

--- a/controller/proposal/bare_pod_manager_test.go
+++ b/controller/proposal/bare_pod_manager_test.go
@@ -1,0 +1,126 @@
+package proposal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+func newBarePodClient() *fake.ClientBuilder {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	return fake.NewClientBuilder().WithScheme(s)
+}
+
+func TestBarePodManager_Claim_Creates(t *testing.T) {
+	fc := newBarePodClient().Build()
+	builder := &PodSpecBuilder{Image: "quay.io/test/sandbox:latest"}
+	m := NewBarePodManager(fc, builder, "test-ns")
+	m.SetStep(
+		&agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-opus-4-6"}},
+		testLLMProvider(agenticv1alpha1.LLMProviderAnthropic),
+		nil,
+	)
+
+	name, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if name != "ls-analysis-my-proposal" {
+		t.Errorf("name = %q, want ls-analysis-my-proposal", name)
+	}
+
+	var pod corev1.Pod
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
+		t.Fatalf("pod not created: %v", err)
+	}
+	if pod.Spec.Containers[0].Image != "quay.io/test/sandbox:latest" {
+		t.Errorf("container image = %q", pod.Spec.Containers[0].Image)
+	}
+	if pod.Labels[LabelProposal] != "my-proposal" {
+		t.Errorf("proposal label = %q", pod.Labels[LabelProposal])
+	}
+	if pod.Labels[LabelStep] != "analysis" {
+		t.Errorf("step label = %q", pod.Labels[LabelStep])
+	}
+}
+
+func TestBarePodManager_Claim_AlreadyExists(t *testing.T) {
+	existing := &corev1.Pod{}
+	existing.Name = "ls-analysis-my-proposal"
+	existing.Namespace = "test-ns"
+
+	fc := newBarePodClient().WithObjects(existing).Build()
+	builder := &PodSpecBuilder{Image: "img"}
+	m := NewBarePodManager(fc, builder, "test-ns")
+	m.SetStep(
+		&agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}},
+		testLLMProvider(agenticv1alpha1.LLMProviderAnthropic),
+		nil,
+	)
+
+	name, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
+	if err != nil {
+		t.Fatalf("Claim should succeed for existing pod: %v", err)
+	}
+	if name != "ls-analysis-my-proposal" {
+		t.Errorf("name = %q", name)
+	}
+}
+
+func TestBarePodManager_Release(t *testing.T) {
+	existing := &corev1.Pod{}
+	existing.Name = "ls-analysis-my-proposal"
+	existing.Namespace = "test-ns"
+
+	fc := newBarePodClient().WithObjects(existing).Build()
+	m := NewBarePodManager(fc, &PodSpecBuilder{Image: "img"}, "test-ns")
+
+	if err := m.Release(context.Background(), "ls-analysis-my-proposal"); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	var pod corev1.Pod
+	err := fc.Get(context.Background(), types.NamespacedName{Name: "ls-analysis-my-proposal", Namespace: "test-ns"}, &pod)
+	if err == nil {
+		t.Error("pod should be deleted")
+	}
+}
+
+func TestBarePodManager_Release_NotFound(t *testing.T) {
+	fc := newBarePodClient().Build()
+	m := NewBarePodManager(fc, &PodSpecBuilder{Image: "img"}, "test-ns")
+
+	if err := m.Release(context.Background(), "nonexistent"); err != nil {
+		t.Fatalf("Release should not error for not-found: %v", err)
+	}
+}
+
+func TestBarePodManager_WaitReady_ImmediateReady(t *testing.T) {
+	pod := &corev1.Pod{}
+	pod.Name = "ls-analysis-my-proposal"
+	pod.Namespace = "test-ns"
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionTrue,
+	}}
+	pod.Status.PodIP = "10.0.0.5"
+
+	fc := newBarePodClient().WithObjects(pod).Build()
+	m := NewBarePodManager(fc, &PodSpecBuilder{Image: "img"}, "test-ns")
+
+	endpoint, err := m.WaitReady(context.Background(), "ls-analysis-my-proposal", 10*time.Second)
+	if err != nil {
+		t.Fatalf("WaitReady: %v", err)
+	}
+	if endpoint != "10.0.0.5" {
+		t.Errorf("endpoint = %q, want 10.0.0.5", endpoint)
+	}
+}

--- a/controller/proposal/podspec_builder.go
+++ b/controller/proposal/podspec_builder.go
@@ -1,0 +1,274 @@
+package proposal
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+type PodSpecBuilder struct {
+	Image string
+}
+
+func (b *PodSpecBuilder) Build(
+	agent *agenticv1alpha1.Agent,
+	llm *agenticv1alpha1.LLMProvider,
+	tools *agenticv1alpha1.ToolsSpec,
+	step string,
+) (*corev1.PodSpec, error) {
+	if agent == nil {
+		return nil, fmt.Errorf("agent is required")
+	}
+	if llm == nil {
+		return nil, fmt.Errorf("LLMProvider is required")
+	}
+
+	container := corev1.Container{
+		Name:  "agent",
+		Image: b.Image,
+		Ports: []corev1.ContainerPort{{
+			Name:          "http",
+			ContainerPort: 8080,
+			Protocol:      corev1.ProtocolTCP,
+		}},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities:            &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		},
+	}
+
+	var volumes []corev1.Volume
+
+	container.Env = append(container.Env,
+		corev1.EnvVar{Name: "LIGHTSPEED_PROVIDER", Value: providerTypeString(llm.Spec.Type)},
+		corev1.EnvVar{Name: "LIGHTSPEED_MODEL", Value: agent.Spec.Model},
+	)
+	b.addProviderSpecificEnv(&container, llm)
+
+	secretName := credentialsSecretName(llm)
+	container.EnvFrom = append(container.EnvFrom, corev1.EnvFromSource{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+		},
+	})
+	volumes = append(volumes, corev1.Volume{
+		Name: llmCredsVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{SecretName: secretName},
+		},
+	})
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      llmCredsVolumeName,
+		MountPath: llmCredsMountPath,
+		ReadOnly:  true,
+	})
+
+	container.ReadinessProbe = &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromInt32(8080)},
+		},
+		InitialDelaySeconds: 3,
+		PeriodSeconds:       10,
+		FailureThreshold:    3,
+	}
+	container.LivenessProbe = &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt32(8080)},
+		},
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       30,
+		FailureThreshold:    3,
+	}
+
+	if tools != nil {
+		skillVols, skillMounts := b.buildSkills(tools.Skills)
+		volumes = append(volumes, skillVols...)
+		container.VolumeMounts = append(container.VolumeMounts, skillMounts...)
+	}
+
+	if tools != nil && len(tools.MCPServers) > 0 {
+		mcpVols, mcpMounts, mcpEnv, err := b.buildMCPServers(tools.MCPServers)
+		if err != nil {
+			return nil, fmt.Errorf("build MCP servers: %w", err)
+		}
+		volumes = append(volumes, mcpVols...)
+		container.VolumeMounts = append(container.VolumeMounts, mcpMounts...)
+		container.Env = append(container.Env, mcpEnv...)
+	}
+
+	if tools != nil && len(tools.RequiredSecrets) > 0 {
+		secVols, secMounts, secEnv := b.buildRequiredSecrets(tools.RequiredSecrets)
+		volumes = append(volumes, secVols...)
+		container.VolumeMounts = append(container.VolumeMounts, secMounts...)
+		container.Env = append(container.Env, secEnv...)
+	}
+
+	return &corev1.PodSpec{
+		ServiceAccountName:           defaultSandboxSA,
+		AutomountServiceAccountToken: ptr.To(false),
+		Containers:                   []corev1.Container{container},
+		Volumes:                      volumes,
+	}, nil
+}
+
+func (b *PodSpecBuilder) addProviderSpecificEnv(container *corev1.Container, llm *agenticv1alpha1.LLMProvider) {
+	switch llm.Spec.Type {
+	case agenticv1alpha1.LLMProviderAnthropic:
+		if u := providerURL(llm); u != "" {
+			container.Env = append(container.Env, corev1.EnvVar{Name: "LIGHTSPEED_PROVIDER_URL", Value: u})
+		}
+	case agenticv1alpha1.LLMProviderGoogleCloudVertex:
+		cfg := llm.Spec.GoogleCloudVertex
+		container.Env = append(container.Env,
+			corev1.EnvVar{Name: "LIGHTSPEED_MODEL_PROVIDER", Value: strings.ToLower(string(cfg.ModelProvider))},
+			corev1.EnvVar{Name: "LIGHTSPEED_PROVIDER_PROJECT", Value: cfg.ProjectID},
+			corev1.EnvVar{Name: "LIGHTSPEED_PROVIDER_REGION", Value: cfg.Region},
+		)
+		if u := providerURL(llm); u != "" {
+			container.Env = append(container.Env, corev1.EnvVar{Name: "LIGHTSPEED_PROVIDER_URL", Value: u})
+		}
+	case agenticv1alpha1.LLMProviderOpenAI:
+		if u := providerURL(llm); u != "" {
+			container.Env = append(container.Env, corev1.EnvVar{Name: "LIGHTSPEED_PROVIDER_URL", Value: u})
+		}
+	case agenticv1alpha1.LLMProviderAzureOpenAI:
+		cfg := llm.Spec.AzureOpenAI
+		providerURLValue := cfg.Endpoint
+		if u := cfg.URL; u != "" {
+			providerURLValue = u
+		}
+		container.Env = append(container.Env, corev1.EnvVar{Name: "LIGHTSPEED_PROVIDER_URL", Value: providerURLValue})
+		if cfg.APIVersion != "" {
+			container.Env = append(container.Env, corev1.EnvVar{Name: "LIGHTSPEED_PROVIDER_API_VERSION", Value: cfg.APIVersion})
+		}
+	case agenticv1alpha1.LLMProviderAWSBedrock:
+		cfg := llm.Spec.AWSBedrock
+		container.Env = append(container.Env, corev1.EnvVar{Name: "LIGHTSPEED_PROVIDER_REGION", Value: cfg.Region})
+		if u := providerURL(llm); u != "" {
+			container.Env = append(container.Env, corev1.EnvVar{Name: "LIGHTSPEED_PROVIDER_URL", Value: u})
+		}
+	}
+}
+
+func (b *PodSpecBuilder) buildSkills(skills []agenticv1alpha1.SkillsSource) ([]corev1.Volume, []corev1.VolumeMount) {
+	if len(skills) == 0 || skills[0].Image == "" {
+		return nil, nil
+	}
+	s := skills[0]
+
+	vol := corev1.Volume{
+		Name: "skills",
+		VolumeSource: corev1.VolumeSource{
+			Image: &corev1.ImageVolumeSource{
+				Reference:  s.Image,
+				PullPolicy: corev1.PullAlways,
+			},
+		},
+	}
+
+	var mounts []corev1.VolumeMount
+	if len(s.Paths) > 0 {
+		baseMountPath := "/app/skills"
+		for _, p := range s.Paths {
+			subPath := strings.TrimPrefix(p, "/")
+			skillName := path.Base(p)
+			mounts = append(mounts, corev1.VolumeMount{
+				Name:      "skills",
+				MountPath: path.Join(baseMountPath, skillName),
+				SubPath:   subPath,
+				ReadOnly:  true,
+			})
+		}
+	}
+
+	return []corev1.Volume{vol}, mounts
+}
+
+func (b *PodSpecBuilder) buildMCPServers(servers []agenticv1alpha1.MCPServerConfig) ([]corev1.Volume, []corev1.VolumeMount, []corev1.EnvVar, error) {
+	var volumes []corev1.Volume
+	var mounts []corev1.VolumeMount
+
+	entries := make([]mcpServerEnvEntry, 0, len(servers))
+	for _, s := range servers {
+		entry := mcpServerEnvEntry{
+			Name:    s.Name,
+			URL:     s.URL,
+			Timeout: s.TimeoutSeconds,
+		}
+		for _, h := range s.Headers {
+			he := mcpHeaderEnvEntry{
+				Name:   h.Name,
+				Source: string(h.ValueFrom.Type),
+			}
+			if h.ValueFrom.Type == agenticv1alpha1.MCPHeaderSourceTypeSecret {
+				he.SecretName = h.ValueFrom.Secret.Name
+				volName := "mcp-header-" + h.ValueFrom.Secret.Name
+				volumes = append(volumes, corev1.Volume{
+					Name: volName,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{SecretName: h.ValueFrom.Secret.Name},
+					},
+				})
+				mounts = append(mounts, corev1.VolumeMount{
+					Name:      volName,
+					MountPath: mcpHeadersMountRoot + "/" + h.ValueFrom.Secret.Name,
+					ReadOnly:  true,
+				})
+			}
+			entry.Headers = append(entry.Headers, he)
+		}
+		entries = append(entries, entry)
+	}
+
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("marshal MCP server config: %w", err)
+	}
+
+	envs := []corev1.EnvVar{{Name: mcpServersEnvVar, Value: string(data)}}
+	return volumes, mounts, envs, nil
+}
+
+func (b *PodSpecBuilder) buildRequiredSecrets(secrets []agenticv1alpha1.SecretRequirement) ([]corev1.Volume, []corev1.VolumeMount, []corev1.EnvVar) {
+	var volumes []corev1.Volume
+	var mounts []corev1.VolumeMount
+	var envs []corev1.EnvVar
+
+	for _, s := range secrets {
+		switch s.MountAs.Type {
+		case agenticv1alpha1.SecretMountFilePath:
+			volName := "req-" + s.Name
+			volumes = append(volumes, corev1.Volume{
+				Name: volName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: s.Name},
+				},
+			})
+			mounts = append(mounts, corev1.VolumeMount{
+				Name:      volName,
+				MountPath: s.MountAs.FilePath.Path,
+				ReadOnly:  true,
+			})
+		case agenticv1alpha1.SecretMountEnvVar:
+			optional := true
+			envs = append(envs, corev1.EnvVar{
+				Name: s.MountAs.EnvVar.Name,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: s.Name},
+						Key:                  "token",
+						Optional:             &optional,
+					},
+				},
+			})
+		}
+	}
+	return volumes, mounts, envs
+}

--- a/controller/proposal/podspec_builder_test.go
+++ b/controller/proposal/podspec_builder_test.go
@@ -1,0 +1,492 @@
+package proposal
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+// envToMap converts []corev1.EnvVar to map[string]string for easy assertion
+func envToMap(envVars []corev1.EnvVar) map[string]string {
+	result := make(map[string]string)
+	for _, ev := range envVars {
+		result[ev.Name] = ev.Value
+	}
+	return result
+}
+
+func intstr8080() intstr.IntOrString {
+	return intstr.FromInt32(8080)
+}
+
+func TestPodSpecBuilder_Anthropic(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{
+		Spec: agenticv1alpha1.AgentSpec{
+			Model: "claude-opus-4-6",
+		},
+	}
+	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderAnthropic, "https://custom.api")
+
+	podSpec, err := builder.Build(agent, llm, nil, "analysis")
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Verify container basics
+	if len(podSpec.Containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(podSpec.Containers))
+	}
+	container := podSpec.Containers[0]
+	if container.Name != "agent" {
+		t.Errorf("container name = %q, want agent", container.Name)
+	}
+	if container.Image != "quay.io/lightspeed/agent:latest" {
+		t.Errorf("container image = %q", container.Image)
+	}
+
+	// Verify port
+	if len(container.Ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(container.Ports))
+	}
+	if container.Ports[0].Name != "http" {
+		t.Errorf("port name = %q, want http", container.Ports[0].Name)
+	}
+	if container.Ports[0].ContainerPort != 8080 {
+		t.Errorf("port = %d, want 8080", container.Ports[0].ContainerPort)
+	}
+	if container.Ports[0].Protocol != corev1.ProtocolTCP {
+		t.Errorf("protocol = %q, want TCP", container.Ports[0].Protocol)
+	}
+
+	// Verify env vars
+	envMap := envToMap(container.Env)
+	if envMap["LIGHTSPEED_PROVIDER"] != "anthropic" {
+		t.Errorf("LIGHTSPEED_PROVIDER = %q, want anthropic", envMap["LIGHTSPEED_PROVIDER"])
+	}
+	if envMap["LIGHTSPEED_MODEL"] != "claude-opus-4-6" {
+		t.Errorf("LIGHTSPEED_MODEL = %q", envMap["LIGHTSPEED_MODEL"])
+	}
+	if envMap["LIGHTSPEED_PROVIDER_URL"] != "https://custom.api" {
+		t.Errorf("LIGHTSPEED_PROVIDER_URL = %q", envMap["LIGHTSPEED_PROVIDER_URL"])
+	}
+
+	// Verify envFrom
+	if len(container.EnvFrom) != 1 {
+		t.Fatalf("expected 1 envFrom, got %d", len(container.EnvFrom))
+	}
+	if container.EnvFrom[0].SecretRef == nil {
+		t.Fatal("envFrom secretRef is nil")
+	}
+	if container.EnvFrom[0].SecretRef.Name != "my-llm-secret" {
+		t.Errorf("secretRef name = %q, want my-llm-secret", container.EnvFrom[0].SecretRef.Name)
+	}
+
+	// Verify volume mount
+	foundMount := false
+	for _, m := range container.VolumeMounts {
+		if m.Name == llmCredsVolumeName && m.MountPath == llmCredsMountPath {
+			foundMount = true
+			if !m.ReadOnly {
+				t.Error("credential volume mount should be readOnly")
+			}
+			break
+		}
+	}
+	if !foundMount {
+		t.Errorf("missing credential volume mount at %s", llmCredsMountPath)
+	}
+
+	// Verify volume
+	foundVolume := false
+	for _, v := range podSpec.Volumes {
+		if v.Name == llmCredsVolumeName {
+			foundVolume = true
+			if v.Secret == nil {
+				t.Fatal("volume secret source is nil")
+			}
+			if v.Secret.SecretName != "my-llm-secret" {
+				t.Errorf("secret name = %q, want my-llm-secret", v.Secret.SecretName)
+			}
+			break
+		}
+	}
+	if !foundVolume {
+		t.Error("missing llm-credentials volume")
+	}
+
+	// Verify readiness probe
+	if container.ReadinessProbe == nil {
+		t.Fatal("readinessProbe is nil")
+	}
+	if container.ReadinessProbe.HTTPGet == nil {
+		t.Fatal("readinessProbe.HTTPGet is nil")
+	}
+	if container.ReadinessProbe.HTTPGet.Path != "/ready" {
+		t.Errorf("readinessProbe path = %q, want /ready", container.ReadinessProbe.HTTPGet.Path)
+	}
+	if container.ReadinessProbe.HTTPGet.Port != intstr8080() {
+		t.Errorf("readinessProbe port = %v, want 8080", container.ReadinessProbe.HTTPGet.Port)
+	}
+	if container.ReadinessProbe.InitialDelaySeconds != 3 {
+		t.Errorf("readinessProbe initialDelay = %d, want 3", container.ReadinessProbe.InitialDelaySeconds)
+	}
+	if container.ReadinessProbe.PeriodSeconds != 10 {
+		t.Errorf("readinessProbe period = %d, want 10", container.ReadinessProbe.PeriodSeconds)
+	}
+	if container.ReadinessProbe.FailureThreshold != 3 {
+		t.Errorf("readinessProbe failure = %d, want 3", container.ReadinessProbe.FailureThreshold)
+	}
+
+	// Verify liveness probe
+	if container.LivenessProbe == nil {
+		t.Fatal("livenessProbe is nil")
+	}
+	if container.LivenessProbe.HTTPGet == nil {
+		t.Fatal("livenessProbe.HTTPGet is nil")
+	}
+	if container.LivenessProbe.HTTPGet.Path != "/health" {
+		t.Errorf("livenessProbe path = %q, want /health", container.LivenessProbe.HTTPGet.Path)
+	}
+	if container.LivenessProbe.HTTPGet.Port != intstr8080() {
+		t.Errorf("livenessProbe port = %v, want 8080", container.LivenessProbe.HTTPGet.Port)
+	}
+	if container.LivenessProbe.InitialDelaySeconds != 10 {
+		t.Errorf("livenessProbe initialDelay = %d, want 10", container.LivenessProbe.InitialDelaySeconds)
+	}
+	if container.LivenessProbe.PeriodSeconds != 30 {
+		t.Errorf("livenessProbe period = %d, want 30", container.LivenessProbe.PeriodSeconds)
+	}
+	if container.LivenessProbe.FailureThreshold != 3 {
+		t.Errorf("livenessProbe failure = %d, want 3", container.LivenessProbe.FailureThreshold)
+	}
+
+	// Verify security context
+	if container.SecurityContext == nil {
+		t.Fatal("securityContext is nil")
+	}
+	if container.SecurityContext.AllowPrivilegeEscalation == nil || *container.SecurityContext.AllowPrivilegeEscalation {
+		t.Error("allowPrivilegeEscalation should be false")
+	}
+	if container.SecurityContext.Capabilities == nil {
+		t.Fatal("capabilities is nil")
+	}
+	if len(container.SecurityContext.Capabilities.Drop) != 1 || container.SecurityContext.Capabilities.Drop[0] != "ALL" {
+		t.Errorf("capabilities.drop = %v, want [ALL]", container.SecurityContext.Capabilities.Drop)
+	}
+
+	// Verify service account
+	if podSpec.ServiceAccountName != defaultSandboxSA {
+		t.Errorf("serviceAccountName = %q, want %q", podSpec.ServiceAccountName, defaultSandboxSA)
+	}
+	if podSpec.AutomountServiceAccountToken == nil || *podSpec.AutomountServiceAccountToken {
+		t.Error("automountServiceAccountToken should be false")
+	}
+}
+
+func TestPodSpecBuilder_Vertex(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "gemini-2.0-flash-exp"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex)
+
+	podSpec, err := builder.Build(agent, llm, nil, "analysis")
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	container := podSpec.Containers[0]
+	envMap := envToMap(container.Env)
+	if envMap["LIGHTSPEED_PROVIDER"] != "vertex" {
+		t.Errorf("LIGHTSPEED_PROVIDER = %q, want vertex", envMap["LIGHTSPEED_PROVIDER"])
+	}
+	if envMap["LIGHTSPEED_MODEL"] != "gemini-2.0-flash-exp" {
+		t.Errorf("LIGHTSPEED_MODEL = %q", envMap["LIGHTSPEED_MODEL"])
+	}
+	if envMap["LIGHTSPEED_MODEL_PROVIDER"] != "anthropic" {
+		t.Errorf("LIGHTSPEED_MODEL_PROVIDER = %q, want anthropic", envMap["LIGHTSPEED_MODEL_PROVIDER"])
+	}
+	if envMap["LIGHTSPEED_PROVIDER_PROJECT"] != "test-project" {
+		t.Errorf("LIGHTSPEED_PROVIDER_PROJECT = %q, want test-project", envMap["LIGHTSPEED_PROVIDER_PROJECT"])
+	}
+	if envMap["LIGHTSPEED_PROVIDER_REGION"] != "us-central1" {
+		t.Errorf("LIGHTSPEED_PROVIDER_REGION = %q, want us-central1", envMap["LIGHTSPEED_PROVIDER_REGION"])
+	}
+}
+
+func TestPodSpecBuilder_Azure(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "gpt-4o"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAzureOpenAI)
+
+	podSpec, err := builder.Build(agent, llm, nil, "analysis")
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	container := podSpec.Containers[0]
+	envMap := envToMap(container.Env)
+	if envMap["LIGHTSPEED_PROVIDER"] != "azure" {
+		t.Errorf("LIGHTSPEED_PROVIDER = %q, want azure", envMap["LIGHTSPEED_PROVIDER"])
+	}
+	if envMap["LIGHTSPEED_PROVIDER_URL"] != "https://test.openai.azure.com" {
+		t.Errorf("LIGHTSPEED_PROVIDER_URL = %q", envMap["LIGHTSPEED_PROVIDER_URL"])
+	}
+	if envMap["LIGHTSPEED_PROVIDER_API_VERSION"] != "2024-02-01" {
+		t.Errorf("LIGHTSPEED_PROVIDER_API_VERSION = %q", envMap["LIGHTSPEED_PROVIDER_API_VERSION"])
+	}
+}
+
+func TestPodSpecBuilder_Bedrock(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "anthropic.claude-3-opus-20240229-v1:0"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAWSBedrock)
+
+	podSpec, err := builder.Build(agent, llm, nil, "analysis")
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	container := podSpec.Containers[0]
+	envMap := envToMap(container.Env)
+	if envMap["LIGHTSPEED_PROVIDER"] != "bedrock" {
+		t.Errorf("LIGHTSPEED_PROVIDER = %q, want bedrock", envMap["LIGHTSPEED_PROVIDER"])
+	}
+	if envMap["LIGHTSPEED_PROVIDER_REGION"] != "us-east-1" {
+		t.Errorf("LIGHTSPEED_PROVIDER_REGION = %q, want us-east-1", envMap["LIGHTSPEED_PROVIDER_REGION"])
+	}
+}
+
+func TestPodSpecBuilder_OpenAI(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "gpt-4o"}}
+	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderOpenAI, "https://api.example.com")
+
+	podSpec, err := builder.Build(agent, llm, nil, "analysis")
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	container := podSpec.Containers[0]
+	envMap := envToMap(container.Env)
+	if envMap["LIGHTSPEED_PROVIDER"] != "openai" {
+		t.Errorf("LIGHTSPEED_PROVIDER = %q, want openai", envMap["LIGHTSPEED_PROVIDER"])
+	}
+	if envMap["LIGHTSPEED_PROVIDER_URL"] != "https://api.example.com" {
+		t.Errorf("LIGHTSPEED_PROVIDER_URL = %q", envMap["LIGHTSPEED_PROVIDER_URL"])
+	}
+}
+
+func TestPodSpecBuilder_NilAgent(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+
+	_, err := builder.Build(nil, llm, nil, "analysis")
+	if err == nil {
+		t.Fatal("expected error when agent is nil")
+	}
+	if err.Error() != "agent is required" {
+		t.Errorf("error = %q, want 'agent is required'", err.Error())
+	}
+}
+
+func TestPodSpecBuilder_NilLLM(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-opus-4-6"}}
+
+	_, err := builder.Build(agent, nil, nil, "analysis")
+	if err == nil {
+		t.Fatal("expected error when LLM is nil")
+	}
+	if err.Error() != "LLMProvider is required" {
+		t.Errorf("error = %q, want 'LLMProvider is required'", err.Error())
+	}
+}
+
+func TestPodSpecBuilder_Skills(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-opus-4-6"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+	tools := &agenticv1alpha1.ToolsSpec{
+		Skills: []agenticv1alpha1.SkillsSource{
+			{Image: "quay.io/lightspeed/skills:latest"},
+		},
+	}
+
+	podSpec, err := builder.Build(agent, llm, tools, "analysis")
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	foundVolume := false
+	for _, v := range podSpec.Volumes {
+		if v.Name == "skills" {
+			foundVolume = true
+			if v.Image == nil {
+				t.Fatal("skills volume image source is nil")
+			}
+			if v.Image.Reference != "quay.io/lightspeed/skills:latest" {
+				t.Errorf("skills image = %q, want quay.io/lightspeed/skills:latest", v.Image.Reference)
+			}
+			if v.Image.PullPolicy != corev1.PullAlways {
+				t.Errorf("skills pullPolicy = %v, want PullAlways", v.Image.PullPolicy)
+			}
+			break
+		}
+	}
+	if !foundVolume {
+		t.Error("missing skills volume")
+	}
+}
+
+func TestPodSpecBuilder_SkillsWithPaths(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-opus-4-6"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+	tools := &agenticv1alpha1.ToolsSpec{
+		Skills: []agenticv1alpha1.SkillsSource{
+			{
+				Image: "quay.io/lightspeed/skills:latest",
+				Paths: []string{"/skills/search.md", "/skills/analyze.md"},
+			},
+		},
+	}
+
+	podSpec, err := builder.Build(agent, llm, tools, "analysis")
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	container := podSpec.Containers[0]
+	if len(container.VolumeMounts) < 2 {
+		t.Fatalf("expected at least 2 volume mounts, got %d", len(container.VolumeMounts))
+	}
+
+	foundSearch := false
+	foundAnalyze := false
+	for _, m := range container.VolumeMounts {
+		if m.Name == "skills" {
+			if m.MountPath == "/app/skills/search.md" && m.SubPath == "skills/search.md" {
+				foundSearch = true
+			}
+			if m.MountPath == "/app/skills/analyze.md" && m.SubPath == "skills/analyze.md" {
+				foundAnalyze = true
+			}
+			if !m.ReadOnly {
+				t.Error("skills mount should be readOnly")
+			}
+		}
+	}
+	if !foundSearch {
+		t.Error("missing search.md skill mount")
+	}
+	if !foundAnalyze {
+		t.Error("missing analyze.md skill mount")
+	}
+}
+
+func TestPodSpecBuilder_RequiredSecrets_EnvVar(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-opus-4-6"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+	tools := &agenticv1alpha1.ToolsSpec{
+		RequiredSecrets: []agenticv1alpha1.SecretRequirement{
+			{
+				Name: "github-token",
+				MountAs: agenticv1alpha1.SecretMountSpec{
+					Type: agenticv1alpha1.SecretMountEnvVar,
+					EnvVar: agenticv1alpha1.SecretMountEnvVarConfig{
+						Name: "GITHUB_TOKEN",
+					},
+				},
+			},
+		},
+	}
+
+	podSpec, err := builder.Build(agent, llm, tools, "analysis")
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	container := podSpec.Containers[0]
+	foundEnv := false
+	for _, e := range container.Env {
+		if e.Name == "GITHUB_TOKEN" {
+			foundEnv = true
+			if e.ValueFrom == nil {
+				t.Fatal("env var valueFrom is nil")
+			}
+			if e.ValueFrom.SecretKeyRef == nil {
+				t.Fatal("env var secretKeyRef is nil")
+			}
+			if e.ValueFrom.SecretKeyRef.Name != "github-token" {
+				t.Errorf("secretKeyRef name = %q, want github-token", e.ValueFrom.SecretKeyRef.Name)
+			}
+			if e.ValueFrom.SecretKeyRef.Key != "token" {
+				t.Errorf("secretKeyRef key = %q, want token", e.ValueFrom.SecretKeyRef.Key)
+			}
+			break
+		}
+	}
+	if !foundEnv {
+		t.Error("missing GITHUB_TOKEN env var")
+	}
+}
+
+func TestPodSpecBuilder_RequiredSecrets_FileMount(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-opus-4-6"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+	tools := &agenticv1alpha1.ToolsSpec{
+		RequiredSecrets: []agenticv1alpha1.SecretRequirement{
+			{
+				Name: "kubeconfig",
+				MountAs: agenticv1alpha1.SecretMountSpec{
+					Type: agenticv1alpha1.SecretMountFilePath,
+					FilePath: agenticv1alpha1.SecretMountFilePathConfig{
+						Path: "/etc/kubeconfig",
+					},
+				},
+			},
+		},
+	}
+
+	podSpec, err := builder.Build(agent, llm, tools, "analysis")
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	foundVolume := false
+	for _, v := range podSpec.Volumes {
+		if v.Name == "req-kubeconfig" {
+			foundVolume = true
+			if v.Secret == nil {
+				t.Fatal("volume secret source is nil")
+			}
+			if v.Secret.SecretName != "kubeconfig" {
+				t.Errorf("secret name = %q, want kubeconfig", v.Secret.SecretName)
+			}
+			break
+		}
+	}
+	if !foundVolume {
+		t.Error("missing req-kubeconfig volume")
+	}
+
+	container := podSpec.Containers[0]
+	foundMount := false
+	for _, m := range container.VolumeMounts {
+		if m.Name == "req-kubeconfig" && m.MountPath == "/etc/kubeconfig" {
+			foundMount = true
+			if !m.ReadOnly {
+				t.Error("required secret mount should be readOnly")
+			}
+			break
+		}
+	}
+	if !foundMount {
+		t.Error("missing /etc/kubeconfig mount")
+	}
+}

--- a/controller/proposal/sandbox.go
+++ b/controller/proposal/sandbox.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
 
 var (
@@ -29,6 +31,7 @@ var (
 
 // SandboxProvider abstracts sandbox lifecycle for testability.
 type SandboxProvider interface {
+	SetStep(agent *agenticv1alpha1.Agent, llm *agenticv1alpha1.LLMProvider, tools *agenticv1alpha1.ToolsSpec)
 	Claim(ctx context.Context, proposalName, step, templateName string) (claimName string, err error)
 	WaitReady(ctx context.Context, claimName string, timeout time.Duration) (endpoint string, err error)
 	Release(ctx context.Context, claimName string) error
@@ -42,6 +45,11 @@ type SandboxManager struct {
 
 func NewSandboxManager(c client.Client, namespace string) *SandboxManager {
 	return &SandboxManager{Client: c, Namespace: namespace}
+}
+
+// SetStep is a no-op for SandboxManager; template-based sandboxes
+// receive step configuration via SandboxTemplate, not the provider.
+func (m *SandboxManager) SetStep(_ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec) {
 }
 
 func (m *SandboxManager) buildClaim(claimName, proposalName, step, templateName string) *unstructured.Unstructured {

--- a/controller/proposal/sandbox.go
+++ b/controller/proposal/sandbox.go
@@ -39,17 +39,25 @@ type SandboxProvider interface {
 
 // SandboxManager handles SandboxClaim lifecycle for proposal execution.
 type SandboxManager struct {
-	Client    client.Client
-	Namespace string
+	Client           client.Client
+	Namespace        string
+	BaseTemplateName string
+
+	agent *agenticv1alpha1.Agent
+	llm   *agenticv1alpha1.LLMProvider
+	tools *agenticv1alpha1.ToolsSpec
 }
 
-func NewSandboxManager(c client.Client, namespace string) *SandboxManager {
-	return &SandboxManager{Client: c, Namespace: namespace}
+func NewSandboxManager(c client.Client, namespace, baseTemplateName string) *SandboxManager {
+	return &SandboxManager{Client: c, Namespace: namespace, BaseTemplateName: baseTemplateName}
 }
 
-// SetStep is a no-op for SandboxManager; template-based sandboxes
-// receive step configuration via SandboxTemplate, not the provider.
-func (m *SandboxManager) SetStep(_ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec) {
+// SetStep stores the per-step agent configuration so that Claim can
+// derive the correct SandboxTemplate automatically.
+func (m *SandboxManager) SetStep(agent *agenticv1alpha1.Agent, llm *agenticv1alpha1.LLMProvider, tools *agenticv1alpha1.ToolsSpec) {
+	m.agent = agent
+	m.llm = llm
+	m.tools = tools
 }
 
 func (m *SandboxManager) buildClaim(claimName, proposalName, step, templateName string) *unstructured.Unstructured {
@@ -77,8 +85,13 @@ func (m *SandboxManager) buildClaim(claimName, proposalName, step, templateName 
 	}
 }
 
-func (m *SandboxManager) Claim(ctx context.Context, proposalName, step, templateName string) (string, error) {
+func (m *SandboxManager) Claim(ctx context.Context, proposalName, step, _ string) (string, error) {
 	log := logf.FromContext(ctx)
+
+	templateName, err := EnsureAgentTemplate(ctx, m.Client, m.BaseTemplateName, m.Namespace, step, m.agent, m.llm, m.tools)
+	if err != nil {
+		return "", fmt.Errorf("ensure agent template: %w", err)
+	}
 
 	claimName := truncateK8sName(fmt.Sprintf("ls-%s-%s", step, proposalName))
 

--- a/controller/proposal/sandbox_agent.go
+++ b/controller/proposal/sandbox_agent.go
@@ -165,12 +165,9 @@ func (s *SandboxAgentCaller) callWithSandbox(
 	query string,
 	agentCtx *agentContext,
 ) (json.RawMessage, error) {
-	templateName, err := EnsureAgentTemplate(ctx, s.K8sClient, defaultBaseTemplateName, s.Namespace, stepName, step.Agent, step.LLM, step.Tools)
-	if err != nil {
-		return nil, fmt.Errorf("ensure agent template: %w", err)
-	}
+	s.Sandbox.SetStep(step.Agent, step.LLM, step.Tools)
 
-	claimName, err := s.Sandbox.Claim(ctx, proposal.Name, stepName, templateName)
+	claimName, err := s.Sandbox.Claim(ctx, proposal.Name, stepName, "")
 	if err != nil {
 		return nil, fmt.Errorf("claim sandbox: %w", err)
 	}

--- a/controller/proposal/sandbox_agent_test.go
+++ b/controller/proposal/sandbox_agent_test.go
@@ -27,6 +27,8 @@ type mockSandboxProvider struct {
 	releaseCalls int
 }
 
+func (m *mockSandboxProvider) SetStep(_ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec) {
+}
 func (m *mockSandboxProvider) Claim(_ context.Context, _, _, _ string) (string, error) {
 	m.claimCalls++
 	return m.claimName, m.claimErr
@@ -713,6 +715,8 @@ type trackingMockSandbox struct {
 	errOnClaim string
 }
 
+func (m *trackingMockSandbox) SetStep(_ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec) {
+}
 func (m *trackingMockSandbox) Claim(_ context.Context, _, _, _ string) (string, error) {
 	return "", nil
 }

--- a/controller/proposal/sandbox_test.go
+++ b/controller/proposal/sandbox_test.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
 
 func newSandboxClient(objects ...client.Object) client.Client {
@@ -22,6 +24,9 @@ func newSandboxClient(objects ...client.Object) client.Client {
 	})
 	mapper.Add(schema.GroupVersionKind{
 		Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Kind: "SandboxClaim",
+	}, apimeta.RESTScopeNamespace)
+	mapper.Add(schema.GroupVersionKind{
+		Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Kind: "SandboxTemplate",
 	}, apimeta.RESTScopeNamespace)
 
 	builder := fake.NewClientBuilder().
@@ -35,8 +40,43 @@ func newSandboxClient(objects ...client.Object) client.Client {
 	return builder.Build()
 }
 
+// baseSandboxTemplate returns a minimal SandboxTemplate for tests.
+func baseSandboxTemplate(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "extensions.agents.x-k8s.io/v1alpha1",
+			"kind":       "SandboxTemplate",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"podTemplate": map[string]any{
+					"spec": map[string]any{
+						"containers": []any{
+							map[string]any{
+								"name":  "agent",
+								"image": "test-agent:latest",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// setTestStep configures the SandboxManager with minimal agent/llm for tests.
+func setTestStep(m *SandboxManager) {
+	m.SetStep(
+		&agenticv1alpha1.Agent{},
+		&agenticv1alpha1.LLMProvider{},
+		nil,
+	)
+}
+
 func TestBuildClaim_Structure(t *testing.T) {
-	m := NewSandboxManager(nil, "test-ns")
+	m := NewSandboxManager(nil, "test-ns", "")
 	claim := m.buildClaim("my-claim", "my-proposal", "analysis", "my-template")
 
 	if got := claim.GetName(); got != "my-claim" {
@@ -54,7 +94,7 @@ func TestBuildClaim_Structure(t *testing.T) {
 }
 
 func TestBuildClaim_Labels(t *testing.T) {
-	m := NewSandboxManager(nil, "ns")
+	m := NewSandboxManager(nil, "ns", "")
 	claim := m.buildClaim("c", "prop-1", "execution", "tpl")
 
 	labels := claim.GetLabels()
@@ -67,7 +107,7 @@ func TestBuildClaim_Labels(t *testing.T) {
 }
 
 func TestBuildClaim_TemplateRef(t *testing.T) {
-	m := NewSandboxManager(nil, "ns")
+	m := NewSandboxManager(nil, "ns", "")
 	claim := m.buildClaim("c", "p", "analysis", "my-template")
 
 	templateRef, found, _ := unstructured.NestedString(claim.Object, "spec", "sandboxTemplateRef", "name")
@@ -82,10 +122,12 @@ func TestBuildClaim_TemplateRef(t *testing.T) {
 }
 
 func TestClaim_Creates(t *testing.T) {
-	c := newSandboxClient()
-	m := NewSandboxManager(c, "test-ns")
+	baseTpl := baseSandboxTemplate("base-tpl", "test-ns")
+	c := newSandboxClient(baseTpl)
+	m := NewSandboxManager(c, "test-ns", "base-tpl")
+	setTestStep(m)
 
-	claimName, err := m.Claim(context.Background(), "my-proposal", "analysis", "analysis-template")
+	claimName, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -116,11 +158,13 @@ func TestClaim_AlreadyExists(t *testing.T) {
 			},
 		},
 	}
+	baseTpl := baseSandboxTemplate("base-tpl", "test-ns")
 
-	c := newSandboxClient(existing)
-	m := NewSandboxManager(c, "test-ns")
+	c := newSandboxClient(existing, baseTpl)
+	m := NewSandboxManager(c, "test-ns", "base-tpl")
+	setTestStep(m)
 
-	claimName, err := m.Claim(context.Background(), "my-proposal", "analysis", "analysis-template")
+	claimName, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
 	if err != nil {
 		t.Fatalf("unexpected error for already-existing claim: %v", err)
 	}
@@ -130,11 +174,13 @@ func TestClaim_AlreadyExists(t *testing.T) {
 }
 
 func TestClaim_LongName(t *testing.T) {
-	c := newSandboxClient()
-	m := NewSandboxManager(c, "test-ns")
+	baseTpl := baseSandboxTemplate("base-tpl", "test-ns")
+	c := newSandboxClient(baseTpl)
+	m := NewSandboxManager(c, "test-ns", "base-tpl")
+	setTestStep(m)
 
 	longProposalName := strings.Repeat("a", 100)
-	claimName, err := m.Claim(context.Background(), longProposalName, "analysis", "template")
+	claimName, err := m.Claim(context.Background(), longProposalName, "analysis", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -144,10 +190,12 @@ func TestClaim_LongName(t *testing.T) {
 }
 
 func TestClaim_ExecutionPhase(t *testing.T) {
-	c := newSandboxClient()
-	m := NewSandboxManager(c, "test-ns")
+	baseTpl := baseSandboxTemplate("base-tpl", "test-ns")
+	c := newSandboxClient(baseTpl)
+	m := NewSandboxManager(c, "test-ns", "base-tpl")
+	setTestStep(m)
 
-	claimName, err := m.Claim(context.Background(), "my-proposal", "execution", "exec-template")
+	claimName, err := m.Claim(context.Background(), "my-proposal", "execution", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -170,10 +218,12 @@ func TestClaim_ExecutionPhase(t *testing.T) {
 }
 
 func TestClaim_VerificationPhase(t *testing.T) {
-	c := newSandboxClient()
-	m := NewSandboxManager(c, "test-ns")
+	baseTpl := baseSandboxTemplate("base-tpl", "test-ns")
+	c := newSandboxClient(baseTpl)
+	m := NewSandboxManager(c, "test-ns", "base-tpl")
+	setTestStep(m)
 
-	claimName, err := m.Claim(context.Background(), "my-proposal", "verification", "validate-template")
+	claimName, err := m.Claim(context.Background(), "my-proposal", "verification", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -195,7 +245,7 @@ func TestRelease_Deletes(t *testing.T) {
 	}
 
 	c := newSandboxClient(existing)
-	m := NewSandboxManager(c, "test-ns")
+	m := NewSandboxManager(c, "test-ns", "")
 
 	err := m.Release(context.Background(), "ls-execution-my-proposal")
 	if err != nil {
@@ -216,7 +266,7 @@ func TestRelease_Deletes(t *testing.T) {
 
 func TestRelease_NotFound(t *testing.T) {
 	c := newSandboxClient()
-	m := NewSandboxManager(c, "test-ns")
+	m := NewSandboxManager(c, "test-ns", "")
 
 	err := m.Release(context.Background(), "nonexistent")
 	if err != nil {

--- a/controller/setup.go
+++ b/controller/setup.go
@@ -20,7 +20,7 @@ type Options struct {
 func Setup(mgr ctrl.Manager, opts Options) error {
 	log := ctrl.Log.WithName("agentic-setup")
 
-	sandboxMgr := proposal.NewSandboxManager(mgr.GetClient(), opts.Namespace)
+	sandboxMgr := proposal.NewSandboxManager(mgr.GetClient(), opts.Namespace, "lightspeed-agent")
 	agentCaller := proposal.NewSandboxAgentCaller(
 		sandboxMgr,
 		mgr.GetClient(),


### PR DESCRIPTION
## Summary
- Move `EnsureAgentTemplate` call from `callWithSandbox` into `SandboxManager.Claim()`
- `callWithSandbox` now calls `SetStep` before each `Claim`, decoupling `SandboxAgentCaller` from template-specific logic
- `SandboxManager` gains `BaseTemplateName` field and stores step config via `SetStep`

**Jira:** [OLS-3244](https://redhat.atlassian.net/browse/OLS-3244)
**Stacked PR:** 3 of 5 — merge after #86
**Depends on:** #86

## Test plan
- [x] All existing sandbox and agent caller tests updated and passing
- [x] SandboxManager.Claim now internally calls EnsureAgentTemplate
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)