### PR TITLE
quickstart: fix uninstall prompt and README env var example

### DIFF
--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -40,8 +40,8 @@ Skip the confirmation prompt with `QUICKSTART_FORCE=1`.
 Example with overrides:
 
 ```bash
-NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim \
-  curl -sL .../install.sh | bash
+export NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim
+curl -sL .../install.sh | bash
 ```
 
 ## LLM Provider Examples

--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -39,8 +39,8 @@ Skip the confirmation prompt with `QUICKSTART_FORCE=1`.
 Example with overrides:
 
 ```bash
-export NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim
-bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
+NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim \
+  bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
 ```
 
 ## LLM Provider Examples

--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -34,14 +34,13 @@ Skip the confirmation prompt with `QUICKSTART_FORCE=1`.
 | `NAMESPACE` | `openshift-lightspeed` | Target namespace |
 | `OPERATOR_IMAGE` | Konflux `:main` | Operator container image |
 | `SANDBOX_IMAGE` | Konflux `:main` | Agent sandbox container image |
-| `CONSOLE_IMAGE` | Konflux `:main` | Console plugin container image (requires OCP 4.21+; set `""` to skip) |
 | `SANDBOX_MODE` | `bare-pod` | Sandbox mode (`bare-pod` or `sandbox-claim`) |
 
 Example with overrides:
 
 ```bash
-export NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim
-curl -sL .../install.sh | bash
+NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim \
+  curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh | bash
 ```
 
 ## LLM Provider Examples

--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -12,7 +12,7 @@ No building, no cloning required.
 ## Install
 
 ```bash
-curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh | bash
+bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
 ```
 
 The script installs CRDs, deploys the operator, and creates an ApprovalPolicy.
@@ -22,7 +22,7 @@ submitting a test proposal.
 ## Uninstall
 
 ```bash
-curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh | bash
+bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh)
 ```
 
 Skip the confirmation prompt with `QUICKSTART_FORCE=1`.
@@ -39,8 +39,8 @@ Skip the confirmation prompt with `QUICKSTART_FORCE=1`.
 Example with overrides:
 
 ```bash
-NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim \
-  curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh | bash
+export NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim
+bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
 ```
 
 ## LLM Provider Examples

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -5,7 +5,7 @@
 # pre-built Konflux images. No building, no cloning.
 #
 # Usage:
-#   curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh | bash
+#   bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
 #
 # Prerequisites:
 #   - oc CLI on PATH
@@ -259,6 +259,6 @@ cat <<DONE
   oc get proposals -n ${NAMESPACE} -w
 
   ── To uninstall ───────────────────────────────────────────
-  curl -sL ${GITHUB_RAW}/hack/quickstart/uninstall.sh | bash
+  bash <(curl -sL ${GITHUB_RAW}/hack/quickstart/uninstall.sh)
 
 DONE

--- a/hack/quickstart/uninstall.sh
+++ b/hack/quickstart/uninstall.sh
@@ -19,8 +19,11 @@ if [ "${QUICKSTART_FORCE:-}" != "1" ]; then
   echo ""
   if [ -t 0 ]; then
     read -rp "Continue? [y/N] " confirm
-  elif [ -e /dev/tty ]; then
-    read -rp "Continue? [y/N] " confirm </dev/tty
+  elif [ -r /dev/tty ]; then
+    if ! read -rp "Continue? [y/N] " confirm </dev/tty; then
+      echo "Non-interactive shell detected. Set QUICKSTART_FORCE=1 to proceed."
+      exit 1
+    fi
   else
     echo "Non-interactive shell detected. Set QUICKSTART_FORCE=1 to proceed."
     exit 1

--- a/hack/quickstart/uninstall.sh
+++ b/hack/quickstart/uninstall.sh
@@ -17,17 +17,7 @@ if [ "${QUICKSTART_FORCE:-}" != "1" ]; then
   echo "This will delete ALL Agentic OLS resources in namespace ${NAMESPACE}"
   echo "and remove the operator CRDs cluster-wide."
   echo ""
-  if [ -t 0 ]; then
-    read -rp "Continue? [y/N] " confirm
-  elif [ -r /dev/tty ]; then
-    if ! read -rp "Continue? [y/N] " confirm </dev/tty; then
-      echo "Non-interactive shell detected. Set QUICKSTART_FORCE=1 to proceed."
-      exit 1
-    fi
-  else
-    echo "Non-interactive shell detected. Set QUICKSTART_FORCE=1 to proceed."
-    exit 1
-  fi
+  read -rp "Continue? [y/N] " confirm
   case "${confirm}" in
     [yY][eE][sS]|[yY]) ;;
     *) echo "Aborted."; exit 0 ;;
@@ -66,16 +56,9 @@ oc delete sa lightspeed-agentic-operator -n "${NAMESPACE}" --ignore-not-found 2>
 oc delete clusterrolebinding lightspeed-agentic-operator --ignore-not-found 2>/dev/null || true
 info "Operator removed"
 
-# --- Step 4: Delete namespace -------------------------------------------------
+# --- Step 4: Delete CRDs -----------------------------------------------------
 
-step "4/5" "Deleting namespace ${NAMESPACE}..."
-
-oc delete namespace "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
-info "Namespace deleted"
-
-# --- Step 5: Delete CRDs -----------------------------------------------------
-
-step "5/5" "Deleting Agentic Operator CRDs..."
+step "4/5" "Deleting Agentic Operator CRDs..."
 
 for crd in \
   agents.agentic.openshift.io \
@@ -87,9 +70,16 @@ for crd in \
   proposalapprovals.agentic.openshift.io \
   proposals.agentic.openshift.io \
   verificationresults.agentic.openshift.io; do
-  oc delete crd "${crd}" --ignore-not-found 2>/dev/null || true
+  oc delete crd "${crd}" --ignore-not-found --timeout=30s 2>/dev/null || true
 done
 info "CRDs deleted"
+
+# --- Step 5: Delete namespace -------------------------------------------------
+
+step "5/5" "Deleting namespace ${NAMESPACE}..."
+
+oc delete namespace "${NAMESPACE}" --ignore-not-found --timeout=60s 2>/dev/null || true
+info "Namespace deleted"
 
 cat <<DONE
 

--- a/hack/quickstart/uninstall.sh
+++ b/hack/quickstart/uninstall.sh
@@ -15,7 +15,7 @@ fail()  { echo "  ✗ $*" >&2; exit 1; }
 
 if [ "${QUICKSTART_FORCE:-}" != "1" ]; then
   echo "This will delete ALL Agentic OLS resources in namespace ${NAMESPACE}"
-  echo "and remove the operator CRDs cluster-wide."
+  echo ", remove the operator CRDs cluster-wide and the namespace itself."
   echo ""
   read -rp "Continue? [y/N] " confirm
   case "${confirm}" in

--- a/hack/quickstart/uninstall.sh
+++ b/hack/quickstart/uninstall.sh
@@ -17,7 +17,14 @@ if [ "${QUICKSTART_FORCE:-}" != "1" ]; then
   echo "This will delete ALL Agentic OLS resources in namespace ${NAMESPACE}"
   echo "and remove the operator CRDs cluster-wide."
   echo ""
-  read -rp "Continue? [y/N] " confirm </dev/tty
+  if [ -t 0 ]; then
+    read -rp "Continue? [y/N] " confirm
+  elif [ -e /dev/tty ]; then
+    read -rp "Continue? [y/N] " confirm </dev/tty
+  else
+    echo "Non-interactive shell detected. Set QUICKSTART_FORCE=1 to proceed."
+    exit 1
+  fi
   case "${confirm}" in
     [yY][eE][sS]|[yY]) ;;
     *) echo "Aborted."; exit 0 ;;

--- a/hack/quickstart/uninstall.sh
+++ b/hack/quickstart/uninstall.sh
@@ -3,7 +3,7 @@
 # Uninstall Agentic OLS quickstart deployment.
 #
 # Usage:
-#   curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh | bash
+#   bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh)
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Fix `curl | bash` uninstall prompt by trying stdin, then `/dev/tty`, then requiring `QUICKSTART_FORCE=1`
- Fix README env var override example to use `export` (otherwise vars only apply to `curl`, not the piped `bash`)

## Test plan
- [ ] `curl -sL .../uninstall.sh | bash` prompts for confirmation
- [ ] `QUICKSTART_FORCE=1 curl -sL .../uninstall.sh | bash` skips prompt
- [ ] `bash uninstall.sh` prompts interactively

Made with [Cursor](https://cursor.com)