### PR TITLE
chore: tag operator :main on Konflux push builds

### DIFF
--- a/.tekton/lightspeed-agentic-operator-push.yaml
+++ b/.tekton/lightspeed-agentic-operator-push.yaml
@@ -493,6 +493,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - main
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
## Summary

- Add `ADDITIONAL_TAGS: [main]` to the `apply-tags` task in the operator push pipeline, matching the sandbox configuration
- After merge and the next successful main push, `quay.io/.../lightspeed-agentic-operator:main` will be available for the quickstart install script

## Context

The quickstart `install.sh` defaults to `:main` for both operator and sandbox images. Sandbox already tags `:main` on push builds; operator did not, causing `ImagePullBackOff` on fresh installs.

## Test plan

- [ ] Konflux push pipeline succeeds on merge
- [ ] `quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-operator:main` exists after build
- [ ] `podman pull .../lightspeed-agentic-operator:main` succeeds
- [ ] In-cluster test pod pulls the image without a pull secret


Made with [Cursor](https://cursor.com)