### PR TITLE
docs: add oc-agentic CLI install, usage, and command reference

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           tag_name: latest
           name: Latest CLI Build
-          prerelease: true
-          make_latest: false
+          prerelease: false
+          make_latest: true
           files: |
             dist/*.tar.gz
             dist/checksums.txt

--- a/README.md
+++ b/README.md
@@ -6,6 +6,80 @@ Kubernetes controller for the agentic proposal workflow (`agentic.openshift.io/v
 - **Two Go modules (`go.mod` / `go.sum` at root and under `api/`)**: below; **directory map, phases, conventions**: [`CLAUDE.md`](CLAUDE.md)
 - **Tests, manifests, Makefile, cluster workflow, `make api-lint`, CEL / `XValidation`**: this file
 
+## CLI Plugin (`oc-agentic`)
+
+The `oc-agentic` binary is an `oc` CLI plugin for managing proposals. Place it in `$PATH` and `oc` auto-discovers it as `oc agentic <subcommand>`. It also works standalone.
+
+### Install
+
+```bash
+# Linux amd64
+curl -L https://github.com/openshift/lightspeed-agentic-operator/releases/latest/download/oc-agentic_linux_amd64.tar.gz | tar xz
+sudo mv oc-agentic /usr/local/bin/
+
+# macOS Apple Silicon
+curl -L https://github.com/openshift/lightspeed-agentic-operator/releases/latest/download/oc-agentic_darwin_arm64.tar.gz | tar xz
+sudo mv oc-agentic /usr/local/bin/
+```
+
+### Usage
+
+```bash
+# Create a proposal
+oc agentic proposal create --request="Fix crashloop in my-app namespace" --target-namespaces=my-app
+
+# List proposals
+oc agentic proposal list
+
+# Inspect a proposal
+oc agentic proposal get ag-abc12
+
+# Approve steps (analysis → execution → verification)
+oc agentic proposal approve ag-abc12 --stage=analysis
+oc agentic proposal approve ag-abc12 --stage=execution --option=0
+oc agentic proposal approve ag-abc12 --stage=verification
+
+# Or approve all pending steps at once
+oc agentic proposal approve ag-abc12 --all --wait
+
+# Deny a step
+oc agentic proposal deny ag-abc12 --stage=execution
+
+# Watch phase transitions
+oc agentic proposal watch ag-abc12
+
+# Stream sandbox logs
+oc agentic proposal logs ag-abc12 --step=Execution -f
+
+# Delete a proposal
+oc agentic proposal delete ag-abc12
+
+# System operations
+oc agentic status                # check if system is active or suspended
+oc agentic suspend --yes         # halt all agentic operations
+oc agentic resume                # resume operations
+oc agentic version
+```
+
+### Command Reference
+
+| Command | Description |
+|---------|-------------|
+| `proposal create` | Create a new proposal (`--request`, `--agent`, `--target-namespaces`) |
+| `proposal list` (`ls`) | List proposals (`-A`, `--phase`, `-o wide\|json\|yaml`) |
+| `proposal get` | Show proposal details (`-o json\|yaml`) |
+| `proposal approve` | Approve a step (`--stage`, `--option`, `--agent`, `--all`, `--wait`) |
+| `proposal deny` | Deny a step (`--stage`, defaults to next pending) |
+| `proposal watch` | Stream phase transitions until terminal |
+| `proposal logs` | Stream sandbox pod logs (`--step`, `-f`) |
+| `proposal delete` | Delete a proposal |
+| `status` | Show system suspension state |
+| `suspend` | Suspend all operations (`--yes` to skip prompt) |
+| `resume` | Resume operations |
+| `version` | Print plugin version |
+
+Default namespace is `openshift-lightspeed` unless overridden with `-n` or kubeconfig context.
+
 ## Development
 
 Run the manager against a cluster using the usual controller-runtime kubeconfig rules (`KUBECONFIG`, default kubeconfig path, or in-cluster as a pod). Auth plugins (OIDC, GCP, Azure, …) are registered via `k8s.io/client-go/plugin/pkg/client/auth`.

--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -63,17 +63,8 @@ The [`examples/`](examples/) directory contains LLMProvider + Agent templates:
 
 ## CLI Plugin
 
-Install the `oc-agentic` CLI plugin to manage proposals from the command line:
-
-```bash
-# Linux amd64
-curl -L https://github.com/openshift/lightspeed-agentic-operator/releases/latest/download/oc-agentic_linux_amd64.tar.gz | tar xz
-sudo mv oc-agentic /usr/local/bin/
-
-# macOS Apple Silicon
-curl -L https://github.com/openshift/lightspeed-agentic-operator/releases/latest/download/oc-agentic_darwin_arm64.tar.gz | tar xz
-sudo mv oc-agentic /usr/local/bin/
-```
+Install the `oc-agentic` CLI plugin to manage proposals from the command line
+([install instructions](../../README.md#install)).
 
 Verify installation:
 

--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -61,9 +61,54 @@ The [`examples/`](examples/) directory contains LLMProvider + Agent templates:
 | [`vertex-anthropic.yaml`](examples/vertex-anthropic.yaml) | Vertex AI with Claude |
 | [`vertex-google.yaml`](examples/vertex-google.yaml) | Vertex AI with Gemini |
 
+## CLI Plugin
+
+Install the `oc-agentic` CLI plugin to manage proposals from the command line:
+
+```bash
+# Linux amd64
+curl -L https://github.com/openshift/lightspeed-agentic-operator/releases/latest/download/oc-agentic_linux_amd64.tar.gz | tar xz
+sudo mv oc-agentic /usr/local/bin/
+
+# macOS Apple Silicon
+curl -L https://github.com/openshift/lightspeed-agentic-operator/releases/latest/download/oc-agentic_darwin_arm64.tar.gz | tar xz
+sudo mv oc-agentic /usr/local/bin/
+```
+
+Verify installation:
+
+```bash
+oc agentic version
+```
+
 ## Example Proposal
 
 [`deploy-test-workload.yaml`](examples/deploy-test-workload.yaml) submits a
 proposal that analyzes the target namespace and deploys a test workload
 (nginx Deployment + Service). Execution requires manual approval via
 `ProposalApproval`.
+
+### Using the CLI
+
+Instead of applying YAML, you can create and manage proposals with the CLI:
+
+```bash
+# Create a proposal
+oc agentic proposal create --request="Deploy a test nginx workload" --target-namespaces=default
+
+# Watch it progress
+oc agentic proposal list
+oc agentic proposal get <name>
+
+# Approve analysis, then execution
+oc agentic proposal approve <name> --stage=analysis
+oc agentic proposal approve <name> --stage=execution --option=0
+
+# Stream sandbox logs
+oc agentic proposal logs <name> -f
+
+# Check system status
+oc agentic status
+```
+
+See the [CLI reference](../../README.md#cli-plugin-oc-agentic) for all commands and flags.


### PR DESCRIPTION
README.md had no mention of the CLI plugin. Add a full section with install commands, usage walkthrough, and command reference table. Quickstart README now includes CLI install and shows how to manage proposals from the command line instead of applying YAML.

Also update .ai/spec/how/cli.md to match current code: CRD-not-installed guards, Draining reason in status, RawPatch in resume, escalation step display in get, and missing phase/step validation gaps.