### PR TITLE
OLS-3164: CLI suspend/resume commands and status reporting

### DIFF
--- a/.ai/spec/how/cli.md
+++ b/.ai/spec/how/cli.md
@@ -15,8 +15,23 @@ Audience: AI agents. Command behavior and user-facing rules belong in **what/** 
 
 | File | Types | Key functions |
 |------|-------|----------------|
-| `root.go` | — | `NewRootCmd(streams)` — registers `proposal` subtree and `version` |
+| `root.go` | — | `NewRootCmd(streams)` — registers `proposal` subtree, `system` commands (`status`, `suspend`, `resume`), and `version` |
 | `version.go` | Package var `Version` (default `dev`) | `NewVersionCmd(streams)` |
+
+---
+
+## Module map: `cli/system/`
+
+| File | Types | Key functions |
+|------|-------|----------------|
+| `helpers.go` | — (`scheme`, `configName` constant) | `newClient`, `getConfig` |
+| `status.go` | `StatusOptions` | `NewStatusCmd`, `Complete`, `Run` |
+| `suspend.go` | `SuspendOptions` | `NewSuspendCmd`, `Complete`, `Run` |
+| `resume.go` | `ResumeOptions` | `NewResumeCmd`, `Complete`, `Run` |
+
+- **`status`:** Gets `AgenticOLSConfig` named `cluster`; prints `"Agentic System: SUSPENDED"` or `"Active"`. `NotFound` = Active.
+- **`suspend`:** Prompts confirmation (skip with `--yes`); patches `spec.suspended=true` or creates the CR if absent. Idempotent (reports "already suspended" if already true).
+- **`resume`:** Patches `spec.suspended=false`. Reports "not suspended" if already false or CR absent.
 
 ---
 
@@ -52,6 +67,9 @@ oc-agentic
 │   ├── watch NAME
 │   ├── logs NAME
 │   └── delete NAME
+├── status
+├── suspend
+├── resume
 └── version
 ```
 
@@ -73,7 +91,7 @@ There is **no** unstructured client for proposal CRUD in the main commands; only
 - Every command embeds or holds `*genericclioptions.ConfigFlags` from `genericclioptions.NewConfigFlags(true)`.
 - **`AddFlags`** on each cobra command wires kubeconfig/context/namespace flags consistent with `kubectl` / `oc`.
 - **`IOStreams`** passed from root for all printing and JSON/YAML encoders.
-- **Namespace resolution:** `ResolveNamespace` prefers `*ConfigFlags.Namespace`; else kubeconfig current context namespace; else `"default"`.
+- **Namespace resolution:** `ResolveNamespace` prefers `*ConfigFlags.Namespace`; else kubeconfig current context namespace (unless `"default"`); else `"openshift-lightspeed"` (the `DefaultNamespace` constant).
 
 ---
 
@@ -93,7 +111,7 @@ There is **no** unstructured client for proposal CRUD in the main commands; only
 ## Output formatting
 
 - **Tables:** `text/tabwriter` via `PrintTable`.
-- **Phases:** ANSI colors in `PhaseColor` / `ColoredPhase` (green complete, red failed/denied, yellow in-progress, magenta escalated).
+- **Phases:** ANSI colors in `PhaseColor` / `ColoredPhase` (green complete, red failed/denied, yellow in-progress, magenta escalated/emergency-stopped).
 - **Structured:** `-o json` uses `encoding/json` encoder with indent; `-o yaml` uses `sigs.k8s.io/yaml` `Marshal`.
 - **Validation:** `ValidateOutputFormat` — list allows `wide` in addition to json/yaml; get/create allow json/yaml only.
 
@@ -142,5 +160,5 @@ User invokes oc-agentic proposal <cmd> [flags]
 
 ## Implementation notes
 
-- **`validProposalPhases` in `helpers.go`** is missing `Proposed` and `Escalating` relative to `ProposalPhase` in `api/v1alpha1/proposal_types.go`. `list --phase` validation (`IsValidPhase`) can reject phase strings that `DerivePhase` still produces; align the slice with API constants when fixing UX.
-- **`watch` terminal set:** `IsTerminalPhase` matches four phases (includes `Escalated`); matches common completion paths; verify against **what/** if `Analyzing` as terminal edge cases matter.
+- **`validProposalPhases` in `helpers.go`** includes all terminal phases including `EmergencyStopped`. Still missing `Proposed` and `Escalating` relative to `ProposalPhase` in `api/v1alpha1/proposal_types.go`. `list --phase` validation (`IsValidPhase`) can reject phase strings that `DerivePhase` still produces; align the slice with API constants when fixing UX.
+- **`watch` terminal set:** `IsTerminalPhase` matches five phases (includes `Escalated` and `EmergencyStopped`); matches common completion paths; verify against **what/** if `Analyzing` as terminal edge cases matter.

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ vendor/
 .env
 .env.*
 !.env.example
+oc-agentic

--- a/cli/proposal/helpers.go
+++ b/cli/proposal/helpers.go
@@ -46,6 +46,7 @@ var validProposalPhases = []string{
 	string(agenticv1alpha1.ProposalPhaseFailed),
 	string(agenticv1alpha1.ProposalPhaseDenied),
 	string(agenticv1alpha1.ProposalPhaseEscalated),
+	string(agenticv1alpha1.ProposalPhaseEmergencyStopped),
 }
 
 var validSandboxSteps = []string{
@@ -77,6 +78,8 @@ func NewClientFromConfig(cfg *rest.Config) (client.Client, error) {
 	return c, nil
 }
 
+const DefaultNamespace = "openshift-lightspeed"
+
 func ResolveNamespace(f *genericclioptions.ConfigFlags) (string, error) {
 	if f.Namespace != nil && *f.Namespace != "" {
 		return *f.Namespace, nil
@@ -85,10 +88,10 @@ func ResolveNamespace(f *genericclioptions.ConfigFlags) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
-	if ctx, ok := rawConfig.Contexts[rawConfig.CurrentContext]; ok && ctx.Namespace != "" {
+	if ctx, ok := rawConfig.Contexts[rawConfig.CurrentContext]; ok && ctx.Namespace != "" && ctx.Namespace != "default" {
 		return ctx.Namespace, nil
 	}
-	return "default", nil
+	return DefaultNamespace, nil
 }
 
 func IsTerminalPhase(phase agenticv1alpha1.ProposalPhase) bool {
@@ -96,7 +99,8 @@ func IsTerminalPhase(phase agenticv1alpha1.ProposalPhase) bool {
 	case agenticv1alpha1.ProposalPhaseCompleted,
 		agenticv1alpha1.ProposalPhaseFailed,
 		agenticv1alpha1.ProposalPhaseEscalated,
-		agenticv1alpha1.ProposalPhaseDenied:
+		agenticv1alpha1.ProposalPhaseDenied,
+		agenticv1alpha1.ProposalPhaseEmergencyStopped:
 		return true
 	}
 	return false
@@ -114,6 +118,8 @@ func PhaseColor(phase agenticv1alpha1.ProposalPhase) string {
 		agenticv1alpha1.ProposalPhaseVerifying:
 		return ColorYellow
 	case agenticv1alpha1.ProposalPhaseEscalated:
+		return ColorMagenta
+	case agenticv1alpha1.ProposalPhaseEmergencyStopped:
 		return ColorMagenta
 	default:
 		return ColorReset

--- a/cli/proposal/helpers_test.go
+++ b/cli/proposal/helpers_test.go
@@ -19,6 +19,7 @@ func TestIsTerminalPhase(t *testing.T) {
 		{agenticv1alpha1.ProposalPhaseFailed, true},
 		{agenticv1alpha1.ProposalPhaseDenied, true},
 		{agenticv1alpha1.ProposalPhaseEscalated, true},
+		{agenticv1alpha1.ProposalPhaseEmergencyStopped, true},
 		{agenticv1alpha1.ProposalPhasePending, false},
 		{agenticv1alpha1.ProposalPhaseAnalyzing, false},
 		{agenticv1alpha1.ProposalPhaseExecuting, false},
@@ -45,6 +46,9 @@ func TestPhaseColor(t *testing.T) {
 	}
 	if c := PhaseColor(agenticv1alpha1.ProposalPhaseEscalated); c != ColorMagenta {
 		t.Errorf("expected magenta for Escalated, got %q", c)
+	}
+	if c := PhaseColor(agenticv1alpha1.ProposalPhaseEmergencyStopped); c != ColorMagenta {
+		t.Errorf("expected magenta for EmergencyStopped, got %q", c)
 	}
 }
 

--- a/cli/proposal/testutil_test.go
+++ b/cli/proposal/testutil_test.go
@@ -79,6 +79,10 @@ func setPhaseConditions(s *agenticv1alpha1.ProposalStatus, phase agenticv1alpha1
 		meta.SetStatusCondition(&s.Conditions, metav1.Condition{
 			Type: agenticv1alpha1.ProposalConditionEscalated, Status: metav1.ConditionTrue, Reason: "MaxRetriesExhausted",
 		})
+	case agenticv1alpha1.ProposalPhaseEmergencyStopped:
+		meta.SetStatusCondition(&s.Conditions, metav1.Condition{
+			Type: agenticv1alpha1.ProposalConditionEmergencyStopped, Status: metav1.ConditionTrue, Reason: "SystemSuspended",
+		})
 	case agenticv1alpha1.ProposalPhasePending:
 		// No conditions — fresh proposal
 	}

--- a/cli/root.go
+++ b/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/openshift/lightspeed-agentic-operator/cli/proposal"
+	"github.com/openshift/lightspeed-agentic-operator/cli/system"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -15,6 +16,9 @@ func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	cmd.AddCommand(proposal.NewProposalCmd(streams))
+	cmd.AddCommand(system.NewStatusCmd(streams))
+	cmd.AddCommand(system.NewSuspendCmd(streams))
+	cmd.AddCommand(system.NewResumeCmd(streams))
 	cmd.AddCommand(NewVersionCmd(streams))
 
 	return cmd

--- a/cli/system/helpers.go
+++ b/cli/system/helpers.go
@@ -43,9 +43,5 @@ func getConfig(ctx context.Context, c client.Client) (*agenticv1alpha1.AgenticOL
 }
 
 func isNoMatchError(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := err.(*meta.NoKindMatchError)
-	return ok
+	return meta.IsNoMatchError(err)
 }

--- a/cli/system/helpers.go
+++ b/cli/system/helpers.go
@@ -1,0 +1,51 @@
+package system
+
+import (
+	"context"
+	"fmt"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const configName = "cluster"
+
+var scheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = agenticv1alpha1.AddToScheme(s)
+	return s
+}()
+
+func newClient(f *genericclioptions.ConfigFlags) (client.Client, error) {
+	cfg, err := f.ToRESTConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get REST config: %w", err)
+	}
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+	return c, nil
+}
+
+func getConfig(ctx context.Context, c client.Client) (*agenticv1alpha1.AgenticOLSConfig, error) {
+	cfg := &agenticv1alpha1.AgenticOLSConfig{}
+	if err := c.Get(ctx, types.NamespacedName{Name: configName}, cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func isNoMatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*meta.NoKindMatchError)
+	return ok
+}

--- a/cli/system/resume.go
+++ b/cli/system/resume.go
@@ -1,0 +1,74 @@
+package system
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ResumeOptions struct {
+	configFlags *genericclioptions.ConfigFlags
+	client      client.Client
+	genericclioptions.IOStreams
+}
+
+func NewResumeCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := &ResumeOptions{
+		configFlags: genericclioptions.NewConfigFlags(true),
+		IOStreams:   streams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "resume",
+		Short: "Resume agentic operations",
+		Example: `  # Resume agentic system
+  oc agentic resume`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(); err != nil {
+				return err
+			}
+			return o.Run(cmd.Context())
+		},
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (o *ResumeOptions) Complete() error {
+	var err error
+	o.client, err = newClient(o.configFlags)
+	return err
+}
+
+func (o *ResumeOptions) Run(ctx context.Context) error {
+	cfg, err := getConfig(ctx, o.client)
+	if isNoMatchError(err) {
+		return fmt.Errorf("agentic system is not installed (AgenticOLSConfig CRD not found)")
+	}
+	if apierrors.IsNotFound(err) {
+		fmt.Fprintln(o.Out, "Agentic system is not suspended (no AgenticOLSConfig found).")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get AgenticOLSConfig: %w", err)
+	}
+
+	if !cfg.Spec.Suspended {
+		fmt.Fprintln(o.Out, "Agentic system is not suspended.")
+		return nil
+	}
+
+	raw := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"suspended":false}}`))
+	if err := o.client.Patch(ctx, cfg, raw); err != nil {
+		return fmt.Errorf("failed to patch AgenticOLSConfig: %w", err)
+	}
+
+	fmt.Fprintln(o.Out, "Agentic system resumed.")
+	return nil
+}

--- a/cli/system/resume_test.go
+++ b/cli/system/resume_test.go
@@ -1,0 +1,63 @@
+package system
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestResume_Suspended(t *testing.T) {
+	streams, out, _ := fakeStreams()
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(testConfig(true)).Build()
+
+	o := &ResumeOptions{client: fc, IOStreams: streams}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "resumed") {
+		t.Errorf("expected resumed message, got %q", got)
+	}
+
+	cfg := &agenticv1alpha1.AgenticOLSConfig{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: configName}, cfg); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if cfg.Spec.Suspended {
+		t.Error("expected Suspended=false after resume")
+	}
+}
+
+func TestResume_NotSuspended(t *testing.T) {
+	streams, out, _ := fakeStreams()
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(testConfig(false)).Build()
+
+	o := &ResumeOptions{client: fc, IOStreams: streams}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "not suspended") {
+		t.Errorf("expected not suspended message, got %q", got)
+	}
+}
+
+func TestResume_NoCR(t *testing.T) {
+	streams, out, _ := fakeStreams()
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+
+	o := &ResumeOptions{client: fc, IOStreams: streams}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "not suspended") {
+		t.Errorf("expected not suspended message when no CR, got %q", got)
+	}
+}

--- a/cli/system/status.go
+++ b/cli/system/status.go
@@ -1,0 +1,67 @@
+package system
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type StatusOptions struct {
+	configFlags *genericclioptions.ConfigFlags
+	client      client.Client
+	genericclioptions.IOStreams
+}
+
+func NewStatusCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := &StatusOptions{
+		configFlags: genericclioptions.NewConfigFlags(true),
+		IOStreams:   streams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show system status",
+		Example: `  # Check if agentic system is suspended
+  oc agentic status`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(); err != nil {
+				return err
+			}
+			return o.Run(cmd.Context())
+		},
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (o *StatusOptions) Complete() error {
+	var err error
+	o.client, err = newClient(o.configFlags)
+	return err
+}
+
+func (o *StatusOptions) Run(ctx context.Context) error {
+	cfg, err := getConfig(ctx, o.client)
+	if apierrors.IsNotFound(err) {
+		fmt.Fprintln(o.Out, "Agentic System: Active")
+		return nil
+	}
+	if isNoMatchError(err) {
+		return fmt.Errorf("agentic system is not installed (AgenticOLSConfig CRD not found)")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get AgenticOLSConfig: %w", err)
+	}
+
+	if cfg.Spec.Suspended {
+		fmt.Fprintln(o.Out, "Agentic System: SUSPENDED")
+	} else {
+		fmt.Fprintln(o.Out, "Agentic System: Active")
+	}
+	return nil
+}

--- a/cli/system/status_test.go
+++ b/cli/system/status_test.go
@@ -1,0 +1,53 @@
+package system
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestStatus_Active(t *testing.T) {
+	streams, out, _ := fakeStreams()
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(testConfig(false)).Build()
+
+	o := &StatusOptions{client: fc, IOStreams: streams}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "Active") {
+		t.Errorf("expected Active, got %q", got)
+	}
+}
+
+func TestStatus_Suspended(t *testing.T) {
+	streams, out, _ := fakeStreams()
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(testConfig(true)).Build()
+
+	o := &StatusOptions{client: fc, IOStreams: streams}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "SUSPENDED") {
+		t.Errorf("expected SUSPENDED, got %q", got)
+	}
+}
+
+func TestStatus_NoCR(t *testing.T) {
+	streams, out, _ := fakeStreams()
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+
+	o := &StatusOptions{client: fc, IOStreams: streams}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "Active") {
+		t.Errorf("expected Active when no CR exists, got %q", got)
+	}
+}

--- a/cli/system/suspend.go
+++ b/cli/system/suspend.go
@@ -79,10 +79,17 @@ func (o *SuspendOptions) Run(ctx context.Context) error {
 			Spec:       agenticv1alpha1.AgenticOLSConfigSpec{Suspended: true},
 		}
 		if err := o.client.Create(ctx, cfg); err != nil {
-			return fmt.Errorf("failed to create AgenticOLSConfig: %w", err)
+			if !apierrors.IsAlreadyExists(err) {
+				return fmt.Errorf("failed to create AgenticOLSConfig: %w", err)
+			}
+			cfg, err = getConfig(ctx, o.client)
+			if err != nil {
+				return fmt.Errorf("failed to get AgenticOLSConfig after conflict: %w", err)
+			}
+		} else {
+			fmt.Fprintln(o.Out, "Agentic system suspended.")
+			return nil
 		}
-		fmt.Fprintln(o.Out, "Agentic system suspended.")
-		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get AgenticOLSConfig: %w", err)

--- a/cli/system/suspend.go
+++ b/cli/system/suspend.go
@@ -1,0 +1,104 @@
+package system
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type SuspendOptions struct {
+	configFlags *genericclioptions.ConfigFlags
+	yes         bool
+	client      client.Client
+	genericclioptions.IOStreams
+}
+
+func NewSuspendCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := &SuspendOptions{
+		configFlags: genericclioptions.NewConfigFlags(true),
+		IOStreams:   streams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "suspend",
+		Short: "Suspend all agentic operations",
+		Example: `  # Suspend (with confirmation prompt)
+  oc agentic suspend
+
+  # Suspend without prompting
+  oc agentic suspend --yes`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(); err != nil {
+				return err
+			}
+			return o.Run(cmd.Context())
+		},
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+	cmd.Flags().BoolVarP(&o.yes, "yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func (o *SuspendOptions) Complete() error {
+	var err error
+	o.client, err = newClient(o.configFlags)
+	return err
+}
+
+func (o *SuspendOptions) Run(ctx context.Context) error {
+	if !o.yes {
+		fmt.Fprint(o.Out, "All agentic operations will be halted and in-flight proposals will be terminated. Continue? [y/N] ")
+		reader := bufio.NewReader(o.In)
+		answer, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("failed to read input: %w", err)
+		}
+		if !strings.EqualFold(strings.TrimSpace(answer), "y") {
+			fmt.Fprintln(o.Out, "Aborted.")
+			return nil
+		}
+	}
+
+	cfg, err := getConfig(ctx, o.client)
+	if isNoMatchError(err) {
+		return fmt.Errorf("agentic system is not installed (AgenticOLSConfig CRD not found)")
+	}
+	if apierrors.IsNotFound(err) {
+		cfg = &agenticv1alpha1.AgenticOLSConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Spec:       agenticv1alpha1.AgenticOLSConfigSpec{Suspended: true},
+		}
+		if err := o.client.Create(ctx, cfg); err != nil {
+			return fmt.Errorf("failed to create AgenticOLSConfig: %w", err)
+		}
+		fmt.Fprintln(o.Out, "Agentic system suspended.")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get AgenticOLSConfig: %w", err)
+	}
+
+	if cfg.Spec.Suspended {
+		fmt.Fprintln(o.Out, "Agentic system is already suspended.")
+		return nil
+	}
+
+	patch := client.MergeFrom(cfg.DeepCopy())
+	cfg.Spec.Suspended = true
+	if err := o.client.Patch(ctx, cfg, patch); err != nil {
+		return fmt.Errorf("failed to patch AgenticOLSConfig: %w", err)
+	}
+
+	fmt.Fprintln(o.Out, "Agentic system suspended.")
+	return nil
+}

--- a/cli/system/suspend.go
+++ b/cli/system/suspend.go
@@ -78,9 +78,9 @@ func (o *SuspendOptions) Run(ctx context.Context) error {
 			ObjectMeta: metav1.ObjectMeta{Name: configName},
 			Spec:       agenticv1alpha1.AgenticOLSConfigSpec{Suspended: true},
 		}
-		if err := o.client.Create(ctx, cfg); err != nil {
-			if !apierrors.IsAlreadyExists(err) {
-				return fmt.Errorf("failed to create AgenticOLSConfig: %w", err)
+		if createErr := o.client.Create(ctx, cfg); createErr != nil {
+			if !apierrors.IsAlreadyExists(createErr) {
+				return fmt.Errorf("failed to create AgenticOLSConfig: %w", createErr)
 			}
 			cfg, err = getConfig(ctx, o.client)
 			if err != nil {

--- a/cli/system/suspend_test.go
+++ b/cli/system/suspend_test.go
@@ -1,0 +1,117 @@
+package system
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSuspend_WithConfirmation(t *testing.T) {
+	streams, out, _ := fakeStreams()
+	streams.In.(*bytes.Buffer).WriteString("y\n")
+
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(testConfig(false)).Build()
+
+	o := &SuspendOptions{client: fc, IOStreams: streams}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "suspended") {
+		t.Errorf("expected suspended message, got %q", got)
+	}
+
+	cfg := &agenticv1alpha1.AgenticOLSConfig{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: configName}, cfg); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !cfg.Spec.Suspended {
+		t.Error("expected Suspended=true after suspend")
+	}
+}
+
+func TestSuspend_Declined(t *testing.T) {
+	streams, out, _ := fakeStreams()
+	streams.In.(*bytes.Buffer).WriteString("n\n")
+
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(testConfig(false)).Build()
+
+	o := &SuspendOptions{client: fc, IOStreams: streams}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "Aborted") {
+		t.Errorf("expected Aborted, got %q", got)
+	}
+
+	cfg := &agenticv1alpha1.AgenticOLSConfig{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: configName}, cfg); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if cfg.Spec.Suspended {
+		t.Error("expected Suspended=false after declining")
+	}
+}
+
+func TestSuspend_SkipConfirmation(t *testing.T) {
+	streams, out, _ := fakeStreams()
+
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(testConfig(false)).Build()
+
+	o := &SuspendOptions{client: fc, yes: true, IOStreams: streams}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "suspended") {
+		t.Errorf("expected suspended message, got %q", got)
+	}
+}
+
+func TestSuspend_AlreadySuspended(t *testing.T) {
+	streams, out, _ := fakeStreams()
+
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).
+		WithObjects(testConfig(true)).Build()
+
+	o := &SuspendOptions{client: fc, yes: true, IOStreams: streams}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "already suspended") {
+		t.Errorf("expected already suspended message, got %q", got)
+	}
+}
+
+func TestSuspend_NoCR_Creates(t *testing.T) {
+	streams, out, _ := fakeStreams()
+
+	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+
+	o := &SuspendOptions{client: fc, yes: true, IOStreams: streams}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "suspended") {
+		t.Errorf("expected suspended message, got %q", got)
+	}
+
+	cfg := &agenticv1alpha1.AgenticOLSConfig{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: configName}, cfg); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !cfg.Spec.Suspended {
+		t.Error("expected Suspended=true on newly created CR")
+	}
+}

--- a/cli/system/testutil_test.go
+++ b/cli/system/testutil_test.go
@@ -1,0 +1,37 @@
+package system
+
+import (
+	"bytes"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = agenticv1alpha1.AddToScheme(s)
+	return s
+}
+
+func testConfig(suspended bool) *agenticv1alpha1.AgenticOLSConfig {
+	return &agenticv1alpha1.AgenticOLSConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: configName},
+		Spec:       agenticv1alpha1.AgenticOLSConfigSpec{Suspended: suspended},
+	}
+}
+
+func fakeStreams() (genericclioptions.IOStreams, *bytes.Buffer, *bytes.Buffer) {
+	in := &bytes.Buffer{}
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	streams := genericclioptions.IOStreams{
+		In:     in,
+		Out:    out,
+		ErrOut: errOut,
+	}
+	return streams, out, errOut
+}


### PR DESCRIPTION
## Summary

Implements CLI commands for managing system suspension (kill switch), per spec rules 19-22.

**New commands:**
- `oc agentic status` — reports "Agentic System: SUSPENDED" or "Active"
- `oc agentic suspend` — patches AgenticOLSConfig.spec.suspended=true with confirmation prompt (skip with `--yes`)
- `oc agentic resume` — patches AgenticOLSConfig.spec.suspended=false

**EmergencyStopped support in existing CLI:**
- Added to `validProposalPhases` — enables `--phase=EmergencyStopped` filter on proposal list
- Added to `IsTerminalPhase` — `watch` exits on this phase
- Added to `PhaseColor` — magenta color for visibility

**Default namespace:** Changed fallback from `"default"` to `"openshift-lightspeed"` (ignores kubeconfig `"default"` namespace as it's not meaningful for this tool).

## Testing

- [x] `make vet` — passes
- [x] `make api-lint` — passes
- [x] `make test` — all unit tests pass (11 new tests in `cli/system/`, updated helpers tests)
- [x] Spec updated: `.ai/spec/how/cli.md`

## Spec Reference

- `.ai/spec/what/system-config.md` rules 19-22
- `.ai/spec/how/cli.md` (updated with new module map and command tree)


Made with [Cursor](https://cursor.com)