### PR TITLE
OLS-3328: Add templog spec for finalizer and OTLP log emission

### DIFF
--- a/.ai/spec/what/audit-logging.md
+++ b/.ai/spec/what/audit-logging.md
@@ -66,7 +66,25 @@ Implementation spec for compliance audit logging in the agentic operator. Parent
 
 18. `spec.audit.otel.endpoint` controls OTEL trace export. When set, the operator configures an OTLP exporter pointed at that endpoint. When empty or absent, a no-op exporter is used. Independent of the `logging` flag — tracing works regardless of whether logging is on or off.
 
-19. The operator MUST pass the OTEL endpoint to the sandbox via environment variable or config mount so the sandbox can configure its own exporter.
+19. The operator MUST pass the OTEL tracing endpoint to the sandbox via environment variable or config mount so the sandbox can configure its own exporter.
+
+### OTLP Log Emission (Templog)
+
+20. When the OTLP log endpoint environment variable is set (wired by the lightspeed-operator when `spec.templog` is enabled), the operator MUST also emit all audit events as OTLP log records to that endpoint. This is in addition to stdout — dual emission.
+
+21. Each OTLP log record MUST carry: `trace_id` in the log record's trace context (Proposal `metadata.uid`, hyphens stripped), `event` as a log record attribute, and the full structured JSON audit event as the log record body.
+
+22. The OTLP log endpoint is independent of `spec.audit.otel.endpoint` (tracing). Both can be active simultaneously.
+
+23. When the OTLP log endpoint is absent, no OTLP log records are emitted. No error, no warning — graceful degradation.
+
+### Templog Finalizer
+
+24. When a new Proposal CR is created and templog is enabled (read from an environment variable set by the lightspeed-operator), the operator MUST add the finalizer `agentic.openshift.io/templog-cleanup` to the Proposal.
+
+25. On Proposal deletion, if the `agentic.openshift.io/templog-cleanup` finalizer is present, the operator MUST connect to PostgreSQL and execute `DELETE FROM templogs.logs WHERE trace_id = $1`. On success, remove the finalizer. On failure, block deletion and requeue with exponential backoff.
+
+26. The finalizer does not depend on the Collector being present — it connects directly to PostgreSQL. See `templog.md` for edge cases.
 
 ### Structured JSON Format
 
@@ -78,3 +96,4 @@ Implementation spec for compliance audit logging in the agentic operator. Parent
 - `approval.md` — approval flow and ProposalApproval CR
 - `sandbox-execution.md` — sandbox HTTP calls where trace context is propagated
 - `crd-api.md` — CRD definitions (ProposalApproval needs `spec.approver` addition)
+- `templog.md` — Temporary audit log storage: OTLP log emission, finalizer, Postgres cleanup

--- a/.ai/spec/what/crd-api.md
+++ b/.ai/spec/what/crd-api.md
@@ -68,7 +68,8 @@ Kubernetes API surface for the agentic operator. **Lifecycle and gates** are in 
 - `metadata.name` (must be `cluster`), `spec.stages[]`, `spec.maxAttempts`, `spec.maxConcurrentProposals`
 
 ### AgenticOLSConfig
-- `metadata.name` (must be `cluster`), `spec.suspended`
+- `metadata.name` (must be `cluster`), `spec.suspended`, `spec.templog`
+- `spec.templog` (bool, default `true`): When `true` or absent, the lightspeed-operator deploys a custom OTel Collector for temporary audit log storage in PostgreSQL. See `templog.md`.
 - `status.conditions` — condition types: `Suspended`
 - See `system-config.md` for full behavioral rules
 
@@ -94,3 +95,4 @@ Kubernetes API surface for the agentic operator. **Lifecycle and gates** are in 
 
 - [PLANNED: OLS-2940] Autonomous workflow CRD migrations may rename or reshape fields; specs MUST be updated when `v1alpha1` changes.
 - [PLANNED: OLS-2894] Explicit **Agent** fields for per-step system prompts if moved from template/runtime-only assembly (today prompts are composed outside `Agent` CR — see `sandbox-execution.md`).
+- [OLS-3328] Add `spec.templog` to `AgenticOLSConfig` CRD for temporary audit log storage.

--- a/.ai/spec/what/templog.md
+++ b/.ai/spec/what/templog.md
@@ -1,0 +1,45 @@
+# Temporary Audit Log Storage — Agentic Operator
+
+Implementation details for the agentic-operator's role in the templog feature. See parent spec `what/templog.md` for requirements and architecture.
+
+## Behavioral Rules
+
+### OTLP Log Emission
+
+1. When the OTLP log endpoint environment variable is set (wired by the lightspeed-operator), the agentic-operator emits audit events as OTLP log records to that endpoint.
+2. Structured JSON to stdout always emits when audit is enabled, regardless of whether the OTLP log endpoint is set. This is dual emission — stdout is never replaced.
+3. The OTLP log endpoint is independent of `spec.audit.otel.endpoint` (tracing). The operator can emit to both simultaneously: OTLP logs to the Collector, OTLP spans to the tracing endpoint.
+4. Each OTLP log record carries:
+   - `trace_id` in the log record's trace context (Proposal `metadata.uid`, hyphens stripped, 32-char hex)
+   - `event` as a log record attribute (the event discriminator, e.g., `audit.proposal.received`)
+   - The full structured JSON audit event as the log record body
+5. When the OTLP log endpoint is absent, no OTLP log records are emitted. No error, no warning — same graceful degradation as the tracing no-op exporter.
+
+### Proposal Finalizer
+
+6. When a new Proposal CR is created and templog is enabled (agentic-operator reads this from an environment variable set by the lightspeed-operator), the operator adds the finalizer `agentic.openshift.io/templog-cleanup` to the Proposal.
+7. When a Proposal CR is deleted and the `agentic.openshift.io/templog-cleanup` finalizer is present:
+   a. The operator connects to PostgreSQL using the credentials from the shared secret.
+   b. Executes `DELETE FROM templogs.logs WHERE trace_id = $1` where `$1` is the Proposal `metadata.uid` with hyphens stripped.
+   c. On success, removes the finalizer — CR deletion proceeds.
+   d. On failure (Postgres unreachable, query error), the finalizer blocks deletion. The reconciler requeues with standard controller-runtime exponential backoff.
+8. The finalizer does not depend on the Collector being present. It connects directly to PostgreSQL. This handles the case where `spec.templog` was disabled after logs were written — the finalizer still fires and cleans up.
+
+### Postgres Connectivity
+
+9. The agentic-operator reads PostgreSQL connection details from the same credentials secret managed by the lightspeed-operator.
+10. The connection to PostgreSQL uses TLS via service-ca certificates (same as all other Postgres clients in the system).
+11. The Postgres connection is used only for the finalizer cleanup query. The agentic-operator does not write to PostgreSQL — that is the Collector's responsibility.
+
+## Edge Cases
+
+- **Templog disabled after Proposal creation.** The finalizer was already added. On deletion, the finalizer fires and deletes rows from Postgres. The Collector being absent does not affect this — the operator connects directly to Postgres.
+- **Postgres unavailable during Proposal deletion.** The finalizer blocks. The Proposal CR cannot be deleted until cleanup succeeds. This is correct for a compliance-adjacent feature.
+- **No rows to delete.** The `DELETE` query returns 0 rows affected. The finalizer succeeds and is removed. No error.
+- **Templog enabled mid-lifecycle.** Proposals created before templog was enabled do not have the finalizer. Their audit events were not stored in Postgres (the Collector was not deployed). No cleanup needed.
+
+## Cross-References
+
+- Parent spec: `what/templog.md`
+- `what/audit-logging.md` — Audit event catalog, structured JSON format, OTEL span hierarchy
+- `what/proposal-lifecycle.md` — Proposal CR lifecycle, phase transitions, finalizers


### PR DESCRIPTION
## Summary
- Adds child spec `what/templog.md` for agentic-operator's role: OTLP log emission, `agentic.openshift.io/templog-cleanup` finalizer, Postgres cleanup on Proposal deletion
- Updates `what/audit-logging.md` with OTLP log emission and finalizer rules
- Updates `what/crd-api.md` with `spec.templog` on `AgenticOLSConfig`

## Context
Part of [OLS-3328](https://redhat.atlassian.net/browse/OLS-3328) (temporary audit log storage). The agentic-operator emits OTLP log records to the Collector and cleans up Postgres rows when Proposals are deleted.

Parent spec PR: https://github.com/openshift/ols/pull/11

## Test plan
- [ ] Spec-only change — no code, no tests
- [ ] Review spec for completeness and accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)