### PR TITLE
chore: use utilruntime.Must for all AddToScheme calls

### DIFF
--- a/cli/proposal/helpers.go
+++ b/cli/proposal/helpers.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/duration"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -57,8 +58,8 @@ var validSandboxSteps = []string{
 
 var scheme = func() *runtime.Scheme {
 	s := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(s)
-	_ = agenticv1alpha1.AddToScheme(s)
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(agenticv1alpha1.AddToScheme(s))
 	return s
 }()
 

--- a/cli/proposal/testutil_test.go
+++ b/cli/proposal/testutil_test.go
@@ -7,14 +7,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 func testScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(s)
-	_ = agenticv1alpha1.AddToScheme(s)
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(agenticv1alpha1.AddToScheme(s))
 	return s
 }
 

--- a/cli/system/helpers.go
+++ b/cli/system/helpers.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,8 +18,8 @@ const configName = "cluster"
 
 var scheme = func() *runtime.Scheme {
 	s := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(s)
-	_ = agenticv1alpha1.AddToScheme(s)
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(agenticv1alpha1.AddToScheme(s))
 	return s
 }()
 

--- a/cli/system/testutil_test.go
+++ b/cli/system/testutil_test.go
@@ -6,14 +6,15 @@ import (
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 func testScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(s)
-	_ = agenticv1alpha1.AddToScheme(s)
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(agenticv1alpha1.AddToScheme(s))
 	return s
 }
 

--- a/controller/console/reconciler_test.go
+++ b/controller/console/reconciler_test.go
@@ -11,15 +11,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func testScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
-	_ = appsv1.AddToScheme(s)
-	_ = consolev1.AddToScheme(s)
-	_ = openshiftv1.AddToScheme(s)
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(appsv1.AddToScheme(s))
+	utilruntime.Must(consolev1.AddToScheme(s))
+	utilruntime.Must(openshiftv1.AddToScheme(s))
 	return s
 }
 

--- a/controller/proposal/bare_pod_manager_test.go
+++ b/controller/proposal/bare_pod_manager_test.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
@@ -15,7 +16,7 @@ import (
 
 func newBarePodClient() *fake.ClientBuilder {
 	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
+	utilruntime.Must(corev1.AddToScheme(s))
 	return fake.NewClientBuilder().WithScheme(s)
 }
 

--- a/controller/proposal/reconciler_test.go
+++ b/controller/proposal/reconciler_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -74,9 +75,9 @@ func (ta *testAgentCaller) ReleaseSandboxes(_ context.Context, _ *agenticv1alpha
 
 func testScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
-	_ = agenticv1alpha1.AddToScheme(s)
-	_ = corev1.AddToScheme(s)
-	_ = rbacv1.AddToScheme(s)
+	utilruntime.Must(agenticv1alpha1.AddToScheme(s))
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(rbacv1.AddToScheme(s))
 	return s
 }
 

--- a/controller/sandbox/bootstrap_test.go
+++ b/controller/sandbox/bootstrap_test.go
@@ -9,12 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func testScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
+	utilruntime.Must(corev1.AddToScheme(s))
 	return s
 }
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
@@ -43,7 +44,7 @@ func newClient(t *testing.T) client.Client {
 	}
 
 	s := scheme.Scheme
-	_ = agenticv1alpha1.AddToScheme(s)
+	utilruntime.Must(agenticv1alpha1.AddToScheme(s))
 
 	c, err := client.New(cfg, client.Options{Scheme: s})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Replace `_ = AddToScheme(...)` with `utilruntime.Must(...)` across CLI, controller tests, and e2e helpers
- Aligns scheme registration with the existing pattern in `cmd/main.go`

## Test plan
- [x] `make vet`
- [x] `make test`


Made with [Cursor](https://cursor.com)