### PR TITLE
fix: mount SA token for execution and verification pods

### DIFF
--- a/controller/proposal/podspec_builder.go
+++ b/controller/proposal/podspec_builder.go
@@ -114,9 +114,11 @@ func (b *PodSpecBuilder) Build(
 		container.Env = append(container.Env, secEnv...)
 	}
 
+	mountToken := step == "execution" || step == "verification"
+
 	return &corev1.PodSpec{
 		ServiceAccountName:           serviceAccount,
-		AutomountServiceAccountToken: ptr.To(false),
+		AutomountServiceAccountToken: ptr.To(mountToken),
 		Containers:                   []corev1.Container{container},
 		Volumes:                      volumes,
 	}, nil


### PR DESCRIPTION
## Summary

- Execution pods had `AutomountServiceAccountToken=false`, so `oc`/`kubectl` couldn't authenticate to the cluster API despite the operator correctly creating per-proposal RBAC (SA + Role + RoleBinding via `ensureExecutionRBAC`)
- Mount the SA token for execution and verification steps; analysis remains without token mount (read access tracked separately in [OLS-3255](https://redhat.atlassian.net/browse/OLS-3255))

## Root cause

`PodSpecBuilder` was introduced with `AutomountServiceAccountToken: false` unconditionally (commit 547733a, June 5). The execution RBAC machinery works correctly — SA is created, permissions are bound — but the pod can't use them without the projected token.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./controller/proposal/ -run TestPodSpecBuilder` passes
- [ ] Deploy to cluster, submit proposal, verify execution pod can run `oc whoami` successfully


Made with [Cursor](https://cursor.com)