### PR TITLE
chore: add parse-agent-steps.sh for debugging sandbox pod logs

### DIFF
--- a/hack/parse-agent-steps.sh
+++ b/hack/parse-agent-steps.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Parse agent tool calls and results from sandbox pod logs.
+# Usage: ./hack/parse-agent-steps.sh <pod-name> [namespace] [max-output-lines]
+set -euo pipefail
+
+POD="${1:?Usage: $0 <pod-name> [namespace] [max-output-lines]}"
+NS="${2:-openshift-lightspeed}"
+MAX_OUTPUT="${3:-10}"
+
+oc logs "$POD" -n "$NS" | awk -v max_output="$MAX_OUTPUT" '
+/INFO lightspeed_agentic: \[agent\] Starting query/ {
+    sub(/.*\[agent\] /, "")
+    printf "--- %s ---\n\n", $0
+    turn = 0
+    in_result = 0
+    next
+}
+/INFO lightspeed_agentic: \[provider:run\] tool_use:/ {
+    if (in_result) { printf "\n"; in_result = 0 }
+    turn++
+    sub(/.*\[provider:run\] tool_use: /, "")
+    printf "Step %d: %s\n", turn, $0
+    next
+}
+/INFO lightspeed_agentic: \[provider:run\] tool_result:/ {
+    sub(/.*\[provider:run\] tool_result: /, "")
+    printf "     → %s\n", $0
+    in_result = 1
+    result_lines = 0
+    next
+}
+/INFO lightspeed_agentic: \[provider:run\] output:/ {
+    if (in_result) { printf "\n"; in_result = 0 }
+    sub(/.*\[provider:run\] output: /, "")
+    printf "\nOutput: %s\n", substr($0, 1, 500)
+    next
+}
+/INFO lightspeed_agentic: \[provider:run\] result:/ {
+    if (in_result) { printf "\n"; in_result = 0 }
+    sub(/.*\[provider:run\] result: /, "")
+    printf "Result: %s\n", $0
+    next
+}
+in_result {
+    if (/^DEBUG |^INFO |^Tracing is disabled|^Processing output|^Setting current|^No conversation|^Calling LLM|^Starting turn|^Turn .* complete/) next
+    if (/^Wall time:/ || /^Process exited with/ || /^Output:$/) next
+    result_lines++
+    if (result_lines <= max_output) printf "       %s\n", $0
+    if (result_lines == max_output + 1) printf "       ... (truncated, use 3rd arg to show more)\n"
+    next
+}
+'


### PR DESCRIPTION
## Summary
- Adds `hack/parse-agent-steps.sh` — parses agent tool_use/tool_result events from sandbox pod logs into a readable step-by-step trace with command output
- Usage: `./hack/parse-agent-steps.sh <pod-name> [namespace] [max-output-lines]`

## Test plan
- [x] Run against an analysis pod: `./hack/parse-agent-steps.sh ls-analysis-<name>`
- [x] Run against an execution pod: `./hack/parse-agent-steps.sh ls-execution-<name>`
- [ ] Verify truncation works with custom max-output-lines (3rd arg)

sample output

```
❯ ../hack/parse-agent-steps.sh ls-execution-fix-web-app
--- Starting query (model=gpt-5.4-mini, provider=openai) ---

Step 1: exec_command({"cmd":"kubectl get deploy,pods -n default -l app=web-app -o wide","yield_time_ms":10000,"max_output_tokens":12000})
     → Chunk ID: 012c49
       NAME                       READY   STATUS             RESTARTS        AGE   IP            NODE                         NOMINATED NODE   READINESS GATES
       web-app-788f89d985-6gpnd   0/1     CrashLoopBackOff   13 (100s ago)   24m   10.129.0.34   ip-10-0-1-177.ec2.internal   <none>           <none>
       Error from server (Forbidden): deployments.apps is forbidden: User "system:serviceaccount:openshift-lightspeed:ls-exec-default-

Step 2: exec_command({"cmd":"kubectl describe pod web-app-788f89d985-6gpnd -n default","yield_time_ms":10000,"max_output_tokens":14000})
     → Chunk ID: 478010
       Name:             web-app-788f89d985-6gpnd
       Namespace:        default
       Priority:         0
       Service Account:  default
       Node:             ip-10-0-1-177.ec2.internal/10.0.1.177
       Start Time:       Thu, 11 Jun 2026 08:16:11 +0000
       Labels:           app=web-app
                         pod-template-hash=788f89d985
       Annotations:      k8s.ovn.org/pod-networks:
                           {"default":{"ip_addresses":["10.129.0.34/23"],"mac_address":

Step 3: exec_command({"cmd":"kubectl logs web-app-788f89d985-6gpnd -n default --previous","yield_time_ms":10000,"max_output_tokens":12000})
     → Chunk ID: 333625
       /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
       /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
       /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
       10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
       10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/n

Step 4: exec_command({"cmd":"kubectl get deploy web-app -n default -o yaml","yield_time_ms":10000,"max_output_tokens":16000})
     → Chunk ID: 340411
       apiVersion: apps/v1
       kind: Deployment
       metadata:
         annotations:
           deployment.kubernetes.io/revision: "1"
           kubectl.kubernetes.io/last-applied-configuration: |
             {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"name":"web-app","namespace":"default"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"web-app"}},"template":{"metadata":{"labels":{"app":"web-app"}},"spec":{"containers":[{"
       INFO:     10.129.0.2:33676 - "GET /ready HTTP/1.1" 200 OK
       Custom tool failed: Update File patch for /dev/null must include a hunk
       Traceback (most recent call last):
       ... (truncated, use 3rd arg to show more)

Step 5: apply_patch()
     → Update File patch for /dev/null must include a hunk

Step 6: exec_command({"cmd":"kubectl patch deployment web-app -n default --type='json' -p='[{\"op\":\"remove\",\"path\":\"/spec/template/spec/containers/0/livenessProbe\"}]'","yield_time_ms":10000,"max_output_tokens":12000})
     → Chunk ID: 4daad4
       deployment.apps/web-app patched


Step 7: exec_command({"cmd":"kubectl rollout status deployment/web-app -n default && kubectl get pods -n default -l app=web-app -o wide && kubectl describe pod -n default -l app=web-app | sed -n '1,140p'","yield_time_ms":10000,"max_output_tokens":16000})
     → Chunk ID: 74ebed
       Process running with session ID 96191
       E0611 08:40:27.755615      56 reflector.go:205] "Failed to watch" err="failed to list *unstructured.Unstructured: deployments.apps \"web-app\" is forbidden: User \"system:serviceaccount:openshift-lightspeed:ls-exec-default-fix-web-app\" cannot list resource \"deployments\" in API group \"apps\" in the namespace \"default\"" reflector="k8s.io/client-go/tools/watch/informerwatcher.go:162" type="*unstructured.

Step 8: write_stdin({"session_id":96191,"chars":"\u0003","yield_time_ms":1000,"max_output_tokens":12000})
     → Chunk ID: 30af37
       stdin is not available for this process. Start the command with `tty=true` in `exec_command` before using `write_stdin`.

Step 9: exec_command({"cmd":"kubectl get pods -n default -l app=web-app -o wide","yield_time_ms":10000,"max_output_tokens":12000})
     → Chunk ID: 25d391
       NAME                       READY   STATUS    RESTARTS   AGE   IP            NODE                         NOMINATED NODE   READINESS GATES
       web-app-7b8f8d6b55-snz8w   1/1     Running   0          15s   10.128.0.63   ip-10-0-1-126.ec2.internal   <none>           <none>

       INFO:     10.129.0.2:42706 - "GET /ready HTTP/1.1" 200 OK
       Resetting current trace

Result: cost=$0.0000, tokens=0

Output: {"success": true, "actionsTaken": [{"type": "investigate", "description": "Inspected pod state for `web-app` with `kubectl get deploy,pods -n default -l app=web-app -o wide`", "outcome": "Succeeded", "output": "Found `web-app-788f89d985-6gpnd` in `CrashLoopBackOff` with 13 restarts. Deployment listing was forbidden by RBAC, but pod state was retrieved.", "error": ""}, {"type": "investigate", "description": "Described the failing pod with `kubectl describe pod web-app-788f89d985-6gpnd -n default`
--- Starting query (model=gpt-5.4-mini, provider=openai) ---

Step 1: exec_command({"cmd":"kubectl get deploy,pods -n default -l app=web-app -o wide","yield_time_ms":10000,"max_output_tokens":12000})
     → Chunk ID: 9d9d3c
       error: You must be logged in to the server (Unauthorized)
       error: You must be logged in to the server (Unauthorized)


Step 2: exec_command({"cmd":"kubectl get deploy,pods -n default -l app=web-app -o wide; echo '---'; kubectl describe pod -n default -l app=web-app","yield_time_ms":10000,"max_output_tokens":12000})
     → Chunk ID: 2d1c86
       error: You must be logged in to the server (Unauthorized)
       error: You must be logged in to the server (Unauthorized)
       ---
       error: You must be logged in to the server (Unauthorized)


Step 3: exec_command({"cmd":"kubectl logs -n default -l app=web-app --previous","yield_time_ms":10000,"max_output_tokens":12000})
     → Chunk ID: 40cada
       error: You must be logged in to the server (Unauthorized)


Step 4: exec_command({"cmd":"kubectl get deploy web-app -n default -o yaml","yield_time_ms":10000,"max_output_tokens":12000})
     → Chunk ID: f3fcd6
       error: You must be logged in to the server (Unauthorized)

       Resetting current trace

Result: cost=$0.0000, tokens=0

Output: {"success": false, "actionsTaken": [{"type": "investigate", "description": "Ran `kubectl get deploy,pods -n default -l app=web-app -o wide` to inspect rollout and pod state", "outcome": "Failed", "output": "error: You must be logged in to the server (Unauthorized)", "error": "Cluster access unavailable due to Kubernetes authentication failure"}, {"type": "investigate", "description": "Ran `kubectl describe pod -n default -l app=web-app` to inspect events on a failing pod", "outcome": "Failed", "
```

```
❯ ../hack/parse-agent-steps.sh ls-verification-fix-web-app
--- Starting query (model=gpt-5.4-mini, provider=openai) ---

Step 1: exec_command({"cmd":"kubectl get pods -n default -l app=web-app -o wide && kubectl describe pod -n default web-app-7b8f8d6b55-snz8w && kubectl logs -n default web-app-7b8f8d6b55-snz8w --previous || true && kubectl rollout status deployment/web-app -n default --timeout=30s", "yield_time_ms":10000, "max_output_tok)
     → Chunk ID: b4710f
       Error from server (Forbidden): pods is forbidden: User "system:serviceaccount:openshift-lightspeed:lightspeed-agent" cannot list resource "pods" in API group "" in the namespace "default"
       Error from server (Forbidden): deployments.apps "web-app" is forbidden: User "system:serviceaccount:openshift-lightspeed:lightspeed-agent" cannot get resource "deployments" in API group "apps" in the namespace "default"

       Resetting current trace

Result: cost=$0.0000, tokens=0

Output: {"success": false, "checks": [{"name": "pods-running", "source": "kubectl get pods -n default -l app=web-app -o wide", "value": "Forbidden: service account cannot list pods in namespace `default`", "result": "Failed"}, {"name": "restart-count-stable", "source": "kubectl get pod -n default <web-app-pod> -o jsonpath='{.status.containerStatuses[0].restartCount}'", "value": "Not verifiable from current permissions; pod lookup was blocked", "result": "Failed"}, {"name": "no-crash-events", "source": "
--- Starting query (model=gpt-5.4-mini, provider=openai) ---

Step 1: exec_command({"cmd":"kubectl get pods -n default -l app=web-app -o wide && echo '---' && kubectl describe pod -n default web-app-7b8f8d6b55-snz8w && echo '---' && kubectl get pod -n default web-app-7b8f8d6b55-snz8w -o jsonpath='{.status.containerStatuses[0].restartCount}'", "yield_time_ms":10000, "max_output_tok)
     → Chunk ID: bffe56
       Error from server (Forbidden): pods is forbidden: User "system:serviceaccount:openshift-lightspeed:lightspeed-agent" cannot list resource "pods" in API group "" in the namespace "default"


Step 2: exec_command({"cmd":"kubectl rollout status deployment/web-app -n default","yield_time_ms":10000,"max_output_tokens":12000})
     → Chunk ID: 13722d
       Error from server (Forbidden): deployments.apps "web-app" is forbidden: User "system:serviceaccount:openshift-lightspeed:lightspeed-agent" cannot get resource "deployments" in API group "apps" in the namespace "default"

       INFO:     10.129.0.2:50026 - "GET /health HTTP/1.1" 200 OK
       INFO:     10.129.0.2:50038 - "GET /ready HTTP/1.1" 200 OK
       Resetting current trace

Result: cost=$0.0000, tokens=0

Output: {"success": false, "checks": [{"name": "pods-running", "source": "kubectl get pods -n default -l app=web-app -o wide", "value": "Forbidden: cannot list pods in namespace default as system:serviceaccount:openshift-lightspeed:lightspeed-agent", "result": "Failed"}, {"name": "restart-count-stable", "source": "kubectl get pod -n default <web-app-pod> -o jsonpath='{.status.containerStatuses[0].restartCount}'", "value": "Not retrieved due to RBAC denial on pod listing", "result": "Failed"}, {"name": "
```




🤖 Generated with [Claude Code](https://claude.com/claude-code)