### PR TITLE
fix: eliminate SetStep/Claim race and mount SA token for execution pods

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 	agenticcontroller "github.com/openshift/lightspeed-agentic-operator/controller"
+	agenticsandbox "github.com/openshift/lightspeed-agentic-operator/controller/sandbox"
 )
 
 var scheme = runtime.NewScheme()
@@ -46,7 +47,7 @@ func main() {
 	flag.StringVar(&namespace, "namespace", "", "The namespace where the operator runs (required).")
 	flag.StringVar(&agenticConsoleImage, "agentic-console-image", "", "The image of the agentic console plugin container.")
 	flag.StringVar(&agenticSandboxImage, "agentic-sandbox-image", "", "The image of the agentic sandbox container.")
-	flag.StringVar(&sandboxMode, "sandbox-mode", "bare-pod", "Sandbox mode: bare-pod (default) or sandbox-claim.")
+	flag.StringVar(&sandboxMode, "sandbox-mode", agenticsandbox.SandboxModeBarePod, "Sandbox mode: bare-pod (default) or sandbox-claim.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))

--- a/controller/proposal/bare_pod_manager.go
+++ b/controller/proposal/bare_pod_manager.go
@@ -23,10 +23,6 @@ type BarePodManager struct {
 	Client    client.Client
 	Builder   *PodSpecBuilder
 	Namespace string
-
-	agent *agenticv1alpha1.Agent
-	llm   *agenticv1alpha1.LLMProvider
-	tools *agenticv1alpha1.ToolsSpec
 }
 
 // NewBarePodManager creates a BarePodManager that manages bare Pods in the given namespace.
@@ -38,23 +34,14 @@ func NewBarePodManager(c client.Client, builder *PodSpecBuilder, namespace strin
 	}
 }
 
-// SetStep stores the resolved step configuration so that the next Claim
-// call can build the correct PodSpec.
-func (m *BarePodManager) SetStep(agent *agenticv1alpha1.Agent, llm *agenticv1alpha1.LLMProvider, tools *agenticv1alpha1.ToolsSpec) {
-	m.agent = agent
-	m.llm = llm
-	m.tools = tools
-}
-
-// Claim creates a bare Pod for the given proposal step. The templateName
-// parameter is ignored (bare pods use PodSpecBuilder instead of templates).
-// Returns the pod name. Idempotent: returns the name if the pod already exists.
-func (m *BarePodManager) Claim(ctx context.Context, proposalName, step, _ string) (string, error) {
+// Claim creates a bare Pod for the given proposal step. Returns the pod
+// name. Idempotent: returns the name if the pod already exists.
+func (m *BarePodManager) Claim(ctx context.Context, proposalName, step string, agent *agenticv1alpha1.Agent, llm *agenticv1alpha1.LLMProvider, tools *agenticv1alpha1.ToolsSpec) (string, error) {
 	log := logf.FromContext(ctx)
 
 	podName := truncateK8sName(fmt.Sprintf("ls-%s-%s", step, proposalName))
 
-	podSpec, err := m.Builder.Build(m.agent, m.llm, m.tools, step)
+	podSpec, err := m.Builder.Build(agent, llm, tools, step)
 	if err != nil {
 		return "", fmt.Errorf("build pod spec: %w", err)
 	}

--- a/controller/proposal/bare_pod_manager_test.go
+++ b/controller/proposal/bare_pod_manager_test.go
@@ -23,13 +23,11 @@ func TestBarePodManager_Claim_Creates(t *testing.T) {
 	fc := newBarePodClient().Build()
 	builder := &PodSpecBuilder{Image: "quay.io/test/sandbox:latest"}
 	m := NewBarePodManager(fc, builder, "test-ns")
-	m.SetStep(
-		&agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-opus-4-6"}},
-		testLLMProvider(agenticv1alpha1.LLMProviderAnthropic),
-		nil,
-	)
 
-	name, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-opus-4-6"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+
+	name, err := m.Claim(context.Background(), "my-proposal", "analysis", agent, llm, nil)
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
@@ -60,13 +58,11 @@ func TestBarePodManager_Claim_AlreadyExists(t *testing.T) {
 	fc := newBarePodClient().WithObjects(existing).Build()
 	builder := &PodSpecBuilder{Image: "img"}
 	m := NewBarePodManager(fc, builder, "test-ns")
-	m.SetStep(
-		&agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}},
-		testLLMProvider(agenticv1alpha1.LLMProviderAnthropic),
-		nil,
-	)
 
-	name, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+
+	name, err := m.Claim(context.Background(), "my-proposal", "analysis", agent, llm, nil)
 	if err != nil {
 		t.Fatalf("Claim should succeed for existing pod: %v", err)
 	}

--- a/controller/proposal/handlers.go
+++ b/controller/proposal/handlers.go
@@ -218,6 +218,9 @@ func (r *ProposalReconciler) handleExecution(
 	}
 
 	base := proposal.DeepCopy()
+	if selectedOption != nil {
+		log.Info("execution RBAC check", "nsRules", len(selectedOption.RBAC.NamespaceScoped), "clusterRules", len(selectedOption.RBAC.ClusterScoped))
+	}
 	if selectedOption != nil && (len(selectedOption.RBAC.NamespaceScoped) > 0 || len(selectedOption.RBAC.ClusterScoped) > 0) {
 		if err := ensureExecutionRBAC(ctx, r.Client, proposal, &selectedOption.RBAC, defaultSandboxSA, r.Namespace); err != nil {
 			return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionExecuted, fmt.Errorf("ensure execution RBAC: %w", err))

--- a/controller/proposal/podspec_builder.go
+++ b/controller/proposal/podspec_builder.go
@@ -40,7 +40,7 @@ func (b *PodSpecBuilder) Build(
 		}},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.To(false),
-			Capabilities:            &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 		},
 	}
 
@@ -110,9 +110,11 @@ func (b *PodSpecBuilder) Build(
 		container.Env = append(container.Env, secEnv...)
 	}
 
+	mountToken := step == "execution" || step == "verification"
+
 	return &corev1.PodSpec{
 		ServiceAccountName:           defaultSandboxSA,
-		AutomountServiceAccountToken: ptr.To(false),
+		AutomountServiceAccountToken: ptr.To(mountToken),
 		Containers:                   []corev1.Container{container},
 		Volumes:                      volumes,
 	}, nil

--- a/controller/proposal/podspec_builder_test.go
+++ b/controller/proposal/podspec_builder_test.go
@@ -183,7 +183,31 @@ func TestPodSpecBuilder_Anthropic(t *testing.T) {
 		t.Errorf("serviceAccountName = %q, want %q", podSpec.ServiceAccountName, defaultSandboxSA)
 	}
 	if podSpec.AutomountServiceAccountToken == nil || *podSpec.AutomountServiceAccountToken {
-		t.Error("automountServiceAccountToken should be false")
+		t.Error("automountServiceAccountToken should be false for analysis step")
+	}
+}
+
+func TestPodSpecBuilder_ExecutionMountsToken(t *testing.T) {
+	builder := PodSpecBuilder{Image: "img"}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+
+	for _, step := range []string{"execution", "verification"} {
+		podSpec, err := builder.Build(agent, llm, nil, step)
+		if err != nil {
+			t.Fatalf("Build(%s): %v", step, err)
+		}
+		if podSpec.AutomountServiceAccountToken == nil || !*podSpec.AutomountServiceAccountToken {
+			t.Errorf("step=%s: automountServiceAccountToken should be true", step)
+		}
+	}
+
+	podSpec, err := builder.Build(agent, llm, nil, "analysis")
+	if err != nil {
+		t.Fatalf("Build(analysis): %v", err)
+	}
+	if podSpec.AutomountServiceAccountToken == nil || *podSpec.AutomountServiceAccountToken {
+		t.Error("step=analysis: automountServiceAccountToken should be false")
 	}
 }
 

--- a/controller/proposal/sandbox.go
+++ b/controller/proposal/sandbox.go
@@ -31,8 +31,7 @@ var (
 
 // SandboxProvider abstracts sandbox lifecycle for testability.
 type SandboxProvider interface {
-	SetStep(agent *agenticv1alpha1.Agent, llm *agenticv1alpha1.LLMProvider, tools *agenticv1alpha1.ToolsSpec)
-	Claim(ctx context.Context, proposalName, step, templateName string) (claimName string, err error)
+	Claim(ctx context.Context, proposalName, step string, agent *agenticv1alpha1.Agent, llm *agenticv1alpha1.LLMProvider, tools *agenticv1alpha1.ToolsSpec) (claimName string, err error)
 	WaitReady(ctx context.Context, claimName string, timeout time.Duration) (endpoint string, err error)
 	Release(ctx context.Context, claimName string) error
 }
@@ -42,22 +41,10 @@ type SandboxManager struct {
 	Client           client.Client
 	Namespace        string
 	BaseTemplateName string
-
-	agent *agenticv1alpha1.Agent
-	llm   *agenticv1alpha1.LLMProvider
-	tools *agenticv1alpha1.ToolsSpec
 }
 
 func NewSandboxManager(c client.Client, namespace, baseTemplateName string) *SandboxManager {
 	return &SandboxManager{Client: c, Namespace: namespace, BaseTemplateName: baseTemplateName}
-}
-
-// SetStep stores the per-step agent configuration so that Claim can
-// derive the correct SandboxTemplate automatically.
-func (m *SandboxManager) SetStep(agent *agenticv1alpha1.Agent, llm *agenticv1alpha1.LLMProvider, tools *agenticv1alpha1.ToolsSpec) {
-	m.agent = agent
-	m.llm = llm
-	m.tools = tools
 }
 
 func (m *SandboxManager) buildClaim(claimName, proposalName, step, templateName string) *unstructured.Unstructured {
@@ -85,10 +72,10 @@ func (m *SandboxManager) buildClaim(claimName, proposalName, step, templateName 
 	}
 }
 
-func (m *SandboxManager) Claim(ctx context.Context, proposalName, step, _ string) (string, error) {
+func (m *SandboxManager) Claim(ctx context.Context, proposalName, step string, agent *agenticv1alpha1.Agent, llm *agenticv1alpha1.LLMProvider, tools *agenticv1alpha1.ToolsSpec) (string, error) {
 	log := logf.FromContext(ctx)
 
-	templateName, err := EnsureAgentTemplate(ctx, m.Client, m.BaseTemplateName, m.Namespace, step, m.agent, m.llm, m.tools)
+	templateName, err := EnsureAgentTemplate(ctx, m.Client, m.BaseTemplateName, m.Namespace, step, agent, llm, tools)
 	if err != nil {
 		return "", fmt.Errorf("ensure agent template: %w", err)
 	}

--- a/controller/proposal/sandbox_agent.go
+++ b/controller/proposal/sandbox_agent.go
@@ -165,9 +165,7 @@ func (s *SandboxAgentCaller) callWithSandbox(
 	query string,
 	agentCtx *agentContext,
 ) (json.RawMessage, error) {
-	s.Sandbox.SetStep(step.Agent, step.LLM, step.Tools)
-
-	claimName, err := s.Sandbox.Claim(ctx, proposal.Name, stepName, "")
+	claimName, err := s.Sandbox.Claim(ctx, proposal.Name, stepName, step.Agent, step.LLM, step.Tools)
 	if err != nil {
 		return nil, fmt.Errorf("claim sandbox: %w", err)
 	}

--- a/controller/proposal/sandbox_agent_test.go
+++ b/controller/proposal/sandbox_agent_test.go
@@ -27,9 +27,7 @@ type mockSandboxProvider struct {
 	releaseCalls int
 }
 
-func (m *mockSandboxProvider) SetStep(_ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec) {
-}
-func (m *mockSandboxProvider) Claim(_ context.Context, _, _, _ string) (string, error) {
+func (m *mockSandboxProvider) Claim(_ context.Context, _, _ string, _ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec) (string, error) {
 	m.claimCalls++
 	return m.claimName, m.claimErr
 }
@@ -715,9 +713,7 @@ type trackingMockSandbox struct {
 	errOnClaim string
 }
 
-func (m *trackingMockSandbox) SetStep(_ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec) {
-}
-func (m *trackingMockSandbox) Claim(_ context.Context, _, _, _ string) (string, error) {
+func (m *trackingMockSandbox) Claim(_ context.Context, _, _ string, _ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec) (string, error) {
 	return "", nil
 }
 func (m *trackingMockSandbox) WaitReady(_ context.Context, _ string, _ time.Duration) (string, error) {

--- a/controller/proposal/sandbox_test.go
+++ b/controller/proposal/sandbox_test.go
@@ -66,14 +66,9 @@ func baseSandboxTemplate(name, namespace string) *unstructured.Unstructured {
 	}
 }
 
-// setTestStep configures the SandboxManager with minimal agent/llm for tests.
-func setTestStep(m *SandboxManager) {
-	m.SetStep(
-		&agenticv1alpha1.Agent{},
-		&agenticv1alpha1.LLMProvider{},
-		nil,
-	)
-}
+func testStepAgent() *agenticv1alpha1.Agent     { return &agenticv1alpha1.Agent{} }
+func testStepLLM() *agenticv1alpha1.LLMProvider { return &agenticv1alpha1.LLMProvider{} }
+func testStepTools() *agenticv1alpha1.ToolsSpec { return nil }
 
 func TestBuildClaim_Structure(t *testing.T) {
 	m := NewSandboxManager(nil, "test-ns", "")
@@ -125,9 +120,8 @@ func TestClaim_Creates(t *testing.T) {
 	baseTpl := baseSandboxTemplate("base-tpl", "test-ns")
 	c := newSandboxClient(baseTpl)
 	m := NewSandboxManager(c, "test-ns", "base-tpl")
-	setTestStep(m)
 
-	claimName, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
+	claimName, err := m.Claim(context.Background(), "my-proposal", "analysis", testStepAgent(), testStepLLM(), testStepTools())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -162,9 +156,8 @@ func TestClaim_AlreadyExists(t *testing.T) {
 
 	c := newSandboxClient(existing, baseTpl)
 	m := NewSandboxManager(c, "test-ns", "base-tpl")
-	setTestStep(m)
 
-	claimName, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
+	claimName, err := m.Claim(context.Background(), "my-proposal", "analysis", testStepAgent(), testStepLLM(), testStepTools())
 	if err != nil {
 		t.Fatalf("unexpected error for already-existing claim: %v", err)
 	}
@@ -177,10 +170,9 @@ func TestClaim_LongName(t *testing.T) {
 	baseTpl := baseSandboxTemplate("base-tpl", "test-ns")
 	c := newSandboxClient(baseTpl)
 	m := NewSandboxManager(c, "test-ns", "base-tpl")
-	setTestStep(m)
 
 	longProposalName := strings.Repeat("a", 100)
-	claimName, err := m.Claim(context.Background(), longProposalName, "analysis", "")
+	claimName, err := m.Claim(context.Background(), longProposalName, "analysis", testStepAgent(), testStepLLM(), testStepTools())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -193,9 +185,8 @@ func TestClaim_ExecutionPhase(t *testing.T) {
 	baseTpl := baseSandboxTemplate("base-tpl", "test-ns")
 	c := newSandboxClient(baseTpl)
 	m := NewSandboxManager(c, "test-ns", "base-tpl")
-	setTestStep(m)
 
-	claimName, err := m.Claim(context.Background(), "my-proposal", "execution", "")
+	claimName, err := m.Claim(context.Background(), "my-proposal", "execution", testStepAgent(), testStepLLM(), testStepTools())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -221,9 +212,8 @@ func TestClaim_VerificationPhase(t *testing.T) {
 	baseTpl := baseSandboxTemplate("base-tpl", "test-ns")
 	c := newSandboxClient(baseTpl)
 	m := NewSandboxManager(c, "test-ns", "base-tpl")
-	setTestStep(m)
 
-	claimName, err := m.Claim(context.Background(), "my-proposal", "verification", "")
+	claimName, err := m.Claim(context.Background(), "my-proposal", "verification", testStepAgent(), testStepLLM(), testStepTools())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/controller/sandbox/bootstrap.go
+++ b/controller/sandbox/bootstrap.go
@@ -14,7 +14,12 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const templateName = "lightspeed-agent"
+const (
+	templateName = "lightspeed-agent"
+
+	SandboxModeBarePod      = "bare-pod"
+	SandboxModeSandboxClaim = "sandbox-claim"
+)
 
 var sandboxTemplateGVK = schema.GroupVersionKind{
 	Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Kind: "SandboxTemplate",
@@ -41,7 +46,7 @@ func EnsureBootstrapResources(ctx context.Context, c client.Client, cfg Bootstra
 	}
 	log.V(1).Info("ServiceAccount ready")
 
-	if cfg.SandboxMode == "sandbox-claim" {
+	if cfg.SandboxMode == SandboxModeSandboxClaim {
 		if err := ensureSandboxTemplate(ctx, c, cfg.Image, cfg.Namespace); err != nil {
 			return fmt.Errorf("ensure SandboxTemplate: %w", err)
 		}

--- a/controller/sandbox/bootstrap_test.go
+++ b/controller/sandbox/bootstrap_test.go
@@ -22,7 +22,7 @@ func testConfig() BootstrapConfig {
 	return BootstrapConfig{
 		Image:       "quay.io/test/agentic-sandbox:latest",
 		Namespace:   "openshift-lightspeed",
-		SandboxMode: "sandbox-claim",
+		SandboxMode: SandboxModeSandboxClaim,
 	}
 }
 
@@ -146,7 +146,7 @@ func TestEnsureBootstrapResources_BarePod_SAOnly(t *testing.T) {
 	cfg := BootstrapConfig{
 		Image:       "quay.io/test/sandbox:latest",
 		Namespace:   "openshift-lightspeed",
-		SandboxMode: "bare-pod",
+		SandboxMode: SandboxModeBarePod,
 	}
 
 	if err := EnsureBootstrapResources(context.Background(), fc, cfg); err != nil {
@@ -177,7 +177,7 @@ func TestEnsureBootstrapResources_SandboxClaim_CreatesAll(t *testing.T) {
 	cfg := BootstrapConfig{
 		Image:       "quay.io/test/sandbox:latest",
 		Namespace:   "openshift-lightspeed",
-		SandboxMode: "sandbox-claim",
+		SandboxMode: SandboxModeSandboxClaim,
 	}
 
 	if err := EnsureBootstrapResources(context.Background(), fc, cfg); err != nil {

--- a/controller/setup.go
+++ b/controller/setup.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -21,9 +22,15 @@ type Options struct {
 func Setup(mgr ctrl.Manager, opts Options) error {
 	log := ctrl.Log.WithName("agentic-setup")
 
+	switch opts.SandboxMode {
+	case agenticsandbox.SandboxModeBarePod, agenticsandbox.SandboxModeSandboxClaim:
+	default:
+		return fmt.Errorf("invalid --sandbox-mode %q: must be %q or %q", opts.SandboxMode, agenticsandbox.SandboxModeBarePod, agenticsandbox.SandboxModeSandboxClaim)
+	}
+
 	var sandboxProvider proposal.SandboxProvider
 	switch opts.SandboxMode {
-	case "sandbox-claim":
+	case agenticsandbox.SandboxModeSandboxClaim:
 		sandboxProvider = proposal.NewSandboxManager(mgr.GetClient(), opts.Namespace, "lightspeed-agent")
 	default:
 		builder := &proposal.PodSpecBuilder{Image: opts.AgenticSandboxImage}


### PR DESCRIPTION
## Summary

Fixes three issues found during bare-pod cluster testing (#89):

- **Concurrency race** (Must Fix #1): `SetStep()` wrote `agent`/`llm`/`tools` to shared struct fields read by `Claim()`. With `MaxConcurrentReconciles=5` and a single provider instance, concurrent proposals could swap each other's config. **Fix**: remove `SetStep()` from `SandboxProvider` interface; pass `(agent, llm, tools)` directly to `Claim()`.

- **SA token for execution pods** (Must Fix #10): `PodSpecBuilder` unconditionally set `AutomountServiceAccountToken: false`, preventing execution agents from running `oc`/`kubectl`. **Fix**: set `true` for execution and verification steps, keep `false` for analysis.

- **Mode string constants** (Should Fix #2): `"bare-pod"` and `"sandbox-claim"` were raw literals in 3 files with no validation. **Fix**: extract `SandboxModeBarePod` / `SandboxModeSandboxClaim` constants, validate at startup.

Also adds RBAC debug logging in `handleExecution` to trace whether `ensureExecutionRBAC` fires correctly (investigating potential `omitzero` deserialization gap from cluster testing).

## Cluster Testing Context

These issues were identified while running a full analysis → execution flow with `real_proposal.yaml` against a live cluster:
- Analysis passed: agent correctly diagnosed wrong image tag, returned scoped RBAC
- Execution failed: agent couldn't reach cluster API (`AutomountServiceAccountToken: false`)
- RBAC resources were not created despite data being present in AnalysisResult CR

Tracking doc: `docs/2026-06-08-bare-pod-post-merge-issues.md`

## Test plan

- [x] `make test` — all unit tests pass
- [x] `go vet` — clean
- [ ] Deploy to cluster with `--sandbox-mode=bare-pod` and rerun `real_proposal.yaml`
- [ ] Verify execution pod has SA token mounted (`automountServiceAccountToken: true`)
- [ ] Verify RBAC debug log shows non-zero rule counts
- [ ] Verify concurrent proposals don't cross-contaminate configs


Made with [Cursor](https://cursor.com)