### PR TITLE
OLS-3396: Publish oc-agentic CLI binaries via GitHub Releases

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,42 @@
+name: Release CLI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cmd/oc-agentic/**"
+      - "cli/**"
+      - "api/**"
+      - "go.mod"
+      - "go.sum"
+      - ".goreleaser.yaml"
+      - ".github/workflows/release-cli.yml"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        with:
+          args: release --snapshot --clean
+
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: latest
+          name: Latest CLI Build
+          prerelease: true
+          make_latest: false
+          files: |
+            dist/*.tar.gz
+            dist/checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,32 @@
+version: 2
+
+project_name: oc-agentic
+
+builds:
+  - main: ./cmd/oc-agentic
+    binary: oc-agentic
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/openshift/lightspeed-agentic-operator/cli.Version={{ .Summary }}
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: "oc-agentic_{{ .Os }}_{{ .Arch }}"
+    files:
+      - none*
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ .Summary }}"
+
+release:
+  disable: true


### PR DESCRIPTION
  ## Summary

  - Adds GoReleaser config and GitHub Actions workflow to publish pre-built `oc-agentic` binaries on every push to `main` that touches CLI-relevant paths
  - Produces 4 tarballs (linux/darwin × amd64/arm64) + SHA256 checksums, uploaded to a rolling `latest` release
  - Version injected via ldflags from `git describe`, replacing the default `dev`

  ## Installation

  ```bash
  # Linux amd64
  curl -L https://github.com/openshift/lightspeed-agentic-operator/releases/latest/download/oc-agentic_linux_amd64.tar.gz | tar xz
  sudo mv oc-agentic /usr/local/bin/

  # macOS Apple Silicon
  curl -L https://github.com/openshift/lightspeed-agentic-operator/releases/latest/download/oc-agentic_darwin_arm64.tar.gz | tar xz
  sudo mv oc-agentic /usr/local/bin/

  Test plan

  - [x] goreleaser check passes
  - [x] goreleaser release --snapshot --clean produces 4 tarballs + checksums.txt
  - [x] Built binary reports git-describe version (oc-agentic 30058f2), not dev
  - [ ] After merge: latest release appears on GitHub with expected artifacts