### PR TITLE
OLS-3502: handle terminating pod in BarePodManager.Claim

### DIFF
--- a/controller/proposal/bare_pod_manager.go
+++ b/controller/proposal/bare_pod_manager.go
@@ -19,6 +19,8 @@ const (
 	ErrBuildPodSpec = "build pod spec"
 	ErrCreatePod    = "create pod for"
 	ErrDeletePod    = "delete pod"
+
+	defaultDeletionTimeout = 2 * time.Minute
 )
 
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;delete
@@ -26,9 +28,10 @@ const (
 // BarePodManager is a SandboxProvider that creates bare Pods using PodSpecBuilder
 // instead of relying on the Sandbox API (SandboxClaim/SandboxTemplate).
 type BarePodManager struct {
-	Client    client.Client
-	Builder   *PodSpecBuilder
-	Namespace string
+	Client          client.Client
+	Builder         *PodSpecBuilder
+	Namespace       string
+	DeletionTimeout time.Duration
 
 	agent          *agenticv1alpha1.Agent
 	llm            *agenticv1alpha1.LLMProvider
@@ -84,10 +87,26 @@ func (m *BarePodManager) Claim(ctx context.Context, proposalName, step, _ string
 	}
 
 	if err := m.Client.Create(ctx, pod); err != nil {
-		if apierrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
+			return "", fmt.Errorf("%s %s: %w", ErrCreatePod, step, err)
+		}
+
+		var existing corev1.Pod
+		key := types.NamespacedName{Name: podName, Namespace: m.Namespace}
+		if getErr := m.Client.Get(ctx, key, &existing); getErr != nil {
+			return "", fmt.Errorf("get existing pod %q: %w", podName, getErr)
+		}
+		if existing.DeletionTimestamp.IsZero() {
 			return podName, nil
 		}
-		return "", fmt.Errorf("%s %s: %w", ErrCreatePod, step, err)
+
+		log.Info("Waiting for terminating pod to disappear", LogKeyName, podName)
+		if err := m.waitForDeletion(ctx, key); err != nil {
+			return "", fmt.Errorf("wait for terminating pod %q: %w", podName, err)
+		}
+		if err := m.Client.Create(ctx, pod); err != nil {
+			return "", fmt.Errorf("%s %s: %w", ErrCreatePod, step, err)
+		}
 	}
 
 	log.Info("Created bare pod", LogKeyName, podName, LogKeyStep, step)
@@ -128,6 +147,35 @@ func (m *BarePodManager) WaitReady(ctx context.Context, podName string, timeout 
 					log.Info("Pod ready", LogKeyName, podName, "podIP", pod.Status.PodIP)
 					return pod.Status.PodIP, nil
 				}
+			}
+		}
+	}
+}
+
+// waitForDeletion polls until the named pod no longer exists. It is used
+// by Claim to wait for a terminating pod to disappear before creating a
+// replacement with the same name. The timeout is controlled by DeletionTimeout
+// (defaults to defaultDeletionTimeout).
+func (m *BarePodManager) waitForDeletion(ctx context.Context, key types.NamespacedName) error {
+	timeout := m.DeletionTimeout
+	if timeout == 0 {
+		timeout = defaultDeletionTimeout
+	}
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if time.Now().After(deadline) {
+				return fmt.Errorf("timeout waiting for pod %q to be deleted after %s", key.Name, timeout)
+			}
+			var pod corev1.Pod
+			if err := m.Client.Get(ctx, key, &pod); apierrors.IsNotFound(err) {
+				return nil
 			}
 		}
 	}

--- a/controller/proposal/bare_pod_manager.go
+++ b/controller/proposal/bare_pod_manager.go
@@ -105,6 +105,9 @@ func (m *BarePodManager) Claim(ctx context.Context, proposalName, step, _ string
 			return "", fmt.Errorf("wait for terminating pod %q: %w", podName, err)
 		}
 		if err := m.Client.Create(ctx, pod); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return podName, nil
+			}
 			return "", fmt.Errorf("%s %s: %w", ErrCreatePod, step, err)
 		}
 	}
@@ -166,17 +169,21 @@ func (m *BarePodManager) waitForDeletion(ctx context.Context, key types.Namespac
 	defer ticker.Stop()
 
 	for {
+		var pod corev1.Pod
+		err := m.Client.Get(ctx, key, &pod)
+		switch {
+		case apierrors.IsNotFound(err):
+			return nil
+		case err != nil:
+			return fmt.Errorf("get pod %q: %w", key.Name, err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for pod %q to be deleted after %s", key.Name, timeout)
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if time.Now().After(deadline) {
-				return fmt.Errorf("timeout waiting for pod %q to be deleted after %s", key.Name, timeout)
-			}
-			var pod corev1.Pod
-			if err := m.Client.Get(ctx, key, &pod); apierrors.IsNotFound(err) {
-				return nil
-			}
 		}
 	}
 }

--- a/controller/proposal/bare_pod_manager_test.go
+++ b/controller/proposal/bare_pod_manager_test.go
@@ -142,7 +142,7 @@ func TestBarePodManager_Claim_TerminatingPodReplacedAfterDeletion(t *testing.T) 
 	fc := newBarePodClient().WithObjects(existing).Build()
 	builder := &PodSpecBuilder{Image: "quay.io/test/sandbox:latest"}
 	m := NewBarePodManager(fc, builder, "test-ns")
-	m.DeletionTimeout = 6 * time.Second
+	m.DeletionTimeout = 30 * time.Second
 	m.SetStep(
 		&agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}},
 		testLLMProvider(agenticv1alpha1.LLMProviderAnthropic),
@@ -151,9 +151,10 @@ func TestBarePodManager_Claim_TerminatingPodReplacedAfterDeletion(t *testing.T) 
 	)
 
 	// Remove the finalizer after a short delay so the fake client
-	// allows the pod to disappear.
+	// allows the pod to disappear. The generous DeletionTimeout above
+	// avoids flakiness on slow CI nodes.
 	go func() {
-		time.Sleep(3 * time.Second)
+		time.Sleep(1 * time.Second)
 		var pod corev1.Pod
 		key := types.NamespacedName{Name: "ls-analysis-my-proposal", Namespace: "test-ns"}
 		if err := fc.Get(t.Context(), key, &pod); err != nil {

--- a/controller/proposal/bare_pod_manager_test.go
+++ b/controller/proposal/bare_pod_manager_test.go
@@ -1,12 +1,12 @@
 package proposal
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -33,7 +33,7 @@ func TestBarePodManager_Claim_Creates(t *testing.T) {
 		defaultSandboxSA,
 	)
 
-	name, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
+	name, err := m.Claim(t.Context(), "my-proposal", "analysis", "")
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestBarePodManager_Claim_Creates(t *testing.T) {
 	}
 
 	var pod corev1.Pod
-	if err := fc.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
+	if err := fc.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
 		t.Fatalf("pod not created: %v", err)
 	}
 	if pod.Spec.Containers[0].Image != "quay.io/test/sandbox:latest" {
@@ -67,13 +67,13 @@ func TestBarePodManager_Claim_UsesPerProposalSA(t *testing.T) {
 		"ls-exec-default-my-proposal",
 	)
 
-	name, err := m.Claim(context.Background(), "my-proposal", "execution", "")
+	name, err := m.Claim(t.Context(), "my-proposal", "execution", "")
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
 
 	var pod corev1.Pod
-	if err := fc.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
+	if err := fc.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
 		t.Fatalf("pod not created: %v", err)
 	}
 	if pod.Spec.ServiceAccountName != "ls-exec-default-my-proposal" {
@@ -93,13 +93,13 @@ func TestBarePodManager_Claim_TruncatesLongProposalNameInLabel(t *testing.T) {
 	)
 
 	longName := strings.Repeat("a", 80)
-	name, err := m.Claim(context.Background(), longName, "analysis", "")
+	name, err := m.Claim(t.Context(), longName, "analysis", "")
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
 
 	var pod corev1.Pod
-	if err := fc.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
+	if err := fc.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
 		t.Fatalf("pod not created: %v", err)
 	}
 	if len(pod.Labels[LabelProposal]) > 63 {
@@ -122,12 +122,90 @@ func TestBarePodManager_Claim_AlreadyExists(t *testing.T) {
 		defaultSandboxSA,
 	)
 
-	name, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
+	name, err := m.Claim(t.Context(), "my-proposal", "analysis", "")
 	if err != nil {
 		t.Fatalf("Claim should succeed for existing pod: %v", err)
 	}
 	if name != "ls-analysis-my-proposal" {
 		t.Errorf("name = %q", name)
+	}
+}
+
+func TestBarePodManager_Claim_TerminatingPodReplacedAfterDeletion(t *testing.T) {
+	now := metav1.Now()
+	existing := &corev1.Pod{}
+	existing.Name = "ls-analysis-my-proposal"
+	existing.Namespace = "test-ns"
+	existing.DeletionTimestamp = &now
+	existing.Finalizers = []string{"test-finalizer"}
+
+	fc := newBarePodClient().WithObjects(existing).Build()
+	builder := &PodSpecBuilder{Image: "quay.io/test/sandbox:latest"}
+	m := NewBarePodManager(fc, builder, "test-ns")
+	m.DeletionTimeout = 6 * time.Second
+	m.SetStep(
+		&agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}},
+		testLLMProvider(agenticv1alpha1.LLMProviderAnthropic),
+		nil,
+		defaultSandboxSA,
+	)
+
+	// Remove the finalizer after a short delay so the fake client
+	// allows the pod to disappear.
+	go func() {
+		time.Sleep(3 * time.Second)
+		var pod corev1.Pod
+		key := types.NamespacedName{Name: "ls-analysis-my-proposal", Namespace: "test-ns"}
+		if err := fc.Get(t.Context(), key, &pod); err != nil {
+			return
+		}
+		pod.Finalizers = nil
+		_ = fc.Update(t.Context(), &pod)
+		_ = fc.Delete(t.Context(), &pod)
+	}()
+
+	name, err := m.Claim(t.Context(), "my-proposal", "analysis", "")
+	if err != nil {
+		t.Fatalf("Claim should succeed after terminating pod disappears: %v", err)
+	}
+	if name != "ls-analysis-my-proposal" {
+		t.Errorf("name = %q, want ls-analysis-my-proposal", name)
+	}
+
+	var pod corev1.Pod
+	if err := fc.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
+		t.Fatalf("new pod not created: %v", err)
+	}
+	if pod.Spec.Containers[0].Image != "quay.io/test/sandbox:latest" {
+		t.Errorf("container image = %q", pod.Spec.Containers[0].Image)
+	}
+}
+
+func TestBarePodManager_Claim_TerminatingPodTimeout(t *testing.T) {
+	now := metav1.Now()
+	existing := &corev1.Pod{}
+	existing.Name = "ls-analysis-my-proposal"
+	existing.Namespace = "test-ns"
+	existing.DeletionTimestamp = &now
+	existing.Finalizers = []string{"test-finalizer"}
+
+	fc := newBarePodClient().WithObjects(existing).Build()
+	builder := &PodSpecBuilder{Image: "img"}
+	m := NewBarePodManager(fc, builder, "test-ns")
+	m.DeletionTimeout = 3 * time.Second
+	m.SetStep(
+		&agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}},
+		testLLMProvider(agenticv1alpha1.LLMProviderAnthropic),
+		nil,
+		defaultSandboxSA,
+	)
+
+	_, err := m.Claim(t.Context(), "my-proposal", "analysis", "")
+	if err == nil {
+		t.Fatal("Claim should fail when terminating pod never disappears")
+	}
+	if !strings.Contains(err.Error(), "timeout waiting for pod") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 
@@ -139,12 +217,12 @@ func TestBarePodManager_Release(t *testing.T) {
 	fc := newBarePodClient().WithObjects(existing).Build()
 	m := NewBarePodManager(fc, &PodSpecBuilder{Image: "img"}, "test-ns")
 
-	if err := m.Release(context.Background(), "ls-analysis-my-proposal"); err != nil {
+	if err := m.Release(t.Context(), "ls-analysis-my-proposal"); err != nil {
 		t.Fatalf("Release: %v", err)
 	}
 
 	var pod corev1.Pod
-	err := fc.Get(context.Background(), types.NamespacedName{Name: "ls-analysis-my-proposal", Namespace: "test-ns"}, &pod)
+	err := fc.Get(t.Context(), types.NamespacedName{Name: "ls-analysis-my-proposal", Namespace: "test-ns"}, &pod)
 	if err == nil {
 		t.Error("pod should be deleted")
 	}
@@ -154,7 +232,7 @@ func TestBarePodManager_Release_NotFound(t *testing.T) {
 	fc := newBarePodClient().Build()
 	m := NewBarePodManager(fc, &PodSpecBuilder{Image: "img"}, "test-ns")
 
-	if err := m.Release(context.Background(), "nonexistent"); err != nil {
+	if err := m.Release(t.Context(), "nonexistent"); err != nil {
 		t.Fatalf("Release should not error for not-found: %v", err)
 	}
 }
@@ -170,13 +248,13 @@ func TestBarePodManager_Claim_AuditEnabled_DefaultsTrue(t *testing.T) {
 		defaultSandboxSA,
 	)
 
-	name, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
+	name, err := m.Claim(t.Context(), "my-proposal", "analysis", "")
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
 
 	var pod corev1.Pod
-	if err := fc.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
+	if err := fc.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
 		t.Fatalf("pod not created: %v", err)
 	}
 	env := envToMap(pod.Spec.Containers[0].Env)
@@ -205,13 +283,13 @@ func TestBarePodManager_Claim_AuditWithOTELEndpoint(t *testing.T) {
 		defaultSandboxSA,
 	)
 
-	name, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
+	name, err := m.Claim(t.Context(), "my-proposal", "analysis", "")
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
 
 	var pod corev1.Pod
-	if err := fc.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
+	if err := fc.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
 		t.Fatalf("pod not created: %v", err)
 	}
 	env := envToMap(pod.Spec.Containers[0].Env)
@@ -239,13 +317,13 @@ func TestBarePodManager_Claim_AuditDisabled(t *testing.T) {
 		defaultSandboxSA,
 	)
 
-	name, err := m.Claim(context.Background(), "my-proposal", "analysis", "")
+	name, err := m.Claim(t.Context(), "my-proposal", "analysis", "")
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
 
 	var pod corev1.Pod
-	if err := fc.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
+	if err := fc.Get(t.Context(), types.NamespacedName{Name: name, Namespace: "test-ns"}, &pod); err != nil {
 		t.Fatalf("pod not created: %v", err)
 	}
 	env := envToMap(pod.Spec.Containers[0].Env)
@@ -267,7 +345,7 @@ func TestBarePodManager_WaitReady_ImmediateReady(t *testing.T) {
 	fc := newBarePodClient().WithObjects(pod).Build()
 	m := NewBarePodManager(fc, &PodSpecBuilder{Image: "img"}, "test-ns")
 
-	endpoint, err := m.WaitReady(context.Background(), "ls-analysis-my-proposal", 10*time.Second)
+	endpoint, err := m.WaitReady(t.Context(), "ls-analysis-my-proposal", 10*time.Second)
 	if err != nil {
 		t.Fatalf("WaitReady: %v", err)
 	}


### PR DESCRIPTION
When a pod with the same name is still terminating from a previous run, Claim now detects the DeletionTimestamp and waits for the pod to disappear before creating a replacement. Previously the AlreadyExists error was silently treated as idempotent success, causing WaitReady to poll a vanishing pod until timeout.

Add DeletionTimeout field to BarePodManager (default 2m) and waitForDeletion helper. Add tests for both the successful replacement and timeout cases.


Assisted-by: Claude Code:claude-opus-4-6