### PR TITLE
chore: make CodeRabbit reviews blocking

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,6 +8,9 @@ tone_instructions: >-
 
 reviews:
   profile: chill
+  request_changes_workflow: true
+  pre_merge_checks:
+    override_requested_reviewers_only: true
 
   auto_review:
     enabled: true


### PR DESCRIPTION
## Summary

- Enable `request_changes_workflow: true` so CodeRabbit submits "Request Changes" reviews that block merging until all comments are addressed or rebutted
- Set `override_requested_reviewers_only: true` so only requested reviewers (not the PR author) can force-override failing checks

## Test plan

- [ ] Open a test PR with a deliberate issue (e.g. hardcoded secret) and verify CodeRabbit submits a blocking "Request Changes" review
- [ ] Verify that replying with a valid rebuttal auto-resolves the thread
- [ ] Verify the PR author cannot use `@coderabbitai ignore pre-merge checks`


Made with [Cursor](https://cursor.com)