### PR TITLE
feat: add --image-pull-policy flag for sandbox pods

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ func main() {
 		agenticConsoleImage string
 		agenticSandboxImage string
 		sandboxMode         string
+		imagePullPolicy     string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -47,6 +48,7 @@ func main() {
 	flag.StringVar(&agenticConsoleImage, "agentic-console-image", "", "The image of the agentic console plugin container.")
 	flag.StringVar(&agenticSandboxImage, "agentic-sandbox-image", "", "The image of the agentic sandbox container.")
 	flag.StringVar(&sandboxMode, "sandbox-mode", "bare-pod", "Sandbox mode: bare-pod (default) or sandbox-claim.")
+	flag.StringVar(&imagePullPolicy, "image-pull-policy", "", "Image pull policy for sandbox pods (Always, IfNotPresent, Never). Empty uses Kubernetes default.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -82,6 +84,7 @@ func main() {
 		AgenticConsoleImage: agenticConsoleImage,
 		AgenticSandboxImage: agenticSandboxImage,
 		SandboxMode:         sandboxMode,
+		ImagePullPolicy:     imagePullPolicy,
 	}); err != nil {
 		log.Error(err, "unable to set up agentic controllers")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,6 +9,7 @@ import (
 
 	consolev1 "github.com/openshift/api/console/v1"
 	openshiftv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -53,6 +54,13 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 	log := ctrl.Log.WithName("setup")
+
+	switch corev1.PullPolicy(imagePullPolicy) {
+	case "", corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever:
+	default:
+		log.Error(nil, "invalid --image-pull-policy", "value", imagePullPolicy, "allowed", "Always|IfNotPresent|Never")
+		os.Exit(1)
+	}
 
 	if namespace == "" {
 		ns := os.Getenv("POD_NAMESPACE")

--- a/controller/proposal/podspec_builder.go
+++ b/controller/proposal/podspec_builder.go
@@ -14,7 +14,8 @@ import (
 )
 
 type PodSpecBuilder struct {
-	Image string
+	Image           string
+	ImagePullPolicy string
 }
 
 func (b *PodSpecBuilder) Build(
@@ -35,8 +36,9 @@ func (b *PodSpecBuilder) Build(
 	}
 
 	container := corev1.Container{
-		Name:  "agent",
-		Image: b.Image,
+		Name:            "agent",
+		Image:           b.Image,
+		ImagePullPolicy: corev1.PullPolicy(b.ImagePullPolicy),
 		Ports: []corev1.ContainerPort{{
 			Name:          "http",
 			ContainerPort: 8080,

--- a/controller/setup.go
+++ b/controller/setup.go
@@ -16,6 +16,7 @@ type Options struct {
 	AgenticConsoleImage string
 	AgenticSandboxImage string
 	SandboxMode         string
+	ImagePullPolicy     string
 }
 
 func Setup(mgr ctrl.Manager, opts Options) error {
@@ -26,7 +27,10 @@ func Setup(mgr ctrl.Manager, opts Options) error {
 	case "sandbox-claim":
 		sandboxProvider = proposal.NewSandboxManager(mgr.GetClient(), opts.Namespace, "lightspeed-agent")
 	default:
-		builder := &proposal.PodSpecBuilder{Image: opts.AgenticSandboxImage}
+		builder := &proposal.PodSpecBuilder{
+			Image:           opts.AgenticSandboxImage,
+			ImagePullPolicy: opts.ImagePullPolicy,
+		}
 		sandboxProvider = proposal.NewBarePodManager(mgr.GetClient(), builder, opts.Namespace)
 	}
 

--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -35,11 +35,19 @@ Skip the confirmation prompt with `QUICKSTART_FORCE=1`.
 | `OPERATOR_IMAGE` | Konflux `:main` | Operator container image |
 | `SANDBOX_IMAGE` | Konflux `:main` | Agent sandbox container image |
 | `SANDBOX_MODE` | `bare-pod` | Sandbox mode (`bare-pod` or `sandbox-claim`) |
+| `IMAGE_PULL_POLICY` | *(empty — Kubernetes default)* | Image pull policy for operator and sandbox pods (`Always`, `IfNotPresent`, `Never`) |
 
 Example with overrides:
 
 ```bash
 NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim \
+  bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
+```
+
+For dev environments with floating tags like `:main`, force fresh pulls:
+
+```bash
+IMAGE_PULL_POLICY=Always \
   bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
 ```
 

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -22,6 +22,7 @@ OPERATOR_IMAGE="${OPERATOR_IMAGE:-quay.io/redhat-user-workloads/crt-nshift-light
 SANDBOX_IMAGE="${SANDBOX_IMAGE:-quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-sandbox:main}"
 CONSOLE_IMAGE="${CONSOLE_IMAGE:-quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console:main}"
 SANDBOX_MODE="${SANDBOX_MODE:-bare-pod}"
+IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-}"
 
 GITHUB_RAW="https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main"
 
@@ -118,11 +119,13 @@ spec:
       containers:
       - name: manager
         image: ${OPERATOR_IMAGE}
+$([ -n "${IMAGE_PULL_POLICY}" ] && echo "        imagePullPolicy: ${IMAGE_PULL_POLICY}")
         args:
         - "--namespace=${NAMESPACE}"
         - "--sandbox-mode=${SANDBOX_MODE}"
         - "--agentic-sandbox-image=${SANDBOX_IMAGE}"
         - "--agentic-console-image=${CONSOLE_IMAGE}"
+$([ -n "${IMAGE_PULL_POLICY}" ] && echo '        - "--image-pull-policy='"${IMAGE_PULL_POLICY}"'"')
         ports:
         - name: metrics
           containerPort: 8080


### PR DESCRIPTION
## Summary

- Adds `--image-pull-policy` operator flag that sets `imagePullPolicy` on sandbox pod containers
- When empty (default), Kubernetes applies its standard default (`IfNotPresent` for non-`:latest` tags)
- Useful for dev environments with floating tags like `:main` where `Always` is needed to pick up new images

### Files changed

| File | Change |
|---|---|
| `cmd/main.go` | New `--image-pull-policy` CLI flag |
| `controller/setup.go` | Thread `ImagePullPolicy` through `Options` to `PodSpecBuilder` |
| `controller/proposal/podspec_builder.go` | Apply policy to sandbox container spec |

### Usage

```bash
# Dev: always pull (good for floating tags like :main)
--image-pull-policy=Always

# Production: omit flag (Kubernetes default)
```

## Test plan

- [ ] Unit tests pass (`go test ./controller/proposal/ -run TestPodSpec`)
- [ ] Deploy operator with `--image-pull-policy=Always`, verify sandbox pods have `imagePullPolicy: Always`
- [ ] Deploy without flag, verify sandbox pods use Kubernetes default

Made with [Cursor](https://cursor.com)