### PR TITLE
test: add in-flight and resume E2E scenarios for kill switch

### DIFF
--- a/test/agent/Dockerfile
+++ b/test/agent/Dockerfile
@@ -20,6 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /mock-agent 
 FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=builder /mock-agent /mock-agent
+COPY --from=builder /workspace/test/agent/skills/ /skills/
 EXPOSE 8080
 USER nonroot:nonroot
 ENTRYPOINT ["/mock-agent"]

--- a/test/agent/skills/e2e-placeholder.md
+++ b/test/agent/skills/e2e-placeholder.md
@@ -1,0 +1,4 @@
+# E2E Placeholder Skill
+
+This file ensures the /skills directory exists in the mock agent image
+for OCI image volume mounts during E2E tests.

--- a/test/e2e/suspension_test.go
+++ b/test/e2e/suspension_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
@@ -25,9 +26,10 @@ func TestSuspension(t *testing.T) {
 	cleanup(t, c, config)
 	t.Cleanup(func() { cleanup(t, c, config) })
 
-	// Activate kill switch.
+	// Activate kill switch — reset fields that cleanup's c.Get may have overwritten.
 	config.SetResourceVersion("")
 	config.SetUID("")
+	config.Spec.Suspended = true
 	if err := c.Create(ctx, config); err != nil {
 		t.Fatalf("create AgenticOLSConfig: %v", err)
 	}
@@ -59,4 +61,79 @@ func TestSuspension(t *testing.T) {
 		t.Fatalf("expected EmergencyStopped after resume, got %s", phase)
 	}
 	t.Log("stopped proposal remains terminal after resume")
+}
+
+// TestSuspension_InFlight verifies rule 6: a proposal that has already
+// progressed past analysis (Proposed phase) is terminated when the kill
+// switch activates.
+func TestSuspension_InFlight(t *testing.T) {
+	c := newClient(t)
+	createFixtures(t, c)
+	ctx := context.Background()
+
+	prop := createProposal(t, c, "suspend-inflight-proposed")
+
+	// Wait for the proposal to reach Proposed (analysis complete, non-terminal).
+	waitForPhase(t, c, prop.Name, agenticv1alpha1.ProposalPhaseProposed)
+	t.Log("proposal reached Proposed — activating kill switch")
+
+	config := &agenticv1alpha1.AgenticOLSConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec:       agenticv1alpha1.AgenticOLSConfigSpec{Suspended: true},
+	}
+	cleanup(t, c, config)
+	t.Cleanup(func() { cleanup(t, c, config) })
+
+	config.SetResourceVersion("")
+	config.SetUID("")
+	config.Spec.Suspended = true
+	if err := c.Create(ctx, config); err != nil {
+		t.Fatalf("create AgenticOLSConfig: %v", err)
+	}
+
+	// The AgenticOLSConfig watch re-queues all non-terminal proposals.
+	waitForPhase(t, c, prop.Name, agenticv1alpha1.ProposalPhaseEmergencyStopped)
+	t.Log("in-flight proposal terminated by suspension guard")
+}
+
+// TestSuspension_ResumeNewProposal verifies rule 10: after resuming the
+// system (suspended → false), new proposals proceed normally.
+func TestSuspension_ResumeNewProposal(t *testing.T) {
+	c := newClient(t)
+	createFixtures(t, c)
+	ctx := context.Background()
+
+	config := &agenticv1alpha1.AgenticOLSConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec:       agenticv1alpha1.AgenticOLSConfigSpec{Suspended: true},
+	}
+	cleanup(t, c, config)
+	t.Cleanup(func() { cleanup(t, c, config) })
+
+	config.SetResourceVersion("")
+	config.SetUID("")
+	config.Spec.Suspended = true
+	if err := c.Create(ctx, config); err != nil {
+		t.Fatalf("create AgenticOLSConfig: %v", err)
+	}
+	time.Sleep(5 * time.Second)
+
+	// Verify suspension works.
+	stopped := createProposal(t, c, "suspend-before-resume")
+	waitForPhase(t, c, stopped.Name, agenticv1alpha1.ProposalPhaseEmergencyStopped)
+	t.Log("confirmed suspension is active")
+
+	// Resume via raw JSON merge patch — avoids omitempty/omitzero serialization
+	// issues with bool false, and sends a MODIFIED watch event that the informer
+	// cache propagates faster than a DELETE.
+	patch := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"suspended":false}}`))
+	if err := c.Patch(ctx, config, patch); err != nil {
+		t.Fatalf("patch config to resume: %v", err)
+	}
+	time.Sleep(5 * time.Second)
+
+	// New proposal should proceed past Pending.
+	resumed := createProposal(t, c, "suspend-after-resume")
+	waitForPhase(t, c, resumed.Name, agenticv1alpha1.ProposalPhaseProposed)
+	t.Log("new proposal proceeded normally after resume")
 }


### PR DESCRIPTION
## Summary

- Fix mock agent image: add `/skills` directory so OCI image volume mounts with `subPath: "skills"` succeed (was causing `CreateContainerError` / `ImageVolumeMountFailed` on all E2E tests)
- Fix `TestSuspension`: reset `config.Spec.Suspended = true` after `cleanup`'s `c.Get` overwrites it, preventing `omitzero` from omitting the spec field (`spec: Required value` error)
- Add `TestSuspension_InFlight` (spec rule 6): verify a proposal already in `Proposed` phase transitions to `EmergencyStopped` when the kill switch activates mid-flight
- Add `TestSuspension_ResumeNewProposal` (spec rule 10): verify new proposals proceed normally after patching `suspended=false`. Uses `RawPatch` with `MergePatchType` to avoid `omitempty`/`omitzero` serialization issues and the 5+ minute cache propagation delays from `DELETE` events

## Test plan

- [x] `TestSuspension` — PASS (16s)
- [x] `TestSuspension_InFlight` — PASS (22s)
- [x] `TestSuspension_ResumeNewProposal` — PASS (34s)
- [x] Full `make test-e2e` run: all suspension tests pass, pre-existing failures (`TestAnalysisFlow`, `TestExecutionFlow`) unchanged


Made with [Cursor](https://cursor.com)