### PR TITLE
OLS-3239: Standardize logging conventions

### DIFF
--- a/controller/console/reconciler.go
+++ b/controller/console/reconciler.go
@@ -60,6 +60,11 @@ http {
 `
 )
 
+const (
+	ErrEnsure       = "ensure"
+	ErrGetConsoleCR = "get Console CR"
+)
+
 type AgenticConsoleConfig struct {
 	Image     string
 	Namespace string
@@ -87,7 +92,7 @@ func EnsureAgenticConsole(ctx context.Context, c client.Client, cfg AgenticConso
 		{"ConsoleActivation", ensureConsoleActivation},
 	} {
 		if err := fn.fn(ctx, c, cfg); err != nil {
-			return fmt.Errorf("ensure %s: %w", fn.name, err)
+			return fmt.Errorf("%s %s: %w", ErrEnsure, fn.name, err)
 		}
 		log.V(1).Info("Resource ready", "resource", fn.name)
 	}
@@ -233,7 +238,7 @@ func ensureConsoleActivation(ctx context.Context, c client.Client, _ AgenticCons
 			if errors.IsNotFound(err) {
 				return fmt.Errorf("Console CR %q not found — OpenShift Console operator may not be installed", consoleCRName)
 			}
-			return fmt.Errorf("get Console CR: %w", err)
+			return fmt.Errorf("%s: %w", ErrGetConsoleCR, err)
 		}
 		if slices.Contains(console.Spec.Plugins, pluginName) {
 			return nil

--- a/controller/proposal/approval.go
+++ b/controller/proposal/approval.go
@@ -13,6 +13,12 @@ import (
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
 
+const (
+	ErrGetApprovalPolicy      = "get ApprovalPolicy"
+	ErrGetProposalApproval    = "get ProposalApproval"
+	ErrCreateProposalApproval = "create ProposalApproval"
+)
+
 func getApprovalPolicy(ctx context.Context, c client.Client) (*agenticv1alpha1.ApprovalPolicy, error) {
 	policy := &agenticv1alpha1.ApprovalPolicy{}
 	err := c.Get(ctx, types.NamespacedName{Name: "cluster"}, policy)
@@ -20,7 +26,7 @@ func getApprovalPolicy(ctx context.Context, c client.Client) (*agenticv1alpha1.A
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("get ApprovalPolicy: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrGetApprovalPolicy, err)
 	}
 	return policy, nil
 }
@@ -45,7 +51,7 @@ func ensureProposalApproval(
 		return existing, nil
 	}
 	if !apierrors.IsNotFound(err) {
-		return nil, fmt.Errorf("get ProposalApproval: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrGetProposalApproval, err)
 	}
 
 	var autoStages []agenticv1alpha1.ApprovalStage
@@ -99,7 +105,7 @@ func ensureProposalApproval(
 		if apierrors.IsAlreadyExists(err) {
 			return getProposalApproval(ctx, c, proposal)
 		}
-		return nil, fmt.Errorf("create ProposalApproval: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrCreateProposalApproval, err)
 	}
 	return approval, nil
 }
@@ -156,7 +162,7 @@ func getStageOverrideAgent(approval *agenticv1alpha1.ProposalApproval, stage age
 	return ""
 }
 
-func getStageOption(approval *agenticv1alpha1.ProposalApproval, policy *agenticv1alpha1.ApprovalPolicy) *int32 {
+func getStageOption(approval *agenticv1alpha1.ProposalApproval, _ *agenticv1alpha1.ApprovalPolicy) *int32 {
 	if approval != nil {
 		for _, s := range approval.Spec.Stages {
 			if s.Type == agenticv1alpha1.ApprovalStageExecution && s.Execution.Option != nil {

--- a/controller/proposal/bare_pod_manager.go
+++ b/controller/proposal/bare_pod_manager.go
@@ -15,6 +15,12 @@ import (
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
 
+const (
+	ErrBuildPodSpec = "build pod spec"
+	ErrCreatePod    = "create pod for"
+	ErrDeletePod    = "delete pod"
+)
+
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;delete
 
 // BarePodManager is a SandboxProvider that creates bare Pods using PodSpecBuilder
@@ -58,7 +64,7 @@ func (m *BarePodManager) Claim(ctx context.Context, proposalName, step, _ string
 
 	podSpec, err := m.Builder.Build(m.agent, m.llm, m.tools, step, m.serviceAccount)
 	if err != nil {
-		return "", fmt.Errorf("build pod spec: %w", err)
+		return "", fmt.Errorf("%s: %w", ErrBuildPodSpec, err)
 	}
 
 	pod := &corev1.Pod{
@@ -77,10 +83,10 @@ func (m *BarePodManager) Claim(ctx context.Context, proposalName, step, _ string
 		if apierrors.IsAlreadyExists(err) {
 			return podName, nil
 		}
-		return "", fmt.Errorf("create pod for %s: %w", step, err)
+		return "", fmt.Errorf("%s %s: %w", ErrCreatePod, step, err)
 	}
 
-	log.Info("Created bare pod", "name", podName, "step", step)
+	log.Info("Created bare pod", LogKeyName, podName, LogKeyStep, step)
 	return podName, nil
 }
 
@@ -106,7 +112,7 @@ func (m *BarePodManager) WaitReady(ctx context.Context, podName string, timeout 
 
 			var pod corev1.Pod
 			if err := m.Client.Get(ctx, key, &pod); err != nil {
-				log.V(1).Info("Waiting for pod", "name", podName)
+				log.V(1).Info("Waiting for pod", LogKeyName, podName)
 				continue
 			}
 
@@ -115,7 +121,7 @@ func (m *BarePodManager) WaitReady(ctx context.Context, podName string, timeout 
 					if pod.Status.PodIP == "" {
 						continue
 					}
-					log.Info("Pod ready", "name", podName, "podIP", pod.Status.PodIP)
+					log.Info("Pod ready", LogKeyName, podName, "podIP", pod.Status.PodIP)
 					return pod.Status.PodIP, nil
 				}
 			}
@@ -139,9 +145,9 @@ func (m *BarePodManager) Release(ctx context.Context, podName string) error {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("delete pod %q: %w", podName, err)
+		return fmt.Errorf("%s %q: %w", ErrDeletePod, podName, err)
 	}
 
-	log.Info("Released bare pod", "name", podName)
+	log.Info("Released bare pod", LogKeyName, podName)
 	return nil
 }

--- a/controller/proposal/client.go
+++ b/controller/proposal/client.go
@@ -17,6 +17,11 @@ const (
 	maxErrorBodyLen = 500
 	maxResponseSize = 2 << 20 // 2 MiB
 	runPath         = "/v1/agent/run"
+
+	ErrMarshalRequest    = "failed to marshal request"
+	ErrCreateHTTPRequest = "failed to create HTTP request"
+	ErrPost              = "POST"
+	ErrReadResponseBody  = "failed to read response body"
 )
 
 type agentRunRequest struct {
@@ -96,24 +101,24 @@ func (c *AgentHTTPClient) Run(ctx context.Context, systemPrompt, query string, o
 
 	body, err := json.Marshal(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrMarshalRequest, err)
 	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+runPath, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrCreateHTTPRequest, err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("POST %s failed: %w", runPath, err)
+		return nil, fmt.Errorf("%s %s failed: %w", ErrPost, runPath, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrReadResponseBody, err)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/controller/proposal/handlers.go
+++ b/controller/proposal/handlers.go
@@ -4,44 +4,71 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+const (
+	ErrUpdateToAnalyzing         = "update to Analyzing"
+	ErrCreateAnalysisResult      = "create analysis result"
+	ErrUpdateAfterAnalysis       = "update after analysis"
+	ErrUpdateToAnalyzingRevision = "update to Analyzing (revision)"
+	ErrUpdateAfterRevision       = "update after revision"
+	ErrUpdateToCompletedAdvisory = "update to Completed (advisory)"
+	ErrUpdateAfterExecSkip       = "update after execution skip"
+	ErrEnsureExecutionRBAC       = "ensure execution RBAC"
+	ErrPersistRBACAnnotation     = "persist RBAC annotation"
+	ErrUpdateToExecuting         = "update to Executing"
+	ErrCreateExecutionResult     = "create execution result"
+	ErrUpdateToCompletedTrust    = "update to Completed (trust-mode)"
+	ErrUpdateToVerifying         = "update to Verifying"
+	ErrResolveSelectedOption     = "resolve selected option"
+	ErrCreateVerificationResult  = "create verification result"
+	ErrUpdateForExecRetry        = "update for execution retry"
+	ErrUpdateRetriesExhausted    = "update (retries exhausted)"
+	ErrUpdateToCompleted         = "update to Completed"
+	ErrGetOverrideAgent          = "get override Agent"
+	ErrGetEscalationLLMProvider  = "get LLMProvider"
+	ErrUpdateToEscalating        = "update to Escalating"
+	ErrCreateEscalationResult    = "create escalation result"
+	ErrUpdateToEscalated         = "update to Escalated"
+	ErrUpdateToDenied            = "update to Denied"
 )
 
 // handleAnalysis checks approval for the analysis step and runs it.
 func (r *ProposalReconciler) handleAnalysis(
 	ctx context.Context,
-	log logr.Logger,
 	proposal *agenticv1alpha1.Proposal,
 	resolved *resolvedWorkflow,
 	approval *agenticv1alpha1.ProposalApproval,
 	policy *agenticv1alpha1.ApprovalPolicy,
 ) (ctrl.Result, error) {
-	log.Info("handling analysis")
+	log := logf.FromContext(ctx)
+	log.V(1).Info("handling analysis")
 
 	if isStageDenied(approval, agenticv1alpha1.SandboxStepAnalysis) {
-		return r.denyProposal(ctx, log, proposal, "Analysis denied by user")
+		return r.denyProposal(ctx, proposal, "Analysis denied by user")
 	}
 
 	if !isStageApproved(approval, policy, agenticv1alpha1.SandboxStepAnalysis) {
-		log.Info("analysis pending approval")
+		log.V(1).Info("analysis pending approval")
 		return ctrl.Result{}, nil
 	}
 
 	analyzed := meta.FindStatusCondition(proposal.Status.Conditions, agenticv1alpha1.ProposalConditionAnalyzed)
 	if analyzed != nil {
 		if analyzed.Status == metav1.ConditionUnknown {
-			log.Info("analysis already in progress, waiting")
+			log.V(1).Info("analysis already in progress, waiting")
 			return ctrl.Result{}, nil
 		}
 		if analyzed.Status == metav1.ConditionTrue {
-			log.Info("analysis already completed")
+			log.V(1).Info("analysis already completed")
 			return ctrl.Result{}, nil
 		}
 	}
@@ -55,22 +82,22 @@ func (r *ProposalReconciler) handleAnalysis(
 		ObservedGeneration: proposal.Generation,
 	})
 	if err := r.statusPatch(ctx, proposal, base); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update to Analyzing: %w", err)
+		return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateToAnalyzing, err)
 	}
 
 	analysisResult, err := r.Agent.Analyze(ctx, proposal, resolved.Analysis, proposal.Spec.Request, defaultSandboxSA)
 	if err != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionAnalyzed, err)
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionAnalyzed, err)
 	}
 	if !analysisResult.Success {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionAnalyzed, fmt.Errorf("analysis agent reported failure"))
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionAnalyzed, fmt.Errorf("analysis agent reported failure"))
 	}
 	base = proposal.DeepCopy()
 	completedAt := metav1.Now()
 	startTime := conditionTime(proposal.Status.Conditions, agenticv1alpha1.ProposalConditionAnalyzed)
 	crName, crErr := r.createAnalysisResult(ctx, proposal, analysisResult, proposal.Status.Steps.Analysis.Sandbox, startTime, &completedAt, "")
 	if crErr != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionAnalyzed, fmt.Errorf("create analysis result: %w", crErr))
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionAnalyzed, fmt.Errorf("%s: %w", ErrCreateAnalysisResult, crErr))
 	}
 	proposal.Status.Steps.Analysis.Results = append(proposal.Status.Steps.Analysis.Results, agenticv1alpha1.StepResultRef{Name: crName, Outcome: agenticv1alpha1.ActionOutcomeFromBool(analysisResult.Success)})
 	meta.SetStatusCondition(&proposal.Status.Conditions, metav1.Condition{
@@ -81,7 +108,7 @@ func (r *ProposalReconciler) handleAnalysis(
 		ObservedGeneration: proposal.Generation,
 	})
 	if err := r.statusPatch(ctx, proposal, base); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update after analysis: %w", err)
+		return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateAfterAnalysis, err)
 	}
 
 	log.Info("analysis complete", "options", len(analysisResult.Options))
@@ -92,16 +119,16 @@ func (r *ProposalReconciler) handleAnalysis(
 // agent's system prompt.
 func (r *ProposalReconciler) handleRevision(
 	ctx context.Context,
-	log logr.Logger,
 	proposal *agenticv1alpha1.Proposal,
 	resolved *resolvedWorkflow,
 ) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
 	generation := proposal.Generation
-	log.Info("handling revision", "generation", generation)
+	log.V(1).Info("handling revision", "generation", generation)
 
 	analyzed := meta.FindStatusCondition(proposal.Status.Conditions, agenticv1alpha1.ProposalConditionAnalyzed)
 	if analyzed != nil && analyzed.Status == metav1.ConditionUnknown {
-		log.Info("revision already in progress, waiting")
+		log.V(1).Info("revision already in progress, waiting")
 		return ctrl.Result{}, nil
 	}
 
@@ -118,7 +145,7 @@ func (r *ProposalReconciler) handleRevision(
 		ObservedGeneration: proposal.Generation,
 	})
 	if err := r.statusPatch(ctx, proposal, base); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update to Analyzing (revision): %w", err)
+		return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateToAnalyzingRevision, err)
 	}
 
 	revisionSuffix := buildRevisionContext(proposal)
@@ -126,10 +153,10 @@ func (r *ProposalReconciler) handleRevision(
 
 	analysisResult, err := r.Agent.Analyze(ctx, proposal, resolved.Analysis, requestWithRevision, defaultSandboxSA)
 	if err != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionAnalyzed, err)
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionAnalyzed, err)
 	}
 	if !analysisResult.Success {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionAnalyzed, fmt.Errorf("analysis agent reported failure"))
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionAnalyzed, fmt.Errorf("analysis agent reported failure"))
 	}
 
 	base = proposal.DeepCopy()
@@ -137,7 +164,7 @@ func (r *ProposalReconciler) handleRevision(
 	startTime := conditionTime(proposal.Status.Conditions, agenticv1alpha1.ProposalConditionAnalyzed)
 	crName, crErr := r.createAnalysisResult(ctx, proposal, analysisResult, proposal.Status.Steps.Analysis.Sandbox, startTime, &completedAt, "")
 	if crErr != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionAnalyzed, fmt.Errorf("create analysis result: %w", crErr))
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionAnalyzed, fmt.Errorf("%s: %w", ErrCreateAnalysisResult, crErr))
 	}
 	proposal.Status.Steps.Analysis.Results = append(proposal.Status.Steps.Analysis.Results, agenticv1alpha1.StepResultRef{Name: crName, Outcome: agenticv1alpha1.ActionOutcomeFromBool(analysisResult.Success)})
 	meta.SetStatusCondition(&proposal.Status.Conditions, metav1.Condition{
@@ -148,7 +175,7 @@ func (r *ProposalReconciler) handleRevision(
 		ObservedGeneration: generation,
 	})
 	if err := r.statusPatch(ctx, proposal, base); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update after revision: %w", err)
+		return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateAfterRevision, err)
 	}
 
 	log.Info("revision analysis complete", "generation", generation, "options", len(analysisResult.Options))
@@ -158,13 +185,13 @@ func (r *ProposalReconciler) handleRevision(
 // handleExecution checks approval and runs execution (or skips if not configured).
 func (r *ProposalReconciler) handleExecution(
 	ctx context.Context,
-	log logr.Logger,
 	proposal *agenticv1alpha1.Proposal,
 	resolved *resolvedWorkflow,
 	approval *agenticv1alpha1.ProposalApproval,
 	policy *agenticv1alpha1.ApprovalPolicy,
 ) (ctrl.Result, error) {
-	log.Info("handling execution")
+	log := logf.FromContext(ctx)
+	log.V(1).Info("handling execution")
 
 	if resolved.Execution == nil {
 		base := proposal.DeepCopy()
@@ -179,42 +206,42 @@ func (r *ProposalReconciler) handleExecution(
 		if resolved.Verification == nil {
 			setVerificationSkipped(proposal)
 			if err := r.statusPatch(ctx, proposal, base); err != nil {
-				return ctrl.Result{}, fmt.Errorf("update to Completed (advisory): %w", err)
+				return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateToCompletedAdvisory, err)
 			}
 			log.Info("advisory-only — completed")
 			return ctrl.Result{}, nil
 		}
 
 		if err := r.statusPatch(ctx, proposal, base); err != nil {
-			return ctrl.Result{}, fmt.Errorf("update after execution skip: %w", err)
+			return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateAfterExecSkip, err)
 		}
 		return ctrl.Result{}, nil
 	}
 
 	if isStageDenied(approval, agenticv1alpha1.SandboxStepExecution) {
-		return r.denyProposal(ctx, log, proposal, "Execution denied by user")
+		return r.denyProposal(ctx, proposal, "Execution denied by user")
 	}
 
 	if !isStageApproved(approval, policy, agenticv1alpha1.SandboxStepExecution) {
-		log.Info("execution pending approval")
+		log.V(1).Info("execution pending approval")
 		return ctrl.Result{}, nil
 	}
 
 	executed := meta.FindStatusCondition(proposal.Status.Conditions, agenticv1alpha1.ProposalConditionExecuted)
 	if executed != nil {
 		if executed.Status == metav1.ConditionUnknown {
-			log.Info("execution already in progress, waiting")
+			log.V(1).Info("execution already in progress, waiting")
 			return ctrl.Result{}, nil
 		}
 		if executed.Status == metav1.ConditionTrue {
-			log.Info("execution already completed")
+			log.V(1).Info("execution already completed")
 			return ctrl.Result{}, nil
 		}
 	}
 
 	selectedOption, trimErr := r.trimNonSelectedOptions(ctx, proposal, approval, policy)
 	if trimErr != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionExecuted, trimErr)
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionExecuted, trimErr)
 	}
 
 	// Determine which SA the execution pod should run as.
@@ -222,10 +249,10 @@ func (r *ProposalReconciler) handleExecution(
 	base := proposal.DeepCopy()
 	if selectedOption != nil && (len(selectedOption.RBAC.NamespaceScoped) > 0 || len(selectedOption.RBAC.ClusterScoped) > 0) {
 		if err := ensureExecutionRBAC(ctx, r.Client, proposal, &selectedOption.RBAC, r.Namespace); err != nil {
-			return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionExecuted, fmt.Errorf("ensure execution RBAC: %w", err))
+			return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionExecuted, fmt.Errorf("%s: %w", ErrEnsureExecutionRBAC, err))
 		}
 		if err := r.Patch(ctx, proposal, client.MergeFrom(base)); err != nil {
-			return ctrl.Result{}, fmt.Errorf("persist RBAC annotation: %w", err)
+			return ctrl.Result{}, fmt.Errorf("%s: %w", ErrPersistRBACAnnotation, err)
 		}
 		base = proposal.DeepCopy()
 		execSA = executionSAName(proposal)
@@ -240,15 +267,15 @@ func (r *ProposalReconciler) handleExecution(
 		ObservedGeneration: proposal.Generation,
 	})
 	if err := r.statusPatch(ctx, proposal, base); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update to Executing: %w", err)
+		return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateToExecuting, err)
 	}
 
 	execResult, err := r.Agent.Execute(ctx, proposal, *resolved.Execution, selectedOption, execSA)
 	if err != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionExecuted, err)
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionExecuted, err)
 	}
 	if !execResult.Success {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionExecuted, fmt.Errorf("execution agent reported failure"))
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionExecuted, fmt.Errorf("execution agent reported failure"))
 	}
 
 	base = proposal.DeepCopy()
@@ -256,7 +283,7 @@ func (r *ProposalReconciler) handleExecution(
 	startTime := conditionTime(proposal.Status.Conditions, agenticv1alpha1.ProposalConditionExecuted)
 	execCRName, execCRErr := r.createExecutionResult(ctx, proposal, execResult, proposal.Status.Steps.Execution.Sandbox, startTime, &completedAt, "")
 	if execCRErr != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionExecuted, fmt.Errorf("create execution result: %w", execCRErr))
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionExecuted, fmt.Errorf("%s: %w", ErrCreateExecutionResult, execCRErr))
 	}
 	proposal.Status.Steps.Execution.Results = append(proposal.Status.Steps.Execution.Results, agenticv1alpha1.StepResultRef{Name: execCRName, Outcome: agenticv1alpha1.ActionOutcomeFromBool(execResult.Success)})
 	meta.SetStatusCondition(&proposal.Status.Conditions, metav1.Condition{
@@ -270,12 +297,12 @@ func (r *ProposalReconciler) handleExecution(
 	if resolved.Verification == nil {
 		setVerificationSkipped(proposal)
 		if err := r.statusPatch(ctx, proposal, base); err != nil {
-			return ctrl.Result{}, fmt.Errorf("update to Completed (trust-mode): %w", err)
+			return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateToCompletedTrust, err)
 		}
 		log.Info("execution complete, verification skipped")
 	} else {
 		if err := r.statusPatch(ctx, proposal, base); err != nil {
-			return ctrl.Result{}, fmt.Errorf("update to Verifying: %w", err)
+			return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateToVerifying, err)
 		}
 		log.Info("execution complete, verifying")
 	}
@@ -294,12 +321,12 @@ func (r *ProposalReconciler) handleExecution(
 // handleVerification checks approval and runs verification.
 func (r *ProposalReconciler) handleVerification(
 	ctx context.Context,
-	log logr.Logger,
 	proposal *agenticv1alpha1.Proposal,
 	resolved *resolvedWorkflow,
 	approval *agenticv1alpha1.ProposalApproval,
 	policy *agenticv1alpha1.ApprovalPolicy,
 ) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
 	// Retry execution RBAC cleanup if it failed during handleExecution transition.
 	// Always attempt — idempotent; covers both namespace-scoped and cluster-scoped-only cases.
 	if err := cleanupExecutionRBAC(ctx, r.Client, proposal, r.Namespace); err != nil {
@@ -320,17 +347,17 @@ func (r *ProposalReconciler) handleVerification(
 	}
 
 	if isStageDenied(approval, agenticv1alpha1.SandboxStepVerification) {
-		return r.denyProposal(ctx, log, proposal, "Verification denied by user")
+		return r.denyProposal(ctx, proposal, "Verification denied by user")
 	}
 
 	if !isStageApproved(approval, policy, agenticv1alpha1.SandboxStepVerification) {
-		log.Info("verification pending approval")
+		log.V(1).Info("verification pending approval")
 		return ctrl.Result{}, nil
 	}
 
 	verified := meta.FindStatusCondition(proposal.Status.Conditions, agenticv1alpha1.ProposalConditionVerified)
 	if verified != nil && verified.Status == metav1.ConditionUnknown {
-		log.Info("verification already in progress, waiting")
+		log.V(1).Info("verification already in progress, waiting")
 		return ctrl.Result{}, nil
 	}
 
@@ -344,7 +371,7 @@ func (r *ProposalReconciler) handleVerification(
 
 	selectedOption, selErr := r.selectedOption(ctx, proposal)
 	if selErr != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionVerified, fmt.Errorf("resolve selected option: %w", selErr))
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionVerified, fmt.Errorf("%s: %w", ErrResolveSelectedOption, selErr))
 	}
 
 	var execOutput *ExecutionOutput
@@ -362,7 +389,7 @@ func (r *ProposalReconciler) handleVerification(
 
 	verifyResult, err := r.Agent.Verify(ctx, proposal, *resolved.Verification, selectedOption, execOutput, defaultSandboxSA)
 	if err != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionVerified, err)
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionVerified, err)
 	}
 
 	base = proposal.DeepCopy()
@@ -370,7 +397,7 @@ func (r *ProposalReconciler) handleVerification(
 	startTime := conditionTime(proposal.Status.Conditions, agenticv1alpha1.ProposalConditionVerified)
 	verifyCRName, verifyCRErr := r.createVerificationResult(ctx, proposal, verifyResult, proposal.Status.Steps.Verification.Sandbox, startTime, &completedAt, "")
 	if verifyCRErr != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionVerified, fmt.Errorf("create verification result: %w", verifyCRErr))
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionVerified, fmt.Errorf("%s: %w", ErrCreateVerificationResult, verifyCRErr))
 	}
 	proposal.Status.Steps.Verification.Results = append(proposal.Status.Steps.Verification.Results, agenticv1alpha1.StepResultRef{Name: verifyCRName, Outcome: agenticv1alpha1.ActionOutcomeFromBool(verifyResult.Success)})
 
@@ -391,7 +418,7 @@ func (r *ProposalReconciler) handleVerification(
 
 		if int(retryCount) < maxRetries-1 {
 			next := retryCount + 1
-			log.Info("verification failed, retrying execution", "attempt", next+1, "maxAttempts", maxRetries, "summary", verifyResult.Summary)
+			log.Info("verification failed, retrying execution", "attempt", next+1, "maxAttempts", maxRetries, LogKeySummary, verifyResult.Summary)
 			proposal.Status.Steps.Execution.RetryCount = &next
 			resetExecutionAndVerification(&proposal.Status.Steps)
 			meta.RemoveStatusCondition(&proposal.Status.Conditions, agenticv1alpha1.ProposalConditionExecuted)
@@ -403,12 +430,12 @@ func (r *ProposalReconciler) handleVerification(
 				ObservedGeneration: proposal.Generation,
 			})
 			if err := r.statusPatch(ctx, proposal, base); err != nil {
-				return ctrl.Result{}, fmt.Errorf("update for execution retry: %w", err)
+				return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateForExecRetry, err)
 			}
 			return ctrl.Result{}, nil
 		}
 
-		log.Info("verification retries exhausted, escalating", "retryCount", retryCount, "summary", verifyResult.Summary)
+		log.Info("verification retries exhausted, escalating", "retryCount", retryCount, LogKeySummary, verifyResult.Summary)
 		meta.SetStatusCondition(&proposal.Status.Conditions, metav1.Condition{
 			Type:               agenticv1alpha1.ProposalConditionVerified,
 			Status:             metav1.ConditionFalse,
@@ -424,7 +451,7 @@ func (r *ProposalReconciler) handleVerification(
 			ObservedGeneration: proposal.Generation,
 		})
 		if err := r.statusPatch(ctx, proposal, base); err != nil {
-			return ctrl.Result{}, fmt.Errorf("update (retries exhausted): %w", err)
+			return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateRetriesExhausted, err)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -437,19 +464,19 @@ func (r *ProposalReconciler) handleVerification(
 		ObservedGeneration: proposal.Generation,
 	})
 	if err := r.statusPatch(ctx, proposal, base); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update to Completed: %w", err)
+		return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateToCompleted, err)
 	}
 
-	log.Info("verification passed", "summary", verifyResult.Summary)
+	log.Info("verification passed", LogKeySummary, verifyResult.Summary)
 	return ctrl.Result{}, nil
 }
 
 // handleFailed performs cleanup for system failures.
 func (r *ProposalReconciler) handleFailed(
 	ctx context.Context,
-	log logr.Logger,
 	proposal *agenticv1alpha1.Proposal,
 ) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
 	log.Info("handling system failure (terminal)")
 
 	if proposal.Annotations[rbacNamespacesAnnotation] != "" {
@@ -462,12 +489,12 @@ func (r *ProposalReconciler) handleFailed(
 
 func (r *ProposalReconciler) handleSuspension(
 	ctx context.Context,
-	log logr.Logger,
 	proposal *agenticv1alpha1.Proposal,
 ) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
 	phase := agenticv1alpha1.DerivePhase(proposal.Status.Conditions)
 
-	log.Info("terminating proposal due to system suspension", "phase", phase)
+	log.Info("terminating proposal due to system suspension", LogKeyPhase, phase)
 
 	if hasSandboxClaims(proposal) {
 		if err := r.Agent.ReleaseSandboxes(ctx, proposal); err != nil {
@@ -504,31 +531,31 @@ func (r *ProposalReconciler) handleSuspension(
 // step's agent by default (or an approval-time override).
 func (r *ProposalReconciler) handleEscalation(
 	ctx context.Context,
-	log logr.Logger,
 	proposal *agenticv1alpha1.Proposal,
 	resolved *resolvedWorkflow,
 	approval *agenticv1alpha1.ProposalApproval,
 	policy *agenticv1alpha1.ApprovalPolicy,
 ) (ctrl.Result, error) {
-	log.Info("handling escalation")
+	log := logf.FromContext(ctx)
+	log.V(1).Info("handling escalation")
 
 	if isStageDenied(approval, agenticv1alpha1.SandboxStepEscalation) {
-		return r.denyProposal(ctx, log, proposal, "Escalation denied by user")
+		return r.denyProposal(ctx, proposal, "Escalation denied by user")
 	}
 
 	if !isStageApproved(approval, policy, agenticv1alpha1.SandboxStepEscalation) {
-		log.Info("escalation pending approval")
+		log.V(1).Info("escalation pending approval")
 		return ctrl.Result{}, nil
 	}
 
 	escalated := meta.FindStatusCondition(proposal.Status.Conditions, agenticv1alpha1.ProposalConditionEscalated)
 	if escalated != nil {
 		if escalated.Status == metav1.ConditionUnknown && escalated.Reason == reasonInProgress {
-			log.Info("escalation already in progress, waiting")
+			log.V(1).Info("escalation already in progress, waiting")
 			return ctrl.Result{}, nil
 		}
 		if escalated.Status == metav1.ConditionTrue {
-			log.Info("escalation already completed")
+			log.V(1).Info("escalation already completed")
 			return ctrl.Result{}, nil
 		}
 	}
@@ -537,11 +564,11 @@ func (r *ProposalReconciler) handleEscalation(
 	if override := getStageOverrideAgent(approval, agenticv1alpha1.SandboxStepEscalation); override != "" {
 		var agent agenticv1alpha1.Agent
 		if err := r.Get(ctx, types.NamespacedName{Name: override}, &agent); err != nil {
-			return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionEscalated, fmt.Errorf("get override Agent %q: %w", override, err))
+			return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionEscalated, fmt.Errorf("%s %q: %w", ErrGetOverrideAgent, override, err))
 		}
 		var llm agenticv1alpha1.LLMProvider
 		if err := r.Get(ctx, types.NamespacedName{Name: agent.Spec.LLMProvider.Name}, &llm); err != nil {
-			return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionEscalated, fmt.Errorf("get LLMProvider %q: %w", agent.Spec.LLMProvider.Name, err))
+			return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionEscalated, fmt.Errorf("%s %q: %w", ErrGetEscalationLLMProvider, agent.Spec.LLMProvider.Name, err))
 		}
 		step = resolvedStep{Agent: &agent, LLM: &llm, Tools: step.Tools}
 	}
@@ -555,13 +582,13 @@ func (r *ProposalReconciler) handleEscalation(
 		ObservedGeneration: proposal.Generation,
 	})
 	if err := r.statusPatch(ctx, proposal, base); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update to Escalating: %w", err)
+		return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateToEscalating, err)
 	}
 
 	escalationText := buildEscalationRequest(proposal)
 	escalationResult, err := r.Agent.Escalate(ctx, proposal, step, escalationText, defaultSandboxSA)
 	if err != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionEscalated, err)
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionEscalated, err)
 	}
 
 	base = proposal.DeepCopy()
@@ -569,7 +596,7 @@ func (r *ProposalReconciler) handleEscalation(
 	startTime := conditionTime(proposal.Status.Conditions, agenticv1alpha1.ProposalConditionEscalated)
 	crName, crErr := r.createEscalationResult(ctx, proposal, escalationResult, proposal.Status.Steps.Escalation.Sandbox, startTime, &completedAt, "")
 	if crErr != nil {
-		return r.failStep(ctx, log, proposal, agenticv1alpha1.ProposalConditionEscalated, fmt.Errorf("create escalation result: %w", crErr))
+		return r.failStep(ctx, proposal, agenticv1alpha1.ProposalConditionEscalated, fmt.Errorf("%s: %w", ErrCreateEscalationResult, crErr))
 	}
 	proposal.Status.Steps.Escalation.Results = append(proposal.Status.Steps.Escalation.Results, agenticv1alpha1.StepResultRef{Name: crName, Outcome: agenticv1alpha1.ActionOutcomeFromBool(escalationResult.Success)})
 
@@ -587,10 +614,10 @@ func (r *ProposalReconciler) handleEscalation(
 		ObservedGeneration: proposal.Generation,
 	})
 	if err := r.statusPatch(ctx, proposal, base); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update to Escalated: %w", err)
+		return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateToEscalated, err)
 	}
 
-	log.Info("escalation complete", "summary", escalationResult.Summary)
+	log.Info("escalation complete", LogKeySummary, escalationResult.Summary)
 	return ctrl.Result{}, nil
 }
 
@@ -604,10 +631,10 @@ func conditionTime(conditions []metav1.Condition, condType string) *metav1.Time 
 // denyProposal transitions the proposal to Denied (terminal).
 func (r *ProposalReconciler) denyProposal(
 	ctx context.Context,
-	log logr.Logger,
 	proposal *agenticv1alpha1.Proposal,
 	message string,
 ) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
 	log.Info("denying proposal", "message", message)
 	base := proposal.DeepCopy()
 	meta.SetStatusCondition(&proposal.Status.Conditions, metav1.Condition{
@@ -618,7 +645,7 @@ func (r *ProposalReconciler) denyProposal(
 		ObservedGeneration: proposal.Generation,
 	})
 	if err := r.statusPatch(ctx, proposal, base); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update to Denied: %w", err)
+		return ctrl.Result{}, fmt.Errorf("%s: %w", ErrUpdateToDenied, err)
 	}
 	return ctrl.Result{}, nil
 }

--- a/controller/proposal/handlers_test.go
+++ b/controller/proposal/handlers_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-logr/logr"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -96,7 +95,7 @@ func TestReconcile_WorkflowVariants(t *testing.T) {
 				WithObjects(objs...).
 				WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-			r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
+			r := &ProposalReconciler{Client: fc, Agent: newTestAgentCaller(), Namespace: "default"}
 
 			if _, err := reconcileOnce(r, "fix-crash"); err != nil {
 				t.Fatalf("analysis reconcile: %v", err)
@@ -127,7 +126,7 @@ func TestReconcile_HappyPath_FullLifecycle(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Reconcile 1: Pending → Proposed (analysis complete)
 	result, err := reconcileOnce(r, "fix-crash")
@@ -215,7 +214,7 @@ func TestReconcile_AnalysisSystemFailure_Terminal(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Reconcile 1: Pending → Failed (system failure)
 	result, err := reconcileOnce(r, "fix-crash")
@@ -254,7 +253,7 @@ func TestReconcile_VerificationObjectiveFailure_RetriesExecution(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Analysis → approve → execution → verifying
 	reconcileOnce(r, "fix-crash")
@@ -320,7 +319,7 @@ func TestReconcile_SystemFailure_Execution_Terminal(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Analysis → approve
 	reconcileOnce(r, "fix-crash")
@@ -357,7 +356,7 @@ func TestReconcile_SystemFailure_Verification_Terminal(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Analysis → approve → execution → verifying
 	reconcileOnce(r, "fix-crash")
@@ -396,7 +395,7 @@ func TestReconcile_ObjectiveFailure_ThenRevise(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Full lifecycle to verification failure, retries exhausted → Analyzing
 	reconcileOnce(r, "fix-crash")
@@ -455,7 +454,7 @@ func TestReconcile_RevisionHappyPath(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Reconcile 1: Pending → Executing (analysis complete)
 	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
@@ -504,7 +503,7 @@ func TestReconcile_RevisionMultipleRounds(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Initial analysis
 	reconcileOnce(r, "fix-crash")
@@ -542,7 +541,7 @@ func TestReconcile_RevisionNoOp_WhenObserved(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Initial analysis
 	reconcileOnce(r, "fix-crash")
@@ -591,7 +590,7 @@ func TestReconcile_RevisionReanalysis(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Analysis → Executing
 	reconcileOnce(r, "fix-crash")
@@ -612,7 +611,7 @@ func TestReconcile_RevisionAnalysisFailure(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Initial analysis succeeds
 	reconcileOnce(r, "fix-crash")
@@ -655,7 +654,7 @@ func TestReconcile_RevisionWithFeedback(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Initial analysis
 	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
@@ -721,7 +720,7 @@ func TestReconcile_ExecutionRBACCreatedOnApproval(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Pending → Proposed (analysis complete)
 	reconcileOnce(r, "fix-crash")
@@ -798,7 +797,7 @@ func TestReconcile_ExecutionRBACCleanedOnFailure(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Analysis → approve
 	reconcileOnce(r, "fix-crash")
@@ -878,7 +877,7 @@ func TestFullLifecycle_WithSandboxAgent(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: sandboxAgent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: sandboxAgent, Namespace: "default"}
 
 	// Reconcile 1: Pending → Executing (via sandbox analysis)
 	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
@@ -980,7 +979,7 @@ func TestReconcile_ExecutingPhase_DoesNotReExecute(t *testing.T) {
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
 	agent := newTestAgentCaller()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Run analysis
 	reconcileOnce(r, "fix-crash")
@@ -1027,7 +1026,7 @@ func TestReconcile_ExecutionOutcomeFailed_FailsStep(t *testing.T) {
 		Success:      false,
 		ActionsTaken: []agenticv1alpha1.ExecutionAction{{Type: "patch", Description: "Failed patch", Outcome: agenticv1alpha1.ActionOutcomeFailed}},
 	}
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Analysis → Executing
 	reconcileOnce(r, "fix-crash")
@@ -1056,7 +1055,7 @@ func TestReconcile_VerificationOutcomeFailed_RetriesExecution(t *testing.T) {
 		Checks:  []agenticv1alpha1.VerifyCheck{{Name: "health", Result: agenticv1alpha1.CheckResultFailed}},
 		Summary: "Health check failed",
 	}
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Analysis → Executing → Approve → Execute → Verify (fail) → retry
 	reconcileOnce(r, "fix-crash")
@@ -1090,7 +1089,7 @@ func TestReconcile_ExecutionSelectsOption(t *testing.T) {
 			{Title: "Option C", Diagnosis: agenticv1alpha1.DiagnosisResult{Summary: "diag-C"}},
 		},
 	}
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Analysis
 	reconcileOnce(r, "fix-crash")
@@ -1133,7 +1132,7 @@ func TestReconcile_ExecutionSingleOption(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: newTestAgentCaller(), Namespace: "default"}
 
 	// Analysis (default stub returns 1 option)
 	reconcileOnce(r, "fix-crash")
@@ -1172,7 +1171,7 @@ func TestReconcile_TrimOptionsOnExecution(t *testing.T) {
 		Checks:  []agenticv1alpha1.VerifyCheck{{Name: "health", Result: agenticv1alpha1.CheckResultFailed}},
 		Summary: "Health check failed",
 	}
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Analysis
 	reconcileOnce(r, "fix-crash")
@@ -1265,7 +1264,7 @@ func TestResultCR_FailureConditions(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	reconcileOnce(r, "fix-crash")
 	p, _ := getProposal(r, "fix-crash")

--- a/controller/proposal/helpers.go
+++ b/controller/proposal/helpers.go
@@ -9,12 +9,12 @@ import (
 	"reflect"
 	"text/template"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
@@ -33,6 +33,9 @@ func renderTemplate(name string, data any) string {
 }
 
 const (
+	ErrGetAnalysisResult         = "get AnalysisResult"
+	ErrTrimAnalysisResultOptions = "trim AnalysisResult options"
+
 	rbacCleanupFinalizer = "agentic.openshift.io/execution-rbac-cleanup"
 
 	reasonInProgress        = "InProgress"
@@ -41,8 +44,6 @@ const (
 	reasonSkipped           = "Skipped"
 	reasonPassed            = "Passed"
 	reasonWorkflowFailed    = "WorkflowResolutionFailed"
-	reasonPendingApproval   = "PendingApproval"
-	reasonAutoApproved      = "AutoApproved"
 	reasonUserDenied        = "UserDenied"
 	defaultSandboxSA        = "lightspeed-agent"
 	reasonRevising          = "Revising"
@@ -50,6 +51,14 @@ const (
 	reasonRetryingExecution = agenticv1alpha1.ReasonRetryingExecution
 	reasonRetriesExhausted  = agenticv1alpha1.ReasonRetriesExhausted
 	reasonSystemSuspended   = "SystemSuspended"
+
+	LogKeyName      = "name"
+	LogKeyStep      = "step"
+	LogKeyPhase     = "phase"
+	LogKeyClaim     = "claimName"
+	LogKeyTemplate  = "template"
+	LogKeySummary   = "summary"
+	LogKeyCondition = "condition"
 )
 
 func isSuspended(ctx context.Context, c client.Client) (bool, error) {
@@ -66,8 +75,9 @@ func isSuspended(ctx context.Context, c client.Client) (bool, error) {
 // failStep marks a step as failed and creates a failure result CR.
 // The caller must have set the step condition to ConditionUnknown before
 // calling failStep so that conditionTime can extract the start time.
-func (r *ProposalReconciler) failStep(ctx context.Context, log logr.Logger, proposal *agenticv1alpha1.Proposal, conditionType string, err error) (ctrl.Result, error) {
-	log.Error(err, "step failed", "condition", conditionType)
+func (r *ProposalReconciler) failStep(ctx context.Context, proposal *agenticv1alpha1.Proposal, conditionType string, err error) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	log.Error(err, "step failed", LogKeyCondition, conditionType)
 	base := proposal.DeepCopy()
 	completedAt := metav1.Now()
 	startTime := conditionTime(proposal.Status.Conditions, conditionType)
@@ -150,7 +160,7 @@ func (r *ProposalReconciler) getLatestAnalysisResult(ctx context.Context, propos
 	latestRef := analysis.Results[len(analysis.Results)-1]
 	var result agenticv1alpha1.AnalysisResult
 	if err := r.Get(ctx, types.NamespacedName{Name: latestRef.Name, Namespace: proposal.Namespace}, &result); err != nil {
-		return nil, fmt.Errorf("get AnalysisResult %s: %w", latestRef.Name, err)
+		return nil, fmt.Errorf("%s %s: %w", ErrGetAnalysisResult, latestRef.Name, err)
 	}
 	return &result, nil
 }
@@ -191,7 +201,7 @@ func (r *ProposalReconciler) trimNonSelectedOptions(ctx context.Context, proposa
 	base := result.DeepCopy()
 	result.Status.Options = []agenticv1alpha1.RemediationOption{selected}
 	if err := r.Status().Patch(ctx, result, client.MergeFrom(base)); err != nil {
-		return nil, fmt.Errorf("trim AnalysisResult options: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrTrimAnalysisResultOptions, err)
 	}
 	return &result.Status.Options[0], nil
 }

--- a/controller/proposal/helpers_test.go
+++ b/controller/proposal/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -82,7 +81,7 @@ func TestSelectedOption_ReturnsFirstOption(t *testing.T) {
 	}
 
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(analysisResult).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Namespace: "default"}
 
 	got, err := r.selectedOption(context.Background(), proposal)
 	if err != nil {
@@ -104,7 +103,7 @@ func TestSelectedOption_NoResults(t *testing.T) {
 	proposal.Namespace = "default"
 
 	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Namespace: "default"}
 
 	got, err := r.selectedOption(context.Background(), proposal)
 	if err != nil {
@@ -140,7 +139,7 @@ func TestTrimNonSelectedOptions_SingleOptionNoop(t *testing.T) {
 	}
 
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(analysisResult).WithStatusSubresource(analysisResult).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Namespace: "default"}
 
 	got, err := r.trimNonSelectedOptions(context.Background(), proposal, approval, nil)
 	if err != nil {
@@ -189,7 +188,7 @@ func TestTrimThenSelectedOption_EndToEnd(t *testing.T) {
 			}
 
 			fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(analysisResult).WithStatusSubresource(analysisResult).Build()
-			r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Namespace: "default"}
+			r := &ProposalReconciler{Client: fc, Namespace: "default"}
 
 			got, err := r.trimNonSelectedOptions(context.Background(), proposal, approval, nil)
 			if err != nil {
@@ -276,7 +275,7 @@ func TestTrimNonSelectedOptions_OutOfRange(t *testing.T) {
 	}
 
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(analysisResult).WithStatusSubresource(analysisResult).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Namespace: "default"}
 
 	_, err := r.trimNonSelectedOptions(context.Background(), proposal, approval, nil)
 	if err == nil {

--- a/controller/proposal/podspec_builder.go
+++ b/controller/proposal/podspec_builder.go
@@ -13,6 +13,11 @@ import (
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
 
+const (
+	ErrBuildMCPServers        = "build MCP servers"
+	ErrMarshalMCPServerConfig = "marshal MCP server config"
+)
+
 type PodSpecBuilder struct {
 	Image           string
 	ImagePullPolicy string
@@ -102,7 +107,7 @@ func (b *PodSpecBuilder) Build(
 	if tools != nil && len(tools.MCPServers) > 0 {
 		mcpVols, mcpMounts, mcpEnv, err := b.buildMCPServers(tools.MCPServers)
 		if err != nil {
-			return nil, fmt.Errorf("build MCP servers: %w", err)
+			return nil, fmt.Errorf("%s: %w", ErrBuildMCPServers, err)
 		}
 		volumes = append(volumes, mcpVols...)
 		container.VolumeMounts = append(container.VolumeMounts, mcpMounts...)
@@ -235,7 +240,7 @@ func (b *PodSpecBuilder) buildMCPServers(servers []agenticv1alpha1.MCPServerConf
 
 	data, err := json.Marshal(entries)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("marshal MCP server config: %w", err)
+		return nil, nil, nil, fmt.Errorf("%s: %w", ErrMarshalMCPServerConfig, err)
 	}
 
 	envs := []corev1.EnvVar{{Name: mcpServersEnvVar, Value: string(data)}}

--- a/controller/proposal/rbac.go
+++ b/controller/proposal/rbac.go
@@ -16,6 +16,17 @@ import (
 
 const (
 	rbacNamespacesAnnotation = "agentic.openshift.io/rbac-namespaces"
+
+	ErrCreateExecutionSA        = "create execution SA"
+	ErrCreateRole               = "create Role in"
+	ErrCreateRoleBinding        = "create RoleBinding in"
+	ErrCreateClusterRole        = "create ClusterRole"
+	ErrCreateClusterRoleBinding = "create ClusterRoleBinding"
+	ErrDeleteRoleBinding        = "delete RoleBinding in"
+	ErrDeleteRole               = "delete Role in"
+	ErrDeleteClusterRoleBinding = "delete ClusterRoleBinding"
+	ErrDeleteClusterRole        = "delete ClusterRole"
+	ErrDeleteExecutionSA        = "delete execution SA"
 )
 
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;delete;get
@@ -41,7 +52,7 @@ func ensureExecutionSA(ctx context.Context, c client.Client, proposal *agenticv1
 		},
 	}
 	if err := c.Create(ctx, sa); err != nil && !apierrors.IsAlreadyExists(err) {
-		return "", fmt.Errorf("create execution SA %s: %w", saName, err)
+		return "", fmt.Errorf("%s %s: %w", ErrCreateExecutionSA, saName, err)
 	}
 	return saName, nil
 }
@@ -98,7 +109,7 @@ func ensureExecutionRBAC(
 				Rules:      nsRules,
 			}
 			if err := c.Create(ctx, role); err != nil && !apierrors.IsAlreadyExists(err) {
-				return fmt.Errorf("create Role in %s: %w", ns, err)
+				return fmt.Errorf("%s %s: %w", ErrCreateRole, ns, err)
 			}
 			binding := &rbacv1.RoleBinding{
 				ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: ns, Labels: labels},
@@ -106,7 +117,7 @@ func ensureExecutionRBAC(
 				Subjects:   subjects,
 			}
 			if err := c.Create(ctx, binding); err != nil && !apierrors.IsAlreadyExists(err) {
-				return fmt.Errorf("create RoleBinding in %s: %w", ns, err)
+				return fmt.Errorf("%s %s: %w", ErrCreateRoleBinding, ns, err)
 			}
 		}
 	}
@@ -119,7 +130,7 @@ func ensureExecutionRBAC(
 			Rules:      clusterRules,
 		}
 		if err := c.Create(ctx, cr); err != nil && !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("create ClusterRole %s: %w", crName, err)
+			return fmt.Errorf("%s %s: %w", ErrCreateClusterRole, crName, err)
 		}
 		crb := &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{Name: crName, Labels: labels},
@@ -127,7 +138,7 @@ func ensureExecutionRBAC(
 			Subjects:   subjects,
 		}
 		if err := c.Create(ctx, crb); err != nil && !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("create ClusterRoleBinding %s: %w", crName, err)
+			return fmt.Errorf("%s %s: %w", ErrCreateClusterRoleBinding, crName, err)
 		}
 	}
 
@@ -143,23 +154,23 @@ func cleanupExecutionRBAC(ctx context.Context, c client.Client, proposal *agenti
 
 	for _, ns := range nsList {
 		if err := deleteIfExists(ctx, c, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: ns}}); err != nil {
-			return fmt.Errorf("delete RoleBinding in %s: %w", ns, err)
+			return fmt.Errorf("%s %s: %w", ErrDeleteRoleBinding, ns, err)
 		}
 		if err := deleteIfExists(ctx, c, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: ns}}); err != nil {
-			return fmt.Errorf("delete Role in %s: %w", ns, err)
+			return fmt.Errorf("%s %s: %w", ErrDeleteRole, ns, err)
 		}
 	}
 
 	crName := clusterRoleName(proposal.Name)
 	if err := deleteIfExists(ctx, c, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: crName}}); err != nil {
-		return fmt.Errorf("delete ClusterRoleBinding %s: %w", crName, err)
+		return fmt.Errorf("%s %s: %w", ErrDeleteClusterRoleBinding, crName, err)
 	}
 	if err := deleteIfExists(ctx, c, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: crName}}); err != nil {
-		return fmt.Errorf("delete ClusterRole %s: %w", crName, err)
+		return fmt.Errorf("%s %s: %w", ErrDeleteClusterRole, crName, err)
 	}
 
 	if err := deleteExecutionSA(ctx, c, proposal, operatorNS); err != nil {
-		return fmt.Errorf("delete execution SA: %w", err)
+		return fmt.Errorf("%s: %w", ErrDeleteExecutionSA, err)
 	}
 	return nil
 }

--- a/controller/proposal/reconciler.go
+++ b/controller/proposal/reconciler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -12,8 +11,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+const (
+	ErrRemoveFinalizer = "remove finalizer"
+	ErrAddFinalizer    = "add finalizer"
 )
 
 // ProposalReconciler reconciles Proposal objects.
@@ -21,7 +26,6 @@ import (
 // Agent must be set before calling SetupWithManager.
 type ProposalReconciler struct {
 	client.Client
-	Log       logr.Logger
 	Agent     AgentCaller
 	Namespace string
 }
@@ -44,7 +48,7 @@ type ProposalReconciler struct {
 // +kubebuilder:rbac:groups=agentic.openshift.io,resources=agenticolsconfigs,verbs=get;list;watch
 
 func (r *ProposalReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("proposal", req.NamespacedName)
+	log := logf.FromContext(ctx)
 
 	var proposal agenticv1alpha1.Proposal
 	if err := r.Get(ctx, req.NamespacedName, &proposal); err != nil {
@@ -58,17 +62,15 @@ func (r *ProposalReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// orphaned sandbox pods/claims. Trade-off: if sandbox API is permanently down,
 			// the Proposal stays in Terminating until resolved (or finalizer is manually removed).
 			if err := r.Agent.ReleaseSandboxes(ctx, &proposal); err != nil {
-				log.Error(err, "sandbox cleanup failed during deletion, retrying")
 				return ctrl.Result{}, err
 			}
 			if err := cleanupExecutionRBAC(ctx, r.Client, &proposal, r.Namespace); err != nil {
-				log.Error(err, "RBAC cleanup failed, retrying")
 				return ctrl.Result{}, err
 			}
 			original := proposal.DeepCopy()
 			controllerutil.RemoveFinalizer(&proposal, rbacCleanupFinalizer)
 			if err := r.Patch(ctx, &proposal, client.MergeFrom(original)); err != nil {
-				return ctrl.Result{}, fmt.Errorf("remove finalizer: %w", err)
+				return ctrl.Result{}, fmt.Errorf("%s: %w", ErrRemoveFinalizer, err)
 			}
 		}
 		return ctrl.Result{}, nil
@@ -80,7 +82,7 @@ func (r *ProposalReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 	if suspended {
-		return r.handleSuspension(ctx, log, &proposal)
+		return r.handleSuspension(ctx, &proposal)
 	}
 
 	phase := agenticv1alpha1.DerivePhase(proposal.Status.Conditions)
@@ -91,7 +93,7 @@ func (r *ProposalReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			original := proposal.DeepCopy()
 			controllerutil.AddFinalizer(&proposal, rbacCleanupFinalizer)
 			if err := r.Patch(ctx, &proposal, client.MergeFrom(original)); err != nil {
-				return ctrl.Result{}, fmt.Errorf("add finalizer: %w", err)
+				return ctrl.Result{}, fmt.Errorf("%s: %w", ErrAddFinalizer, err)
 			}
 			if err := r.Get(ctx, req.NamespacedName, &proposal); err != nil {
 				return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -113,7 +115,7 @@ func (r *ProposalReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 
 	case agenticv1alpha1.ProposalPhaseFailed:
-		return r.handleFailed(ctx, log, &proposal)
+		return r.handleFailed(ctx, &proposal)
 	}
 
 	// --- Ensure ProposalApproval exists ---
@@ -146,33 +148,33 @@ func (r *ProposalReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
-	log.Info("reconciling", "phase", phase)
+	log.V(1).Info("reconciling", LogKeyPhase, phase)
 
 	// --- Phase routing ---
 	switch phase {
 	case agenticv1alpha1.ProposalPhasePending, agenticv1alpha1.ProposalPhaseAnalyzing:
 		if needsRevision(&proposal) {
-			return r.handleRevision(ctx, log, &proposal, resolved)
+			return r.handleRevision(ctx, &proposal, resolved)
 		}
-		return r.handleAnalysis(ctx, log, &proposal, resolved, approval, policy)
+		return r.handleAnalysis(ctx, &proposal, resolved, approval, policy)
 
 	case agenticv1alpha1.ProposalPhaseProposed, agenticv1alpha1.ProposalPhaseExecuting:
 		if needsRevision(&proposal) {
-			return r.handleRevision(ctx, log, &proposal, resolved)
+			return r.handleRevision(ctx, &proposal, resolved)
 		}
-		return r.handleExecution(ctx, log, &proposal, resolved, approval, policy)
+		return r.handleExecution(ctx, &proposal, resolved, approval, policy)
 
 	case agenticv1alpha1.ProposalPhaseVerifying:
-		return r.handleVerification(ctx, log, &proposal, resolved, approval, policy)
+		return r.handleVerification(ctx, &proposal, resolved, approval, policy)
 
 	case agenticv1alpha1.ProposalPhaseEscalating:
 		if needsRevision(&proposal) {
-			return r.handleRevision(ctx, log, &proposal, resolved)
+			return r.handleRevision(ctx, &proposal, resolved)
 		}
-		return r.handleEscalation(ctx, log, &proposal, resolved, approval, policy)
+		return r.handleEscalation(ctx, &proposal, resolved, approval, policy)
 
 	default:
-		log.Info("unhandled phase, no-op", "phase", phase)
+		log.V(1).Info("unhandled phase, no-op", LogKeyPhase, phase)
 		return ctrl.Result{}, nil
 	}
 }

--- a/controller/proposal/reconciler_test.go
+++ b/controller/proposal/reconciler_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -279,7 +278,7 @@ func TestReconcile_StatusInitialization(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
 
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: newTestAgentCaller(), Namespace: "default"}
 
 	_, err := reconcileOnce(r, "fresh")
 	if err != nil {
@@ -305,7 +304,7 @@ func TestReconcile_Denied_Terminal(t *testing.T) {
 	}
 
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(proposal).WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: newTestAgentCaller(), Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: newTestAgentCaller(), Namespace: "default"}
 
 	result, err := reconcileOnce(r, "fix-crash")
 	if err != nil {
@@ -336,7 +335,6 @@ func TestReconcileSuspension(t *testing.T) {
 			Build()
 		r := &ProposalReconciler{
 			Client:    fc,
-			Log:       logr.Discard(),
 			Agent:     newTestAgentCaller(),
 			Namespace: "default",
 		}
@@ -365,7 +363,6 @@ func TestReconcileSuspension(t *testing.T) {
 			Build()
 		r := &ProposalReconciler{
 			Client:    fc,
-			Log:       logr.Discard(),
 			Agent:     newTestAgentCaller(),
 			Namespace: "default",
 		}
@@ -390,7 +387,6 @@ func TestReconcileSuspension(t *testing.T) {
 			Build()
 		r := &ProposalReconciler{
 			Client:    fc,
-			Log:       logr.Discard(),
 			Agent:     newTestAgentCaller(),
 			Namespace: "default",
 		}
@@ -420,7 +416,6 @@ func TestReconcileSuspension(t *testing.T) {
 			Build()
 		r := &ProposalReconciler{
 			Client:    fc,
-			Log:       logr.Discard(),
 			Agent:     newTestAgentCaller(),
 			Namespace: "default",
 		}
@@ -472,11 +467,10 @@ func TestHandleSuspension(t *testing.T) {
 				Build()
 			r := &ProposalReconciler{
 				Client:    fc,
-				Log:       logr.Discard(),
 				Agent:     newTestAgentCaller(),
 				Namespace: "default",
 			}
-			_, err := r.handleSuspension(context.Background(), logr.Discard(), tt.proposal)
+			_, err := r.handleSuspension(context.Background(), tt.proposal)
 			if err != nil {
 				t.Fatalf("handleSuspension() error: %v", err)
 			}

--- a/controller/proposal/resolve.go
+++ b/controller/proposal/resolve.go
@@ -10,6 +10,14 @@ import (
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
 
+const (
+	ErrGetAgent                = "get Agent"
+	ErrGetLLMProvider          = "get LLMProvider"
+	ErrResolveAnalysisStep     = "resolve analysis step"
+	ErrResolveExecutionStep    = "resolve execution step"
+	ErrResolveVerificationStep = "resolve verification step"
+)
+
 type resolvedStep struct {
 	Agent *agenticv1alpha1.Agent
 	LLM   *agenticv1alpha1.LLMProvider
@@ -34,7 +42,7 @@ func resolveProposal(ctx context.Context, c client.Client, proposal *agenticv1al
 		if !ok {
 			agent = &agenticv1alpha1.Agent{}
 			if err := c.Get(ctx, types.NamespacedName{Name: agentName}, agent); err != nil {
-				return nil, nil, fmt.Errorf("get Agent %q: %w", agentName, err)
+				return nil, nil, fmt.Errorf("%s %q: %w", ErrGetAgent, agentName, err)
 			}
 			agentCache[agentName] = agent
 		}
@@ -44,7 +52,7 @@ func resolveProposal(ctx context.Context, c client.Client, proposal *agenticv1al
 		if !ok {
 			llm = &agenticv1alpha1.LLMProvider{}
 			if err := c.Get(ctx, types.NamespacedName{Name: llmName}, llm); err != nil {
-				return nil, nil, fmt.Errorf("get LLMProvider %q (referenced by Agent %q): %w", llmName, agentName, err)
+				return nil, nil, fmt.Errorf("%s %q (referenced by Agent %q): %w", ErrGetLLMProvider, llmName, agentName, err)
 			}
 			llmCache[llmName] = llm
 		}
@@ -70,14 +78,14 @@ func resolveProposal(ctx context.Context, c client.Client, proposal *agenticv1al
 
 	agent, llm, err := resolveAgent(effectiveAgent(agenticv1alpha1.SandboxStepAnalysis, proposal.Spec.Analysis))
 	if err != nil {
-		return nil, fmt.Errorf("resolve analysis step: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrResolveAnalysisStep, err)
 	}
 	resolved.Analysis = resolvedStep{Agent: agent, LLM: llm, Tools: toolsForStep(proposal.Spec.Analysis)}
 
 	if !proposal.Spec.Execution.IsZero() {
 		agent, llm, err := resolveAgent(effectiveAgent(agenticv1alpha1.SandboxStepExecution, proposal.Spec.Execution))
 		if err != nil {
-			return nil, fmt.Errorf("resolve execution step: %w", err)
+			return nil, fmt.Errorf("%s: %w", ErrResolveExecutionStep, err)
 		}
 		resolved.Execution = &resolvedStep{Agent: agent, LLM: llm, Tools: toolsForStep(proposal.Spec.Execution)}
 	}
@@ -85,7 +93,7 @@ func resolveProposal(ctx context.Context, c client.Client, proposal *agenticv1al
 	if !proposal.Spec.Verification.IsZero() {
 		agent, llm, err := resolveAgent(effectiveAgent(agenticv1alpha1.SandboxStepVerification, proposal.Spec.Verification))
 		if err != nil {
-			return nil, fmt.Errorf("resolve verification step: %w", err)
+			return nil, fmt.Errorf("%s: %w", ErrResolveVerificationStep, err)
 		}
 		resolved.Verification = &resolvedStep{Agent: agent, LLM: llm, Tools: toolsForStep(proposal.Spec.Verification)}
 	}

--- a/controller/proposal/results.go
+++ b/controller/proposal/results.go
@@ -12,6 +12,13 @@ import (
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
 
+const (
+	ErrGetExistingResult          = "get existing"
+	ErrUpdateExistingResultStatus = "update existing"
+	ErrCreateResultCR             = "create"
+	ErrPatchResultStatus          = "patch"
+)
+
 func resultCRName(proposalName, step string, index int) string {
 	return truncateK8sName(fmt.Sprintf("%s-%s-%d", proposalName, step, index))
 }
@@ -304,7 +311,7 @@ func createIdempotent(ctx context.Context, c client.Client, obj client.Object, k
 		if apierrors.IsAlreadyExists(err) {
 			existing := obj.DeepCopyObject().(client.Object)
 			if getErr := c.Get(ctx, client.ObjectKeyFromObject(obj), existing); getErr != nil {
-				return fmt.Errorf("get existing %s %s: %w", kind, obj.GetName(), getErr)
+				return fmt.Errorf("%s %s %s: %w", ErrGetExistingResult, kind, obj.GetName(), getErr)
 			}
 			patched := existing.DeepCopyObject().(client.Object)
 			if sh, ok := patched.(statusHolder); ok {
@@ -314,18 +321,18 @@ func createIdempotent(ctx context.Context, c client.Client, obj client.Object, k
 			}
 			copyResultStatus(patched, withStatus)
 			if patchErr := c.Status().Patch(ctx, patched, client.MergeFrom(existing)); patchErr != nil {
-				return fmt.Errorf("update existing %s %s status: %w", kind, obj.GetName(), patchErr)
+				return fmt.Errorf("%s %s %s status: %w", ErrUpdateExistingResultStatus, kind, obj.GetName(), patchErr)
 			}
 			return nil
 		}
-		return fmt.Errorf("create %s %s: %w", kind, obj.GetName(), err)
+		return fmt.Errorf("%s %s %s: %w", ErrCreateResultCR, kind, obj.GetName(), err)
 	}
 
 	// After Create, obj has ResourceVersion but status is stripped.
 	// Use the saved copy (with full status) for the status patch.
 	withStatus.SetResourceVersion(obj.GetResourceVersion())
 	if err := c.Status().Patch(ctx, withStatus, client.MergeFrom(obj)); err != nil {
-		return fmt.Errorf("patch %s %s status: %w", kind, obj.GetName(), err)
+		return fmt.Errorf("%s %s %s status: %w", ErrPatchResultStatus, kind, obj.GetName(), err)
 	}
 	return nil
 }

--- a/controller/proposal/sandbox.go
+++ b/controller/proposal/sandbox.go
@@ -16,6 +16,15 @@ import (
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
 
+const (
+	ErrEnsureAgentTemplate      = "ensure agent template"
+	ErrCreateSandboxClaim       = "failed to create SandboxClaim for"
+	ErrExtractSandboxName       = "extract sandbox name from claim"
+	ErrExtractSandboxConditions = "extract conditions from sandbox"
+	ErrExtractServiceFQDN       = "extract serviceFQDN from sandbox"
+	ErrDeleteSandboxClaim       = "failed to delete SandboxClaim"
+)
+
 var (
 	sandboxClaimGVK = schema.GroupVersionKind{
 		Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Kind: "SandboxClaim",
@@ -92,7 +101,7 @@ func (m *SandboxManager) Claim(ctx context.Context, proposalName, step, _ string
 
 	templateName, err := EnsureAgentTemplate(ctx, m.Client, m.BaseTemplateName, m.Namespace, step, m.agent, m.llm, m.tools, m.serviceAccount)
 	if err != nil {
-		return "", fmt.Errorf("ensure agent template: %w", err)
+		return "", fmt.Errorf("%s: %w", ErrEnsureAgentTemplate, err)
 	}
 
 	claimName := truncateK8sName(fmt.Sprintf("ls-%s-%s", step, proposalName))
@@ -102,10 +111,10 @@ func (m *SandboxManager) Claim(ctx context.Context, proposalName, step, _ string
 		if apierrors.IsAlreadyExists(err) {
 			return claimName, nil
 		}
-		return "", fmt.Errorf("failed to create SandboxClaim for %s: %w", step, err)
+		return "", fmt.Errorf("%s %s: %w", ErrCreateSandboxClaim, step, err)
 	}
 
-	log.Info("Created SandboxClaim", "name", claimName, "step", step, "template", templateName)
+	log.Info("Created SandboxClaim", LogKeyClaim, claimName, LogKeyStep, step, LogKeyTemplate, templateName)
 	return claimName, nil
 }
 
@@ -131,13 +140,13 @@ func (m *SandboxManager) WaitReady(ctx context.Context, claimName string, timeou
 
 			claim.SetGroupVersionKind(sandboxClaimGVK)
 			if err := m.Client.Get(ctx, claimKey, claim); err != nil {
-				log.V(1).Info("Waiting for SandboxClaim", "name", claimName)
+				log.V(1).Info("Waiting for SandboxClaim", LogKeyClaim, claimName)
 				continue
 			}
 
 			sandboxName, found, nestedErr := unstructured.NestedString(claim.Object, "status", "sandbox", "name")
 			if nestedErr != nil {
-				return "", fmt.Errorf("extract sandbox name from claim %q: %w", claimName, nestedErr)
+				return "", fmt.Errorf("%s %q: %w", ErrExtractSandboxName, claimName, nestedErr)
 			}
 			if !found || sandboxName == "" {
 				continue
@@ -147,13 +156,13 @@ func (m *SandboxManager) WaitReady(ctx context.Context, claimName string, timeou
 			if err := m.Client.Get(ctx, types.NamespacedName{
 				Name: sandboxName, Namespace: m.Namespace,
 			}, sandbox); err != nil {
-				log.V(1).Info("Waiting for Sandbox", "name", sandboxName, "error", err)
+				log.V(1).Info("Waiting for Sandbox", LogKeyName, sandboxName, "error", err)
 				continue
 			}
 
 			conditions, found, nestedErr := unstructured.NestedSlice(sandbox.Object, "status", "conditions")
 			if nestedErr != nil {
-				return "", fmt.Errorf("extract conditions from sandbox %q: %w", sandboxName, nestedErr)
+				return "", fmt.Errorf("%s %q: %w", ErrExtractSandboxConditions, sandboxName, nestedErr)
 			}
 			if !found {
 				continue
@@ -167,12 +176,12 @@ func (m *SandboxManager) WaitReady(ctx context.Context, claimName string, timeou
 				if cond["type"] == "Ready" && cond["status"] == string(metav1.ConditionTrue) {
 					fqdn, fqdnFound, fqdnErr := unstructured.NestedString(sandbox.Object, "status", "serviceFQDN")
 					if fqdnErr != nil {
-						return "", fmt.Errorf("extract serviceFQDN from sandbox %q: %w", sandboxName, fqdnErr)
+						return "", fmt.Errorf("%s %q: %w", ErrExtractServiceFQDN, sandboxName, fqdnErr)
 					}
 					if !fqdnFound || fqdn == "" {
 						continue
 					}
-					log.Info("Sandbox ready", "sandbox", sandboxName, "fqdn", fqdn)
+					log.Info("Sandbox ready", LogKeyName, sandboxName, "fqdn", fqdn)
 					return fqdn, nil
 				}
 			}
@@ -192,9 +201,9 @@ func (m *SandboxManager) Release(ctx context.Context, claimName string) error {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to delete SandboxClaim %q: %w", claimName, err)
+		return fmt.Errorf("%s %q: %w", ErrDeleteSandboxClaim, claimName, err)
 	}
 
-	log.Info("Released SandboxClaim", "name", claimName)
+	log.Info("Released SandboxClaim", LogKeyClaim, claimName)
 	return nil
 }

--- a/controller/proposal/sandbox_agent.go
+++ b/controller/proposal/sandbox_agent.go
@@ -16,6 +16,17 @@ import (
 const (
 	defaultSandboxTimeout   = 5 * time.Minute
 	defaultBaseTemplateName = "lightspeed-agent"
+
+	ErrAnalysisAgentCall         = "analysis agent call"
+	ErrParseAnalysisResponse     = "parse analysis response"
+	ErrExecutionAgentCall        = "execution agent call"
+	ErrParseExecutionResponse    = "parse execution response"
+	ErrVerificationAgentCall     = "verification agent call"
+	ErrParseVerificationResponse = "parse verification response"
+	ErrEscalationAgentCall       = "escalation agent call"
+	ErrParseEscalationResponse   = "parse escalation response"
+	ErrClaimSandbox              = "claim sandbox"
+	ErrWaitForSandbox            = "wait for sandbox"
 )
 
 type analysisResponse struct {
@@ -68,12 +79,12 @@ func (s *SandboxAgentCaller) Analyze(ctx context.Context, proposal *agenticv1alp
 	query := buildAnalysisQuery(requestText, proposal)
 	raw, err := s.callWithSandbox(ctx, proposal, stepString(agenticv1alpha1.SandboxStepAnalysis), step, query, buildAgentContext(proposal), serviceAccount)
 	if err != nil {
-		return nil, fmt.Errorf("analysis agent call: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrAnalysisAgentCall, err)
 	}
 
 	var resp analysisResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {
-		return nil, fmt.Errorf("parse analysis response: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrParseAnalysisResponse, err)
 	}
 
 	return &AnalysisOutput{
@@ -91,12 +102,12 @@ func (s *SandboxAgentCaller) Execute(ctx context.Context, proposal *agenticv1alp
 	query := buildExecutionQuery(option)
 	raw, err := s.callWithSandbox(ctx, proposal, stepString(agenticv1alpha1.SandboxStepExecution), step, query, agentCtx, serviceAccount)
 	if err != nil {
-		return nil, fmt.Errorf("execution agent call: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrExecutionAgentCall, err)
 	}
 
 	var resp executionResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {
-		return nil, fmt.Errorf("parse execution response: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrParseExecutionResponse, err)
 	}
 
 	out := &ExecutionOutput{
@@ -119,12 +130,12 @@ func (s *SandboxAgentCaller) Verify(ctx context.Context, proposal *agenticv1alph
 	query := buildVerificationQuery(option, exec)
 	raw, err := s.callWithSandbox(ctx, proposal, stepString(agenticv1alpha1.SandboxStepVerification), step, query, agentCtx, serviceAccount)
 	if err != nil {
-		return nil, fmt.Errorf("verification agent call: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrVerificationAgentCall, err)
 	}
 
 	var resp verificationResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {
-		return nil, fmt.Errorf("parse verification response: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrParseVerificationResponse, err)
 	}
 
 	return &VerificationOutput{
@@ -138,7 +149,7 @@ func (s *SandboxAgentCaller) Escalate(ctx context.Context, proposal *agenticv1al
 	agentCtx := buildAgentContext(proposal)
 	raw, err := s.callWithSandbox(ctx, proposal, stepString(agenticv1alpha1.SandboxStepEscalation), step, requestText, agentCtx, serviceAccount)
 	if err != nil {
-		return nil, fmt.Errorf("escalation agent call: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrEscalationAgentCall, err)
 	}
 
 	var resp struct {
@@ -147,7 +158,7 @@ func (s *SandboxAgentCaller) Escalate(ctx context.Context, proposal *agenticv1al
 		Content string `json:"content"`
 	}
 	if err := json.Unmarshal(raw, &resp); err != nil {
-		return nil, fmt.Errorf("parse escalation response: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrParseEscalationResponse, err)
 	}
 
 	return &EscalationOutput{
@@ -170,7 +181,7 @@ func (s *SandboxAgentCaller) callWithSandbox(
 
 	claimName, err := s.Sandbox.Claim(ctx, proposal.Name, stepName, "")
 	if err != nil {
-		return nil, fmt.Errorf("claim sandbox: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrClaimSandbox, err)
 	}
 
 	// Write sandbox info immediately so the console can stream logs
@@ -184,7 +195,7 @@ func (s *SandboxAgentCaller) callWithSandbox(
 
 	endpoint, err := s.Sandbox.WaitReady(ctx, claimName, timeout)
 	if err != nil {
-		return nil, fmt.Errorf("wait for sandbox: %w", err)
+		return nil, fmt.Errorf("%s: %w", ErrWaitForSandbox, err)
 	}
 
 	agentURL := endpoint
@@ -217,7 +228,7 @@ func (s *SandboxAgentCaller) ReleaseSandboxes(ctx context.Context, proposal *age
 			continue
 		}
 		if err := s.Sandbox.Release(ctx, info.ClaimName); err != nil {
-			log.Error(err, "failed to release sandbox", "claimName", info.ClaimName)
+			log.Error(err, "failed to release sandbox", LogKeyClaim, info.ClaimName)
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -253,7 +264,7 @@ func (s *SandboxAgentCaller) patchSandboxInfo(ctx context.Context, proposal *age
 	}
 
 	if err := s.K8sClient.Status().Patch(ctx, &current, client.MergeFrom(base)); err != nil {
-		log.Error(err, "failed to patch sandbox info", "step", step, "claimName", claimName)
+		log.Error(err, "failed to patch sandbox info", LogKeyStep, step, LogKeyClaim, claimName)
 	}
 }
 

--- a/controller/proposal/sandbox_templates.go
+++ b/controller/proposal/sandbox_templates.go
@@ -21,6 +21,53 @@ import (
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
 
+const (
+	ErrMarshalTemplateHash      = "marshal template hash input"
+	ErrReadBaseTemplate         = "failed to read base sandbox template"
+	ErrComputeTemplateHash      = "compute template hash"
+	ErrCheckTemplate            = "failed to check template"
+	ErrPatchSkillsImage         = "patch skills image"
+	ErrPatchSkillsPaths         = "patch skills paths"
+	ErrPatchLLMCredentials      = "patch LLM credentials"
+	ErrPatchMCPServers          = "patch MCP servers"
+	ErrPatchRequiredSecrets     = "patch required secrets"
+	ErrPatchProbes              = "patch probes"
+	ErrSetServiceAccountName    = "set serviceAccountName on template"
+	ErrCreateTemplate           = "failed to create template"
+	ErrSetProvider              = "set LIGHTSPEED_PROVIDER"
+	ErrSetModel                 = "set LIGHTSPEED_MODEL"
+	ErrAddCredentialsEnvFrom    = "add credentials envFrom"
+	ErrAddCredentialsVolume     = "add credentials volume"
+	ErrMountCredentials         = "mount credentials"
+	ErrSetProviderURL           = "set LIGHTSPEED_PROVIDER_URL"
+	ErrSetModelProvider         = "set LIGHTSPEED_MODEL_PROVIDER"
+	ErrSetProviderProject       = "set LIGHTSPEED_PROVIDER_PROJECT"
+	ErrSetProviderRegion        = "set LIGHTSPEED_PROVIDER_REGION"
+	ErrSetProviderAPIVersion    = "set LIGHTSPEED_PROVIDER_API_VERSION"
+	ErrAddSecretVolume          = "add secret volume"
+	ErrAddVolumeMountForSecret  = "add volume mount"
+	ErrAddEnvVarFromSecret      = "add env var from secret"
+	ErrPatchProbesFn            = "patchProbes"
+	ErrListOldTemplates         = "failed to list old templates"
+	ErrExtractSAName            = "extract serviceAccountName from template"
+	ErrReadContainers           = "read containers"
+	ErrAddEnvFromSecretFn       = "addEnvFromSecret"
+	ErrSetEnvFrom               = "set envFrom"
+	ErrUpsertEnv                = "upsertEnv"
+	ErrSetEnv                   = "set env"
+	ErrAddVolumeMountFn         = "addVolumeMount"
+	ErrSetVolumeMountsUpdate    = "set volumeMounts (update)"
+	ErrSetVolumeMountsAppend    = "set volumeMounts (append)"
+	ErrReadVolumes              = "read volumes"
+	ErrSetSkillsImageRef        = "set skills image reference"
+	ErrSetSkillsImagePullPolicy = "set skills image pullPolicy"
+	ErrPatchSkillsPathsFn       = "patchSkillsPaths"
+	ErrSetVolumeMounts          = "set volumeMounts"
+	ErrAddMCPHeaderVolume       = "add MCP header secret volume"
+	ErrAddMCPHeaderMount        = "add MCP header volume mount"
+	ErrMarshalMCPConfig         = "marshal MCP server config"
+)
+
 var sandboxTemplateGVK = schema.GroupVersionKind{
 	Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Kind: "SandboxTemplate",
 }
@@ -72,7 +119,7 @@ func computeTemplateHash(
 	}
 	data, err := json.Marshal(input)
 	if err != nil {
-		return "", fmt.Errorf("marshal template hash input: %w", err)
+		return "", fmt.Errorf("%s: %w", ErrMarshalTemplateHash, err)
 	}
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])[:10], nil
@@ -109,7 +156,7 @@ func EnsureAgentTemplate(
 	base := &unstructured.Unstructured{}
 	base.SetGroupVersionKind(sandboxTemplateGVK)
 	if err := c.Get(ctx, types.NamespacedName{Name: baseTemplateName, Namespace: namespace}, base); err != nil {
-		return "", fmt.Errorf("failed to read base sandbox template %q: %w", baseTemplateName, err)
+		return "", fmt.Errorf("%s %q: %w", ErrReadBaseTemplate, baseTemplateName, err)
 	}
 
 	var skills []agenticv1alpha1.SkillsSource
@@ -123,7 +170,7 @@ func EnsureAgentTemplate(
 
 	hash, err := computeTemplateHash(llm, agent.Spec.Model, skills, mcpServers, requiredSecrets, step, base.GetResourceVersion(), serviceAccount)
 	if err != nil {
-		return "", fmt.Errorf("compute template hash: %w", err)
+		return "", fmt.Errorf("%s: %w", ErrComputeTemplateHash, err)
 	}
 	name := agentTemplateName(step, agent.Name, hash)
 
@@ -134,7 +181,7 @@ func EnsureAgentTemplate(
 		return name, nil
 	}
 	if !apierrors.IsNotFound(err) {
-		return "", fmt.Errorf("failed to check template %q: %w", name, err)
+		return "", fmt.Errorf("%s %q: %w", ErrCheckTemplate, name, err)
 	}
 
 	derived := base.DeepCopy()
@@ -162,38 +209,38 @@ func EnsureAgentTemplate(
 
 	if len(skills) > 0 && skills[0].Image != "" {
 		if err := patchSkillsImage(derived, skills[0].Image); err != nil {
-			return "", fmt.Errorf("patch skills image: %w", err)
+			return "", fmt.Errorf("%s: %w", ErrPatchSkillsImage, err)
 		}
 		if len(skills[0].Paths) > 0 {
 			if err := patchSkillsPaths(derived, skills[0].Paths); err != nil {
-				return "", fmt.Errorf("patch skills paths: %w", err)
+				return "", fmt.Errorf("%s: %w", ErrPatchSkillsPaths, err)
 			}
 		}
 	}
 
 	if err := patchLLMCredentials(derived, llm, agent.Spec.Model); err != nil {
-		return "", fmt.Errorf("patch LLM credentials: %w", err)
+		return "", fmt.Errorf("%s: %w", ErrPatchLLMCredentials, err)
 	}
 
 	if len(mcpServers) > 0 {
 		if err := patchMCPServers(derived, mcpServers); err != nil {
-			return "", fmt.Errorf("patch MCP servers: %w", err)
+			return "", fmt.Errorf("%s: %w", ErrPatchMCPServers, err)
 		}
 	}
 
 	if len(requiredSecrets) > 0 {
 		if err := patchRequiredSecrets(derived, requiredSecrets); err != nil {
-			return "", fmt.Errorf("patch required secrets: %w", err)
+			return "", fmt.Errorf("%s: %w", ErrPatchRequiredSecrets, err)
 		}
 	}
 
 	if err := patchProbes(derived); err != nil {
-		return "", fmt.Errorf("patch probes: %w", err)
+		return "", fmt.Errorf("%s: %w", ErrPatchProbes, err)
 	}
 
 	if serviceAccount != "" {
 		if err := unstructured.SetNestedField(derived.Object, serviceAccount, "spec", "podTemplate", "spec", "serviceAccountName"); err != nil {
-			return "", fmt.Errorf("set serviceAccountName on template: %w", err)
+			return "", fmt.Errorf("%s: %w", ErrSetServiceAccountName, err)
 		}
 	}
 
@@ -201,13 +248,13 @@ func EnsureAgentTemplate(
 		if apierrors.IsAlreadyExists(err) {
 			return name, nil
 		}
-		return "", fmt.Errorf("failed to create template %q: %w", name, err)
+		return "", fmt.Errorf("%s %q: %w", ErrCreateTemplate, name, err)
 	}
 
 	log.Info("Created agent SandboxTemplate",
-		"name", name,
+		LogKeyName, name,
 		"base", baseTemplateName,
-		"step", step,
+		LogKeyStep, step,
 		"agent", agent.Name,
 		"llmProvider", llm.Name,
 		"hash", hash)
@@ -274,48 +321,48 @@ func patchLLMCredentials(tmpl *unstructured.Unstructured, llm *agenticv1alpha1.L
 	secretName := credentialsSecretName(llm)
 
 	if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER", providerTypeString(llm.Spec.Type)); err != nil {
-		return fmt.Errorf("set LIGHTSPEED_PROVIDER: %w", err)
+		return fmt.Errorf("%s: %w", ErrSetProvider, err)
 	}
 	if err := setEnvVar(tmpl, "LIGHTSPEED_MODEL", model); err != nil {
-		return fmt.Errorf("set LIGHTSPEED_MODEL: %w", err)
+		return fmt.Errorf("%s: %w", ErrSetModel, err)
 	}
 	if err := addEnvFromSecret(tmpl, secretName); err != nil {
-		return fmt.Errorf("add credentials envFrom: %w", err)
+		return fmt.Errorf("%s: %w", ErrAddCredentialsEnvFrom, err)
 	}
 	if err := addSecretVolume(tmpl, llmCredsVolumeName, secretName); err != nil {
-		return fmt.Errorf("add credentials volume: %w", err)
+		return fmt.Errorf("%s: %w", ErrAddCredentialsVolume, err)
 	}
 	if err := addVolumeMount(tmpl, llmCredsVolumeName, llmCredsMountPath, true); err != nil {
-		return fmt.Errorf("mount credentials: %w", err)
+		return fmt.Errorf("%s: %w", ErrMountCredentials, err)
 	}
 
 	switch llm.Spec.Type {
 	case agenticv1alpha1.LLMProviderAnthropic:
 		if u := providerURL(llm); u != "" {
 			if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_URL", u); err != nil {
-				return fmt.Errorf("set LIGHTSPEED_PROVIDER_URL: %w", err)
+				return fmt.Errorf("%s: %w", ErrSetProviderURL, err)
 			}
 		}
 	case agenticv1alpha1.LLMProviderGoogleCloudVertex:
 		cfg := llm.Spec.GoogleCloudVertex
 		if err := setEnvVar(tmpl, "LIGHTSPEED_MODEL_PROVIDER", strings.ToLower(string(cfg.ModelProvider))); err != nil {
-			return fmt.Errorf("set LIGHTSPEED_MODEL_PROVIDER: %w", err)
+			return fmt.Errorf("%s: %w", ErrSetModelProvider, err)
 		}
 		if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_PROJECT", cfg.ProjectID); err != nil {
-			return fmt.Errorf("set LIGHTSPEED_PROVIDER_PROJECT: %w", err)
+			return fmt.Errorf("%s: %w", ErrSetProviderProject, err)
 		}
 		if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_REGION", cfg.Region); err != nil {
-			return fmt.Errorf("set LIGHTSPEED_PROVIDER_REGION: %w", err)
+			return fmt.Errorf("%s: %w", ErrSetProviderRegion, err)
 		}
 		if u := providerURL(llm); u != "" {
 			if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_URL", u); err != nil {
-				return fmt.Errorf("set LIGHTSPEED_PROVIDER_URL: %w", err)
+				return fmt.Errorf("%s: %w", ErrSetProviderURL, err)
 			}
 		}
 	case agenticv1alpha1.LLMProviderOpenAI:
 		if u := providerURL(llm); u != "" {
 			if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_URL", u); err != nil {
-				return fmt.Errorf("set LIGHTSPEED_PROVIDER_URL: %w", err)
+				return fmt.Errorf("%s: %w", ErrSetProviderURL, err)
 			}
 		}
 	case agenticv1alpha1.LLMProviderAzureOpenAI:
@@ -325,21 +372,21 @@ func patchLLMCredentials(tmpl *unstructured.Unstructured, llm *agenticv1alpha1.L
 			providerURLValue = u
 		}
 		if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_URL", providerURLValue); err != nil {
-			return fmt.Errorf("set LIGHTSPEED_PROVIDER_URL: %w", err)
+			return fmt.Errorf("%s: %w", ErrSetProviderURL, err)
 		}
 		if cfg.APIVersion != "" {
 			if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_API_VERSION", cfg.APIVersion); err != nil {
-				return fmt.Errorf("set LIGHTSPEED_PROVIDER_API_VERSION: %w", err)
+				return fmt.Errorf("%s: %w", ErrSetProviderAPIVersion, err)
 			}
 		}
 	case agenticv1alpha1.LLMProviderAWSBedrock:
 		cfg := llm.Spec.AWSBedrock
 		if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_REGION", cfg.Region); err != nil {
-			return fmt.Errorf("set LIGHTSPEED_PROVIDER_REGION: %w", err)
+			return fmt.Errorf("%s: %w", ErrSetProviderRegion, err)
 		}
 		if u := providerURL(llm); u != "" {
 			if err := setEnvVar(tmpl, "LIGHTSPEED_PROVIDER_URL", u); err != nil {
-				return fmt.Errorf("set LIGHTSPEED_PROVIDER_URL: %w", err)
+				return fmt.Errorf("%s: %w", ErrSetProviderURL, err)
 			}
 		}
 	}
@@ -352,14 +399,14 @@ func patchRequiredSecrets(tmpl *unstructured.Unstructured, secrets []agenticv1al
 		case agenticv1alpha1.SecretMountFilePath:
 			volName := "req-" + s.Name
 			if err := addSecretVolume(tmpl, volName, s.Name); err != nil {
-				return fmt.Errorf("add secret volume %q: %w", s.Name, err)
+				return fmt.Errorf("%s %q: %w", ErrAddSecretVolume, s.Name, err)
 			}
 			if err := addVolumeMount(tmpl, volName, s.MountAs.FilePath.Path, true); err != nil {
-				return fmt.Errorf("add volume mount %q: %w", s.MountAs.FilePath.Path, err)
+				return fmt.Errorf("%s %q: %w", ErrAddVolumeMountForSecret, s.MountAs.FilePath.Path, err)
 			}
 		case agenticv1alpha1.SecretMountEnvVar:
 			if err := addEnvVarFromSecret(tmpl, s.MountAs.EnvVar.Name, s.Name, "token"); err != nil {
-				return fmt.Errorf("add env var from secret %q: %w", s.Name, err)
+				return fmt.Errorf("%s %q: %w", ErrAddEnvVarFromSecret, s.Name, err)
 			}
 		}
 	}
@@ -369,7 +416,7 @@ func patchRequiredSecrets(tmpl *unstructured.Unstructured, secrets []agenticv1al
 func patchProbes(tmpl *unstructured.Unstructured) error {
 	container, containers, err := firstContainer(tmpl)
 	if err != nil {
-		return fmt.Errorf("patchProbes: %w", err)
+		return fmt.Errorf("%s: %w", ErrPatchProbesFn, err)
 	}
 
 	container["readinessProbe"] = map[string]any{
@@ -415,7 +462,7 @@ func gcOldTemplates(
 		Namespace:     namespace,
 		LabelSelector: sel,
 	}); err != nil {
-		return fmt.Errorf("failed to list old templates: %w", err)
+		return fmt.Errorf("%s: %w", ErrListOldTemplates, err)
 	}
 
 	log := logf.FromContext(ctx).WithName("sandbox-templates")
@@ -425,10 +472,10 @@ func gcOldTemplates(
 			continue
 		}
 		if err := c.Delete(ctx, item); err != nil && !apierrors.IsNotFound(err) {
-			log.Error(err, "failed to delete old template", "name", item.GetName())
+			log.Error(err, "failed to delete old template", LogKeyName, item.GetName())
 			continue
 		}
-		log.Info("Garbage-collected old SandboxTemplate", "name", item.GetName())
+		log.Info("Garbage-collected old SandboxTemplate", LogKeyName, item.GetName())
 	}
 	return nil
 }
@@ -442,7 +489,7 @@ func SandboxTemplateServiceAccount(ctx context.Context, c client.Client, templat
 	}
 	sa, found, err := unstructured.NestedString(tmpl.Object, "spec", "podTemplate", "spec", "serviceAccountName")
 	if err != nil {
-		return "", fmt.Errorf("extract serviceAccountName from template %q: %w", templateName, err)
+		return "", fmt.Errorf("%s %q: %w", ErrExtractSAName, templateName, err)
 	}
 	if !found || sa == "" {
 		return "", fmt.Errorf("template %q has no serviceAccountName", templateName)
@@ -454,7 +501,7 @@ func SandboxTemplateServiceAccount(ctx context.Context, c client.Client, templat
 func firstContainer(tmpl *unstructured.Unstructured) (map[string]any, []any, error) {
 	containers, found, err := unstructured.NestedSlice(tmpl.Object, "spec", "podTemplate", "spec", "containers")
 	if err != nil {
-		return nil, nil, fmt.Errorf("read containers: %w", err)
+		return nil, nil, fmt.Errorf("%s: %w", ErrReadContainers, err)
 	}
 	if !found || len(containers) == 0 {
 		return nil, nil, fmt.Errorf("template has no containers")
@@ -494,7 +541,7 @@ func addEnvVarFromSecret(tmpl *unstructured.Unstructured, envName, secretName, k
 func addEnvFromSecret(tmpl *unstructured.Unstructured, secretName string) error {
 	container, containers, err := firstContainer(tmpl)
 	if err != nil {
-		return fmt.Errorf("addEnvFromSecret: %w", err)
+		return fmt.Errorf("%s: %w", ErrAddEnvFromSecretFn, err)
 	}
 	envFromList, _, _ := unstructured.NestedSlice(container, "envFrom")
 	for _, e := range envFromList {
@@ -513,7 +560,7 @@ func addEnvFromSecret(tmpl *unstructured.Unstructured, secretName string) error 
 		},
 	})
 	if err := unstructured.SetNestedSlice(container, envFromList, "envFrom"); err != nil {
-		return fmt.Errorf("set envFrom: %w", err)
+		return fmt.Errorf("%s: %w", ErrSetEnvFrom, err)
 	}
 	return writeContainers(tmpl, container, containers)
 }
@@ -521,7 +568,7 @@ func addEnvFromSecret(tmpl *unstructured.Unstructured, secretName string) error 
 func upsertEnv(tmpl *unstructured.Unstructured, name string, entry map[string]any) error {
 	container, containers, err := firstContainer(tmpl)
 	if err != nil {
-		return fmt.Errorf("upsertEnv(%s): %w", name, err)
+		return fmt.Errorf("%s(%s): %w", ErrUpsertEnv, name, err)
 	}
 	envList, _, _ := unstructured.NestedSlice(container, "env")
 
@@ -542,7 +589,7 @@ func upsertEnv(tmpl *unstructured.Unstructured, name string, entry map[string]an
 	}
 
 	if err := unstructured.SetNestedSlice(container, envList, "env"); err != nil {
-		return fmt.Errorf("set env: %w", err)
+		return fmt.Errorf("%s: %w", ErrSetEnv, err)
 	}
 	return writeContainers(tmpl, container, containers)
 }
@@ -572,7 +619,7 @@ func addSecretVolume(tmpl *unstructured.Unstructured, volumeName, secretName str
 func addVolumeMount(tmpl *unstructured.Unstructured, name, mountPath string, readOnly bool) error {
 	container, containers, err := firstContainer(tmpl)
 	if err != nil {
-		return fmt.Errorf("addVolumeMount: %w", err)
+		return fmt.Errorf("%s: %w", ErrAddVolumeMountFn, err)
 	}
 	mounts, _, _ := unstructured.NestedSlice(container, "volumeMounts")
 	mount := map[string]any{
@@ -588,14 +635,14 @@ func addVolumeMount(tmpl *unstructured.Unstructured, name, mountPath string, rea
 		if existing["mountPath"] == mountPath {
 			mounts[i] = mount
 			if err := unstructured.SetNestedSlice(container, mounts, "volumeMounts"); err != nil {
-				return fmt.Errorf("set volumeMounts (update): %w", err)
+				return fmt.Errorf("%s: %w", ErrSetVolumeMountsUpdate, err)
 			}
 			return writeContainers(tmpl, container, containers)
 		}
 	}
 	mounts = append(mounts, mount)
 	if err := unstructured.SetNestedSlice(container, mounts, "volumeMounts"); err != nil {
-		return fmt.Errorf("set volumeMounts (append): %w", err)
+		return fmt.Errorf("%s: %w", ErrSetVolumeMountsAppend, err)
 	}
 	return writeContainers(tmpl, container, containers)
 }
@@ -603,7 +650,7 @@ func addVolumeMount(tmpl *unstructured.Unstructured, name, mountPath string, rea
 func patchSkillsImage(tmpl *unstructured.Unstructured, image string) error {
 	volumes, found, err := unstructured.NestedSlice(tmpl.Object, "spec", "podTemplate", "spec", "volumes")
 	if err != nil {
-		return fmt.Errorf("read volumes: %w", err)
+		return fmt.Errorf("%s: %w", ErrReadVolumes, err)
 	}
 	if !found {
 		return fmt.Errorf("template has no volumes")
@@ -618,10 +665,10 @@ func patchSkillsImage(tmpl *unstructured.Unstructured, image string) error {
 			continue
 		}
 		if err := unstructured.SetNestedField(vol, image, "image", "reference"); err != nil {
-			return fmt.Errorf("set skills image reference: %w", err)
+			return fmt.Errorf("%s: %w", ErrSetSkillsImageRef, err)
 		}
 		if err := unstructured.SetNestedField(vol, "Always", "image", "pullPolicy"); err != nil {
-			return fmt.Errorf("set skills image pullPolicy: %w", err)
+			return fmt.Errorf("%s: %w", ErrSetSkillsImagePullPolicy, err)
 		}
 		volumes[i] = vol
 	}
@@ -634,7 +681,7 @@ func patchSkillsPaths(tmpl *unstructured.Unstructured, paths []string) error {
 	}
 	container, containers, err := firstContainer(tmpl)
 	if err != nil {
-		return fmt.Errorf("patchSkillsPaths: %w", err)
+		return fmt.Errorf("%s: %w", ErrPatchSkillsPathsFn, err)
 	}
 	mounts, _, _ := unstructured.NestedSlice(container, "volumeMounts")
 
@@ -668,7 +715,7 @@ func patchSkillsPaths(tmpl *unstructured.Unstructured, paths []string) error {
 	}
 
 	if err := unstructured.SetNestedSlice(container, filtered, "volumeMounts"); err != nil {
-		return fmt.Errorf("set volumeMounts: %w", err)
+		return fmt.Errorf("%s: %w", ErrSetVolumeMounts, err)
 	}
 	return writeContainers(tmpl, container, containers)
 }
@@ -704,10 +751,10 @@ func patchMCPServers(tmpl *unstructured.Unstructured, servers []agenticv1alpha1.
 			if h.ValueFrom.Type == agenticv1alpha1.MCPHeaderSourceTypeSecret {
 				he.SecretName = h.ValueFrom.Secret.Name
 				if err := addSecretVolume(tmpl, "mcp-header-"+h.ValueFrom.Secret.Name, h.ValueFrom.Secret.Name); err != nil {
-					return fmt.Errorf("add MCP header secret volume: %w", err)
+					return fmt.Errorf("%s: %w", ErrAddMCPHeaderVolume, err)
 				}
 				if err := addVolumeMount(tmpl, "mcp-header-"+h.ValueFrom.Secret.Name, mcpHeadersMountRoot+"/"+h.ValueFrom.Secret.Name, true); err != nil {
-					return fmt.Errorf("add MCP header volume mount: %w", err)
+					return fmt.Errorf("%s: %w", ErrAddMCPHeaderMount, err)
 				}
 			}
 			entry.Headers = append(entry.Headers, he)
@@ -717,7 +764,7 @@ func patchMCPServers(tmpl *unstructured.Unstructured, servers []agenticv1alpha1.
 
 	data, err := json.Marshal(entries)
 	if err != nil {
-		return fmt.Errorf("marshal MCP server config: %w", err)
+		return fmt.Errorf("%s: %w", ErrMarshalMCPConfig, err)
 	}
 	return setEnvVar(tmpl, mcpServersEnvVar, string(data))
 }

--- a/controller/proposal/sandbox_templates_test.go
+++ b/controller/proposal/sandbox_templates_test.go
@@ -1,6 +1,7 @@
 package proposal
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -516,14 +517,14 @@ func TestSetEnvVar_FailsOnNoContainers(t *testing.T) {
 }
 
 func TestEnsureAgentTemplate_NilAgent(t *testing.T) {
-	_, err := EnsureAgentTemplate(nil, nil, "base", "ns", "analysis", nil, testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex), nil, "lightspeed-agent")
+	_, err := EnsureAgentTemplate(context.Background(), nil, "base", "ns", "analysis", nil, testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex), nil, "lightspeed-agent")
 	if err == nil {
 		t.Error("expected error for nil agent")
 	}
 }
 
 func TestEnsureAgentTemplate_NilLLM(t *testing.T) {
-	_, err := EnsureAgentTemplate(nil, nil, "base", "ns", "analysis", testDefaultAgent(), nil, nil, "lightspeed-agent")
+	_, err := EnsureAgentTemplate(context.Background(), nil, "base", "ns", "analysis", testDefaultAgent(), nil, nil, "lightspeed-agent")
 	if err == nil {
 		t.Error("expected error for nil LLM")
 	}

--- a/controller/proposal/state_machine_test.go
+++ b/controller/proposal/state_machine_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -40,10 +39,6 @@ func testPolicyWithMaxAttempts(analysis, execution, verification agenticv1alpha1
 	}
 }
 
-func manualObjects() []client.Object {
-	return []client.Object{testDefaultAgent(), testLLM("smart"), testManualPolicy()}
-}
-
 func newReconcilerWithPolicy(t *testing.T, proposal *agenticv1alpha1.Proposal, agent *testAgentCaller, policy *agenticv1alpha1.ApprovalPolicy, extraObjs ...client.Object) (*ProposalReconciler, client.WithWatch) {
 	t.Helper()
 	scheme := testScheme()
@@ -54,7 +49,7 @@ func newReconcilerWithPolicy(t *testing.T, proposal *agenticv1alpha1.Proposal, a
 	objs = append(objs, extraObjs...)
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 	// Initial reconcile creates ProposalApproval (auto-approved stages based on policy).
 	reconcileOnce(r, proposal.Name)
 	return r, fc
@@ -171,16 +166,6 @@ func denyStage(t *testing.T, fc client.WithWatch, name string, stageType agentic
 	approval.Spec.Stages = append(approval.Spec.Stages, stage)
 	if err := fc.Patch(context.Background(), &approval, client.MergeFrom(base)); err != nil {
 		t.Fatalf("deny %s: %v", stageType, err)
-	}
-}
-
-func mustRequeue(t *testing.T, result ctrl.Result, err error, context string) {
-	t.Helper()
-	if err != nil {
-		t.Fatalf("%s: unexpected error: %v", context, err)
-	}
-	if !result.Requeue {
-		t.Fatalf("%s: expected Requeue=true", context)
 	}
 }
 
@@ -507,7 +492,7 @@ func TestNoPolicy_DefaultsToManual(t *testing.T) {
 	objs := []client.Object{proposal, testDefaultAgent(), testLLM("smart")}
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
 		WithStatusSubresource(proposal, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
-	r := &ProposalReconciler{Client: fc, Log: logr.Discard(), Agent: agent, Namespace: "default"}
+	r := &ProposalReconciler{Client: fc, Agent: agent, Namespace: "default"}
 
 	// Initial reconcile creates ProposalApproval; analysis should wait for approval
 	reconcileOnce(r, "fix-crash")

--- a/controller/sandbox/bootstrap.go
+++ b/controller/sandbox/bootstrap.go
@@ -22,6 +22,11 @@ var sandboxTemplateGVK = schema.GroupVersionKind{
 	Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Kind: "SandboxTemplate",
 }
 
+const (
+	ErrEnsureSA              = "ensure ServiceAccount"
+	ErrEnsureSandboxTemplate = "ensure SandboxTemplate"
+)
+
 type BootstrapConfig struct {
 	Image       string
 	Namespace   string
@@ -39,13 +44,13 @@ func EnsureBootstrapResources(ctx context.Context, c client.Client, cfg Bootstra
 	log.Info("Ensuring bootstrap resources", "image", cfg.Image, "namespace", cfg.Namespace, "mode", cfg.SandboxMode)
 
 	if err := ensureServiceAccount(ctx, c, cfg.Namespace); err != nil {
-		return fmt.Errorf("ensure ServiceAccount: %w", err)
+		return fmt.Errorf("%s: %w", ErrEnsureSA, err)
 	}
 	log.V(1).Info("ServiceAccount ready")
 
 	if cfg.SandboxMode == "sandbox-claim" {
 		if err := ensureSandboxTemplate(ctx, c, cfg.Image, cfg.Namespace); err != nil {
-			return fmt.Errorf("ensure SandboxTemplate: %w", err)
+			return fmt.Errorf("%s: %w", ErrEnsureSandboxTemplate, err)
 		}
 		log.V(1).Info("SandboxTemplate ready")
 	}

--- a/controller/setup.go
+++ b/controller/setup.go
@@ -43,7 +43,6 @@ func Setup(mgr ctrl.Manager, opts Options) error {
 
 	if err := (&proposal.ProposalReconciler{
 		Client:    mgr.GetClient(),
-		Log:       ctrl.Log.WithName("controllers").WithName("Proposal"),
 		Agent:     agentCaller,
 		Namespace: opts.Namespace,
 	}).SetupWithManager(mgr); err != nil {

--- a/future/configmap-agent-communication.md
+++ b/future/configmap-agent-communication.md
@@ -1,0 +1,128 @@
+# Future: ConfigMap-based agent communication
+
+## Current approach
+
+The operator creates a sandbox pod running an HTTP server. It calls `POST /v1/agent/run` synchronously, blocking the reconcile loop until the agent responds (up to 5 minutes). The agent is a long-running HTTP server that must stay alive for the duration of the sandbox claim.
+
+## Proposed alternative: run-to-completion with file I/O
+
+Replace the HTTP server with a batch CLI program that reads input from a mounted file and writes output to stdout (or a known file path).
+
+### Flow
+
+1. **Operator creates input ConfigMap** with the request payload:
+   ```yaml
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: ls-analysis-<proposal>-input
+   data:
+     request.json: |
+       {"query":"...","outputSchema":{...},"context":{...}}
+   ```
+
+2. **Operator creates sandbox** — pod spec mounts the ConfigMap as a volume at `/input/request.json`. Pod command is the agent CLI (not an HTTP server). Pod `restartPolicy: Never`.
+
+3. **Operator pre-creates output ConfigMap** (empty):
+   ```yaml
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: ls-analysis-<proposal>-output
+     labels:
+       agentic.openshift.io/proposal: <proposal>
+       agentic.openshift.io/step: analysis
+   data: {}
+   ```
+
+5. **Agent runs** — reads `/input/request.json`, calls LLM, writes result to the output ConfigMap:
+   ```go
+   cm.Data["response.json"] = string(resultJSON)
+   client.Update(ctx, cm)
+   ```
+   Agent SA only needs `update` on this specific ConfigMap (narrow Role scoped by resource name).
+
+6. **Pod completes** (exit 0 = success, non-zero = failure).
+
+7. **Operator detects completion** — watches pod status or sandbox condition. Reads `data["response.json"]` from the output ConfigMap. Operator also runs periodic checks (e.g. on requeue timer) to detect runaway agents that exceed expected duration and deletes them (kills the pod, marks step as failed).
+
+8. **Operator parses output** — same JSON contract as today, just read from ConfigMap instead of HTTP response body. Operator deletes both input and output ConfigMaps after processing.
+
+### Advantages
+
+- **No HTTP server** — agent is a simple CLI: read file → call LLM → write ConfigMap → exit
+- **No network policies** — no service discovery, no port exposure, no DNS resolution issues
+- **No long-running reconcile** — operator creates sandbox and returns. Reconciles again on pod completion event.
+- **Simpler agent image** — no `net/http`, no healthz, no request parsing. Just a `main()` that processes one request.
+- **Natural timeout** — pod `activeDeadlineSeconds` handles timeouts at the k8s level
+- **Crash recovery** — if operator restarts, it checks pod status on next reconcile (no lost HTTP connection)
+- **Operator controls lifecycle** — creates both input and output ConfigMaps, owns them, deletes them after use
+- **Minimal agent RBAC** — only needs `update` on the single output ConfigMap (can be scoped by resourceName in the Role)
+
+### Disadvantages
+
+- **ConfigMap 1MB limit** — large outputs could hit this (unlikely in practice; current responses are <10KB)
+- **No streaming** — can't stream partial results (current HTTP also doesn't stream, so no regression)
+- **Slightly slower** — volume mount propagation adds ~1-2s vs direct HTTP
+- **Agent needs k8s client** — must write to ConfigMap (lightweight: just one Update call, no watches)
+
+### Agent code (simplified)
+
+```go
+func main() {
+    // Read input from mounted ConfigMap volume
+    input, _ := os.ReadFile("/input/request.json")
+    
+    var req Request
+    json.Unmarshal(input, &req)
+    
+    result := callLLM(req)
+    
+    // Write output to the pre-created output ConfigMap
+    resultJSON, _ := json.Marshal(result)
+    cm := &corev1.ConfigMap{}
+    client.Get(ctx, types.NamespacedName{
+        Name:      os.Getenv("OUTPUT_CONFIGMAP"),
+        Namespace: os.Getenv("POD_NAMESPACE"),
+    }, cm)
+    cm.Data["response.json"] = string(resultJSON)
+    client.Update(ctx, cm)
+}
+```
+
+### Operator changes
+
+1. `callWithSandbox` → `dispatchToSandbox` (non-blocking: create ConfigMap + SandboxClaim, return)
+2. New reconcile path: when pod completes → read output → continue to next phase
+3. `SandboxManager.WaitReady` replaced by pod completion watch
+4. `AgentHTTPClient` removed entirely
+
+### Migration path
+
+1. Support both modes behind a feature flag (HTTP vs file I/O)
+2. Default to HTTP (current behavior)
+3. Switch to file I/O once validated
+4. Remove HTTP path
+
+### RBAC for agent
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent-output-writer
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["ls-analysis-<proposal>-output"]
+  verbs: ["get", "update"]
+```
+
+The operator creates this Role + RoleBinding per sandbox (scoped to the specific output ConfigMap name). Deleted on cleanup.
+
+### Open questions
+
+- Should the input ConfigMap be cleaned up by the operator or by the sandbox controller?
+- How does the console stream agent logs during execution if the agent is a batch job? (Currently it reads sandbox pod logs — same approach works here)
+- Should the output ConfigMap name be passed as env var (`OUTPUT_CONFIGMAP`) or derived from a convention?


### PR DESCRIPTION
**Summary**
Unify logger acquisition, verbosity levels, and structured field keys across the proposal controller. Removes the explicit logr.Logger parameter threading in favor of logf.FromContext(ctx), demotes high-frequency no-op messages to V(1), and introduces LogKey* constants to prevent field-name drift.

**Design decisions**
FromContext over param threading: controller-runtime injects the reconcile key into the context logger before calling Reconcile(). Every downstream handler inherits the proposal identity ({"controller": "proposal", "Proposal": {"name": "...", "namespace": "..."}}) without manual WithValues.
V(1) threshold: Messages that fire on every reconcile without indicating progress (waiting, pending, no-op) are noise at V(0). Phase-transition and resource-creation messages remain at V(0).
Log-and-swallow sites unchanged: All 16 existing log-and-swallow patterns were reviewed and confirmed intentional (best-effort cleanup, terminal states, requeue-on-failure).
Constants only for multi-file keys: Single-use keys like "base", "hash", "llmProvider" stay as literals — constants would add indirection without preventing drift.