### PR TITLE
fix: add missing RBAC markers for core API resources (OLS-3240)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ build: fmt vet ## Build manager binary to bin/manager.
 
 .PHONY: manifests
 manifests: controller-gen ## Regenerate CRD YAML and RBAC ClusterRole (do not edit role.yaml by hand).
-	$(CONTROLLER_GEN) rbac:roleName=agentic-operator-manager-role crd paths=./api/v1alpha1/... paths=./controller/proposal/... output:crd:artifacts:config=config/crd/bases output:rbac:artifacts:config=config/rbac
+	$(CONTROLLER_GEN) rbac:roleName=agentic-operator-manager-role crd paths=./api/v1alpha1/... paths=./controller/... output:crd:artifacts:config=config/crd/bases output:rbac:artifacts:config=config/rbac
 
 ##@ Deployment
 # Same pattern as lightspeed-operator: `kustomize build config/crd | kubectl apply`

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - services
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - create
@@ -85,6 +94,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - consoleplugins
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - extensions.agents.x-k8s.io
   resources:
   - sandboxclaims
@@ -105,6 +130,13 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - consoles
+  verbs:
+  - get
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/controller/console/reconciler.go
+++ b/controller/console/reconciler.go
@@ -1,5 +1,12 @@
 package console
 
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;create;update
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;create;update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;create;update
+// +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;create;update
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;update
+
 import (
 	"context"
 	"fmt"

--- a/controller/sandbox/bootstrap.go
+++ b/controller/sandbox/bootstrap.go
@@ -1,5 +1,7 @@
 package sandbox
 
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create
+
 import (
 	"context"
 	"fmt"


### PR DESCRIPTION
This is a rebase of PR#81
The generated ClusterRole was missing permissions for core Kubernetes resources (ServiceAccounts, ConfigMaps, Services, Deployments) and OpenShift resources (ConsolePlugins, Consoles) that the operator creates at runtime. This was masked by cluster-admin in all current deployments.

Add +kubebuilder:rbac markers to controller/sandbox/bootstrap.go and controller/console/reconciler.go. Widen make manifests path from controller/proposal/... to controller/... so controller-gen picks up markers from all controller packages.

Verified on live cluster: operator now starts successfully under least-privilege RBAC with only the generated role.yaml (no cluster-admin).