### PR TITLE
quickstart: deploy agentic console plugin

### DIFF
--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -34,6 +34,7 @@ Skip the confirmation prompt with `QUICKSTART_FORCE=1`.
 | `NAMESPACE` | `openshift-lightspeed` | Target namespace |
 | `OPERATOR_IMAGE` | Konflux `:main` | Operator container image |
 | `SANDBOX_IMAGE` | Konflux `:main` | Agent sandbox container image |
+| `CONSOLE_IMAGE` | Konflux `:main` | Console plugin container image |
 | `SANDBOX_MODE` | `bare-pod` | Sandbox mode (`bare-pod` or `sandbox-claim`) |
 
 Example with overrides:

--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -34,7 +34,7 @@ Skip the confirmation prompt with `QUICKSTART_FORCE=1`.
 | `NAMESPACE` | `openshift-lightspeed` | Target namespace |
 | `OPERATOR_IMAGE` | Konflux `:main` | Operator container image |
 | `SANDBOX_IMAGE` | Konflux `:main` | Agent sandbox container image |
-| `CONSOLE_IMAGE` | Konflux `:main` | Console plugin container image |
+| `CONSOLE_IMAGE` | Konflux `:main` | Console plugin container image (requires OCP 4.21+; set `""` to skip) |
 | `SANDBOX_MODE` | `bare-pod` | Sandbox mode (`bare-pod` or `sandbox-claim`) |
 
 Example with overrides:

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -11,6 +11,9 @@
 #   - oc CLI on PATH
 #   - Logged into the target OpenShift cluster
 #   - cluster-admin privileges
+#
+# Note: The console plugin requires OpenShift 4.21+.
+#       Set CONSOLE_IMAGE="" to skip console deployment on older clusters.
 
 set -euo pipefail
 
@@ -203,11 +206,13 @@ cat <<DONE
 ════════════════════════════════════════════════════════════════
   Agentic OLS installed successfully!
 
-  Namespace:      ${NAMESPACE}
-  Sandbox mode:   ${SANDBOX_MODE}
+  Namespace     : ${NAMESPACE}
+  Sandbox mode  : ${SANDBOX_MODE}
   Operator image: ${OPERATOR_IMAGE}
-  Sandbox image:  ${SANDBOX_IMAGE}
-  Console image:  ${CONSOLE_IMAGE}
+  Sandbox image : ${SANDBOX_IMAGE}
+  Console image : ${CONSOLE_IMAGE}
+
+  > Console works only on OpenShift 4.21+
 ════════════════════════════════════════════════════════════════
 
   NEXT: Configure your LLM provider. Pick one:

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
 OPERATOR_IMAGE="${OPERATOR_IMAGE:-quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-operator:main}"
 SANDBOX_IMAGE="${SANDBOX_IMAGE:-quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-sandbox:main}"
+CONSOLE_IMAGE="${CONSOLE_IMAGE:-quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console:main}"
 SANDBOX_MODE="${SANDBOX_MODE:-bare-pod}"
 
 GITHUB_RAW="https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main"
@@ -118,6 +119,7 @@ spec:
         - "--namespace=${NAMESPACE}"
         - "--sandbox-mode=${SANDBOX_MODE}"
         - "--agentic-sandbox-image=${SANDBOX_IMAGE}"
+        - "--agentic-console-image=${CONSOLE_IMAGE}"
         ports:
         - name: metrics
           containerPort: 8080
@@ -205,6 +207,7 @@ cat <<DONE
   Sandbox mode:   ${SANDBOX_MODE}
   Operator image: ${OPERATOR_IMAGE}
   Sandbox image:  ${SANDBOX_IMAGE}
+  Console image:  ${CONSOLE_IMAGE}
 ════════════════════════════════════════════════════════════════
 
   NEXT: Configure your LLM provider. Pick one:
@@ -242,7 +245,7 @@ cat <<DONE
   # Check the analysis result:
   oc get analysisresult -n ${NAMESPACE} -o json
 
-  # Approve execution (option 0 = first option):
+  # Approve execution (option 0 = first option) via oc CLI or in console UI:
   oc patch proposalapproval namespace-inventory -n ${NAMESPACE} \\
     --type=json \\
     -p '[{"op":"add","path":"/spec/stages/-","value":{"type":"Execution","execution":{"option":0}}}]'


### PR DESCRIPTION
## Summary
- Pass `--agentic-console-image` to the operator deployment in `install.sh` so the console plugin is auto-deployed alongside the sandbox
- Add `CONSOLE_IMAGE` env var override (defaults to Konflux `:main` build)
- Update README with the new variable

The operator already handles the full console plugin lifecycle (ConfigMap, Service, Deployment, ConsolePlugin CR, Console activation) — this just wires the image into the quickstart.

## Test plan
- [ ] Run `install.sh` on a cluster and verify the console plugin deployment appears
- [ ] Verify the console plugin is registered and accessible in the OpenShift Console
- [ ] Verify `CONSOLE_IMAGE=""` skips console deployment (operator behavior)

Made with [Cursor](https://cursor.com)