### PR TITLE
fix: RBAC adding list and watch verb for resources watched by operator

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,7 +12,9 @@ rules:
   verbs:
   - create
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -100,7 +102,9 @@ rules:
   verbs:
   - create
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - console.openshift.io
   resources:
@@ -108,7 +112,9 @@ rules:
   verbs:
   - create
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - extensions.agents.x-k8s.io
   resources:
@@ -136,7 +142,9 @@ rules:
   - consoles
   verbs:
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/controller/console/reconciler.go
+++ b/controller/console/reconciler.go
@@ -1,11 +1,11 @@
 package console
 
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create
-// +kubebuilder:rbac:groups="",resources=services,verbs=get;create;update
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;create;update
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;create;update
-// +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;create;update
-// +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;update
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;watch;update
 
 import (
 	"context"


### PR DESCRIPTION
controller-runtime creates cluster-scoped informers for every type the operator reads or writes. 
Informers require list+watch. Without them, the cache never syncs, all informers time out, and the manager exits.