### PR TITLE
feat: bootstrap analysis RBAC in operator instead of quickstart script

### DIFF
--- a/controller/sandbox/bootstrap.go
+++ b/controller/sandbox/bootstrap.go
@@ -1,12 +1,14 @@
 package sandbox
 
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create
 
 import (
 	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -23,8 +25,9 @@ var sandboxTemplateGVK = schema.GroupVersionKind{
 }
 
 const (
-	ErrEnsureSA              = "ensure ServiceAccount"
-	ErrEnsureSandboxTemplate = "ensure SandboxTemplate"
+	ErrEnsureSA                 = "ensure ServiceAccount"
+	ErrEnsureClusterRoleBinding = "ensure ClusterRoleBinding"
+	ErrEnsureSandboxTemplate    = "ensure SandboxTemplate"
 )
 
 type BootstrapConfig struct {
@@ -47,6 +50,14 @@ func EnsureBootstrapResources(ctx context.Context, c client.Client, cfg Bootstra
 		return fmt.Errorf("%s: %w", ErrEnsureSA, err)
 	}
 	log.V(1).Info("ServiceAccount ready")
+
+	if err := ensureClusterRoleBinding(ctx, c, "lightspeed-agent-cluster-reader", "cluster-reader", templateName, cfg.Namespace); err != nil {
+		return fmt.Errorf("%s %s: %w", ErrEnsureClusterRoleBinding, "cluster-reader", err)
+	}
+	if err := ensureClusterRoleBinding(ctx, c, "lightspeed-agent-monitoring-view", "cluster-monitoring-view", templateName, cfg.Namespace); err != nil {
+		return fmt.Errorf("%s %s: %w", ErrEnsureClusterRoleBinding, "cluster-monitoring-view", err)
+	}
+	log.V(1).Info("Agent read ClusterRoleBindings ready")
 
 	if cfg.SandboxMode == "sandbox-claim" {
 		if err := ensureSandboxTemplate(ctx, c, cfg.Image, cfg.Namespace); err != nil {
@@ -77,6 +88,29 @@ func ensureServiceAccount(ctx context.Context, c client.Client, namespace string
 		AutomountServiceAccountToken: ptr.To(false),
 	}
 	if err := c.Create(ctx, sa); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func ensureClusterRoleBinding(ctx context.Context, c client.Client, name, clusterRoleName, saName, namespace string) error {
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      saName,
+			Namespace: namespace,
+		}},
+	}
+	if err := c.Create(ctx, crb); err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
 	return nil

--- a/controller/sandbox/bootstrap_test.go
+++ b/controller/sandbox/bootstrap_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,6 +17,7 @@ import (
 func testScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(rbacv1.AddToScheme(s))
 	return s
 }
 
@@ -43,6 +45,26 @@ func TestEnsureBootstrapResources_CreatesResources(t *testing.T) {
 	}
 	if sa.AutomountServiceAccountToken != nil && *sa.AutomountServiceAccountToken {
 		t.Error("ServiceAccount should not automount token")
+	}
+
+	for _, tc := range []struct {
+		bindingName string
+		roleName    string
+	}{
+		{"lightspeed-agent-cluster-reader", "cluster-reader"},
+		{"lightspeed-agent-monitoring-view", "cluster-monitoring-view"},
+	} {
+		var crb rbacv1.ClusterRoleBinding
+		if err := fc.Get(context.Background(), types.NamespacedName{Name: tc.bindingName}, &crb); err != nil {
+			t.Errorf("ClusterRoleBinding %s not created: %v", tc.bindingName, err)
+			continue
+		}
+		if crb.RoleRef.Name != tc.roleName {
+			t.Errorf("ClusterRoleBinding %s RoleRef.Name = %q, want %q", tc.bindingName, crb.RoleRef.Name, tc.roleName)
+		}
+		if len(crb.Subjects) != 1 || crb.Subjects[0].Name != templateName || crb.Subjects[0].Namespace != cfg.Namespace {
+			t.Errorf("ClusterRoleBinding %s has unexpected subjects: %v", tc.bindingName, crb.Subjects)
+		}
 	}
 
 	tmpl := &unstructured.Unstructured{}

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -181,39 +181,6 @@ $([ -n "${IMAGE_PULL_POLICY}" ] && echo '        - "--image-pull-policy='"${IMAG
 EOF
 info "Operator deployment applied"
 
-# --- Step 3b: Agent read RBAC -------------------------------------------------
-
-info "Binding read permissions to lightspeed-agent SA..."
-
-oc apply -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: lightspeed-agent-cluster-reader
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-reader
-subjects:
-- kind: ServiceAccount
-  name: lightspeed-agent
-  namespace: ${NAMESPACE}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: lightspeed-agent-monitoring-view
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-monitoring-view
-subjects:
-- kind: ServiceAccount
-  name: lightspeed-agent
-  namespace: ${NAMESPACE}
-EOF
-info "Agent read RBAC applied (cluster-reader + cluster-monitoring-view)"
-
 # --- Step 4: ApprovalPolicy ---------------------------------------------------
 
 step "4/7" "Creating ApprovalPolicy..."


### PR DESCRIPTION
Move ClusterRoleBinding creation for the lightspeed-agent SA from the quickstart install.sh into the operator's bootstrap code. The operator now creates cluster-reader and cluster-monitoring-view bindings at startup via EnsureBootstrapResources, following the same idempotent create-or-skip pattern used for the ServiceAccount.


Assisted-by: Claude Code:claude-opus-4-6