### PR TITLE
quickstart: update console plugin minimum to OpenShift 4.22+

### DIFF
--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -315,7 +315,7 @@ cat <<DONE
   Sandbox image : ${SANDBOX_IMAGE}
   Console image : ${CONSOLE_IMAGE}
 
-  > Console works only on OpenShift 4.21+
+  > Console works only on OpenShift 4.22+
 ════════════════════════════════════════════════════════════════
 
   NEXT: Configure your LLM provider. Pick one:


### PR DESCRIPTION
## Summary
- Update the quickstart install success message to state the agentic console plugin requires OpenShift 4.22+ (was 4.21+)

## Test plan
- [x] Verified only the post-install banner text in `hack/quickstart/install.sh` changed


Made with [Cursor](https://cursor.com)