### PR TITLE
chore: add fmt-check target to catch formatting drift in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,16 @@ GOLANGCI_LINT_KAL ?= $(LOCALBIN)/golangci-lint-kube-api-linter
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
+.PHONY: fmt-check
+fmt-check: ## Verify go fmt produces no changes.
+	@test -z "$$(gofmt -l .)" || { echo "Unformatted files:"; gofmt -l .; exit 1; }
+
 .PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: fmt vet ## Run unit tests (main + api + cli modules).
+test: fmt-check vet ## Run unit tests (main + api + cli modules).
 	# Root module: controller, cli, etc. (exclude test/e2e — needs -tags=e2e and a running mock; see test-e2e).
 	go test $$(go list ./... | grep -vF 'github.com/openshift/lightspeed-agentic-operator/test/e2e') -count=1
 	# API module is separate go.mod; GOWORK=off avoids picking up a repo root go.work.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Do not edit **`config/crd/bases/`** or generated **`config/rbac/role.yaml`** by 
 
 ```bash
 make manifests # controller-gen → config/crd/bases + config/rbac/role.yaml
-make test      # fmt + vet + go test (root + api module)
+make test      # fmt-check + vet + go test (root + api module)
 make install   # kubectl apply CRDs from config/crd only
 make run       # install + install-agent-sandbox + vet + go run ./cmd/main.go
 make uninstall # kubectl delete CRDs from config/crd (optional: ignore-not-found=true)
@@ -61,7 +61,7 @@ make api-lint       # Kube API linter on api/ (golangci-lint custom + plugin; se
 
 ### Testing
 
-**`make test`** runs **`fmt`**, **`vet`**, root-module tests, and **`cd api && GOWORK=off go test ./... -count=1`** (the API tree is a separate module; **`GOWORK=off`** avoids a repo-root **`go.work`** hijacking module choice). The **`test/e2e`** package is excluded from this target — it requires **`-tags=e2e`** and a running mock agent.
+**`make test`** runs **`fmt-check`** (fails if any file needs reformatting — run **`make fmt`** to fix), **`vet`**, root-module tests, and **`cd api && GOWORK=off go test ./... -count=1`** (the API tree is a separate module; **`GOWORK=off`** avoids a repo-root **`go.work`** hijacking module choice). The **`test/e2e`** package is excluded from this target — it requires **`-tags=e2e`** and a running mock agent.
 
 **`make test-e2e`** runs **`go test -tags=e2e ./test/e2e/...`** against a live cluster with the operator running. Prerequisites: **`make run TEMPLATE_NAME=lightspeed-agent-mock`** (or deployed operator with **`--template-name=lightspeed-agent-mock`**) and mock agent SandboxTemplate applied (**`kubectl apply -k test/agent/sandboxtemplate`**). See `test/e2e/` package doc for details.
 


### PR DESCRIPTION
## Summary

- Add `make fmt-check` target that fails when `gofmt` finds unformatted files
- Replace `fmt` with `fmt-check` as a dependency of `make test`, so CI's `unit` job catches formatting drift instead of silently fixing it
- `make fmt` is preserved for local use

## Context

`go fmt ./...` is a fixer, not a checker — it silently rewrites files and always exits 0. This means the CI `unit` job (`make test`) was never actually gating on formatting. Pre-existing drift was discovered during [OLS-3161](https://redhat.atlassian.net/browse/OLS-3161) work (fixed in #98).

## Testing

- [x] `make fmt-check` fails on unformatted files, passes on formatted ones
- [x] `make test` passes with the new dependency

Made with [Cursor](https://cursor.com)