### PR TITLE
OLS-3024: Add Jaeger deploy/undeploy scripts for dev OTLP tracing

### DIFF
--- a/hack/deploy-jaeger.sh
+++ b/hack/deploy-jaeger.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Deploy Jaeger all-in-one for dev OTLP trace collection (OLS-3024)
+set -euo pipefail
+
+NAMESPACE="${1:-observability}"
+
+echo "==> Deploying Jaeger all-in-one to namespace '$NAMESPACE'"
+
+oc get project "$NAMESPACE" &>/dev/null || oc new-project "$NAMESPACE"
+
+oc create deployment jaeger --image=jaegertracing/jaeger:latest --port=16686 -n "$NAMESPACE" 2>/dev/null || echo "deployment/jaeger already exists"
+
+oc set env deployment/jaeger COLLECTOR_OTLP_ENABLED=true -n "$NAMESPACE"
+
+for svc in jaeger-ui:16686 jaeger-otlp-grpc:4317 jaeger-otlp-http:4318; do
+  name="${svc%%:*}"
+  port="${svc##*:}"
+  oc expose deployment jaeger --port="$port" --target-port="$port" --name="$name" -n "$NAMESPACE" 2>/dev/null || echo "svc/$name already exists"
+done
+
+oc expose svc jaeger-ui -n "$NAMESPACE" 2>/dev/null || echo "route/jaeger-ui already exists"
+
+echo "==> Waiting for rollout..."
+oc rollout status deployment/jaeger -n "$NAMESPACE" --timeout=120s
+
+ROUTE=$(oc get route jaeger-ui -n "$NAMESPACE" -o jsonpath='{.spec.host}')
+
+echo ""
+echo "Jaeger UI:   http://$ROUTE"
+echo "OTLP gRPC:   jaeger-otlp-grpc.$NAMESPACE.svc.cluster.local:4317"
+echo "OTLP HTTP:   jaeger-otlp-http.$NAMESPACE.svc.cluster.local:4318"

--- a/hack/undeploy-jaeger.sh
+++ b/hack/undeploy-jaeger.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Remove Jaeger all-in-one dev deployment (OLS-3024)
+set -euo pipefail
+
+NAMESPACE="${1:-observability}"
+
+echo "==> Removing Jaeger from namespace '$NAMESPACE'"
+
+oc delete route jaeger-ui -n "$NAMESPACE" --ignore-not-found
+oc delete svc jaeger-ui jaeger-otlp-grpc jaeger-otlp-http -n "$NAMESPACE" --ignore-not-found
+oc delete deployment jaeger -n "$NAMESPACE" --ignore-not-found
+oc delete project "$NAMESPACE" --ignore-not-found
+
+echo "==> Done"


### PR DESCRIPTION
## Summary
- Adds `hack/deploy-jaeger.sh` — deploys Jaeger all-in-one with OTLP collection enabled for dev trace verification
- Adds `hack/undeploy-jaeger.sh` — tears down the Jaeger deployment and namespace
- Both scripts are idempotent and accept an optional namespace argument (defaults to `observability`)

## Test plan
- [ ] Run `./hack/deploy-jaeger.sh` on a dev cluster
- [ ] Verify Jaeger UI route is accessible
- [ ] Verify OTLP gRPC (4317) and HTTP (4318) services exist
- [ ] Run `./hack/undeploy-jaeger.sh` to clean up

🤖 Generated with [Claude Code](https://claude.com/claude-code)