### PR TITLE
OLS-3496: Update analysis prompt for script-grounded RBAC derivation

### DIFF
--- a/controller/proposal/revision_test.go
+++ b/controller/proposal/revision_test.go
@@ -86,14 +86,20 @@ func TestBuildAnalysisQuery_FullProposal(t *testing.T) {
 		},
 	}
 	result := buildAnalysisQuery("Fix the crash", proposal)
-	if !strings.Contains(result, "RBAC permissions") {
-		t.Error("full proposal should mention RBAC permissions")
+	if !strings.Contains(result, "Derive RBAC") {
+		t.Error("full proposal should mention RBAC derivation")
 	}
-	if !strings.Contains(result, "verification plan") {
+	if !strings.Contains(result, "Verification plan") {
 		t.Error("full proposal should mention verification plan")
 	}
 	if !strings.Contains(result, "Fix the crash") {
 		t.Error("should contain the request text")
+	}
+	if !strings.Contains(result, "kubectl") {
+		t.Error("should instruct use of kubectl")
+	}
+	if !strings.Contains(result, "remediation script") {
+		t.Error("should require a remediation script")
 	}
 }
 
@@ -104,10 +110,10 @@ func TestBuildAnalysisQuery_TrustMode(t *testing.T) {
 		},
 	}
 	result := buildAnalysisQuery("Fix the crash", proposal)
-	if !strings.Contains(result, "RBAC permissions") {
-		t.Error("execution proposal should mention RBAC permissions")
+	if !strings.Contains(result, "Derive RBAC") {
+		t.Error("execution proposal should mention RBAC derivation")
 	}
-	if strings.Contains(result, "verification plan") {
+	if strings.Contains(result, "Verification plan") {
 		t.Error("trust-mode proposal should NOT mention verification plan")
 	}
 }
@@ -115,10 +121,10 @@ func TestBuildAnalysisQuery_TrustMode(t *testing.T) {
 func TestBuildAnalysisQuery_Advisory(t *testing.T) {
 	proposal := &agenticv1alpha1.Proposal{}
 	result := buildAnalysisQuery("What is 2+2?", proposal)
-	if strings.Contains(result, "RBAC permissions") {
-		t.Error("advisory proposal should NOT mention RBAC permissions")
+	if strings.Contains(result, "Derive RBAC") {
+		t.Error("advisory proposal should NOT mention RBAC derivation")
 	}
-	if strings.Contains(result, "verification plan") {
+	if strings.Contains(result, "Verification plan") {
 		t.Error("advisory proposal should NOT mention verification plan")
 	}
 	if !strings.Contains(result, "What is 2+2?") {

--- a/controller/proposal/sandbox_agent_test.go
+++ b/controller/proposal/sandbox_agent_test.go
@@ -423,8 +423,8 @@ func TestSandboxAgentCaller_AnalysisQueryFraming(t *testing.T) {
 	if !strings.Contains(httpClient.lastQuery, "Pod crashing with OOMKilled") {
 		t.Error("analysis query should contain the original request")
 	}
-	if !strings.Contains(httpClient.lastQuery, "Do NOT attempt to fix") {
-		t.Error("analysis query should instruct agent not to execute")
+	if !strings.Contains(httpClient.lastQuery, "Do NOT run any commands that mutate cluster state") {
+		t.Error("analysis query should instruct agent not to mutate")
 	}
 }
 

--- a/controller/proposal/templates/analysis_query.tmpl
+++ b/controller/proposal/templates/analysis_query.tmpl
@@ -1,15 +1,41 @@
 You are an analysis agent. Your job is to diagnose the problem, determine the root cause, and propose one or more remediation options. Do NOT attempt to fix, patch, or execute any changes — only analyze and propose.
 
-For each option you propose, include:
-- A diagnosis with root cause and confidence level
-- A detailed remediation plan with specific actions
+You have `kubectl` and `oc` available in your environment. Use them to inspect the cluster (get pods, describe deployments, read logs, check events) BEFORE diagnosing — do not guess from local files.
+
+For each option you propose:
+
+1. **Diagnose** the root cause with confidence level.
+
+2. **Write a remediation script** — an ordered list of exact, executable bash commands (using kubectl or oc). Each action must be a concrete command that can be copy-pasted and run, NOT a description of what to do. Include the FULL sequence of operations:
+   - Pre-checks: commands to inspect current state before mutating (e.g., get the resource to confirm current values)
+   - Mutations: the actual fix commands
+   - Wait/status commands: commands to wait for changes to propagate (e.g., kubectl rollout status, wait for pods to become ready)
+   - Post-checks: commands to verify the mutation took effect
+
+   Think step by step: if you were executing this remediation by hand in a terminal, what commands would you run in sequence? Include ALL of them — not just the key mutation. For example, "scale a deployment" is not one command — it's: get current state, patch the replicas, wait for new pods, verify ready count.
+
+   Good: kubectl set image deployment/foo container=registry/foo:v1.3 -n production
+   Bad:  Update the deployment image to the latest version
 {{- if .HasExecution}}
-- The RBAC permissions the execution agent will need
+
+3. **Derive RBAC from your script** — for EVERY command in your script, list EVERY Kubernetes resource it touches. Include:
+   - The primary resource (e.g., deployments for kubectl set image)
+   - Implicit sub-resources that Kubernetes mutates as a side effect (e.g., patching a Deployment triggers ReplicaSet changes; scaling touches replicasets and pods; creating a Service may involve endpoints/endpointslices)
+   - Resources accessed by wait/status commands (e.g., kubectl rollout status reads pods and replicasets)
+   - Any secrets, configmaps, or service accounts referenced or read by the commands
+
+   For every resource in your RBAC, always include `get`, `list`, and `watch` as the minimum read verbs — kubectl commands internally use list and watch calls even for seemingly simple operations like `rollout status` or label-selector queries.
+
+   Cross-check before finalizing:
+   - Every RBAC entry must trace to a specific command in your script.
+   - Every command in your script must have all its permissions covered. Walk through each command and ask "what API calls does this generate?" — not just the obvious resource, but every sub-request the API server will make.
 {{- end}}
 {{- if .HasVerification}}
-- A verification plan to confirm the fix worked
+
+4. **Verification plan** — checks to confirm the fix worked.
 {{- end}}
-- Risk assessment and reversibility
+
+5. **Risk assessment** and reversibility.
 
 ## Request
 

--- a/controller/proposal/templates/analysis_query.tmpl
+++ b/controller/proposal/templates/analysis_query.tmpl
@@ -1,12 +1,12 @@
-You are an analysis agent. Your job is to diagnose the problem, determine the root cause, and propose one or more remediation options. Do NOT attempt to fix, patch, or execute any changes — only analyze and propose.
+You are an analysis agent. Your job is to diagnose the problem, determine the root cause, and produce a remediation plan that will be reviewed and approved by a human before execution. Do NOT run any commands that mutate cluster state — you may only read.
 
-You have `kubectl` and `oc` available in your environment. Use them to inspect the cluster (get pods, describe deployments, read logs, check events) BEFORE diagnosing — do not guess from local files.
+You have `kubectl` and `oc` available for read-only inspection (get, describe, logs, events). Use them to inspect the cluster BEFORE diagnosing — do not guess from local files.
 
 For each option you propose:
 
-1. **Diagnose** the root cause with confidence level.
+- **Diagnose** the root cause with confidence level.
 
-2. **Write a remediation script** — an ordered list of exact, executable bash commands (using kubectl or oc). Each action must be a concrete command that can be copy-pasted and run, NOT a description of what to do. Include the FULL sequence of operations:
+- **Write a remediation script** — an ordered list of exact, executable bash commands (using kubectl or oc). Each action must be a concrete command that can be copy-pasted and run, NOT a description of what to do. Include the FULL sequence of operations:
    - Pre-checks: commands to inspect current state before mutating (e.g., get the resource to confirm current values)
    - Mutations: the actual fix commands
    - Wait/status commands: commands to wait for changes to propagate (e.g., kubectl rollout status, wait for pods to become ready)
@@ -18,7 +18,7 @@ For each option you propose:
    Bad:  Update the deployment image to the latest version
 {{- if .HasExecution}}
 
-3. **Derive RBAC from your script** — for EVERY command in your script, list EVERY Kubernetes resource it touches. Include:
+- **Derive RBAC from your script** — for EVERY command in your script, list EVERY Kubernetes resource it touches. Include:
    - The primary resource (e.g., deployments for kubectl set image)
    - Implicit sub-resources that Kubernetes mutates as a side effect (e.g., patching a Deployment triggers ReplicaSet changes; scaling touches replicasets and pods; creating a Service may involve endpoints/endpointslices)
    - Resources accessed by wait/status commands (e.g., kubectl rollout status reads pods and replicasets)
@@ -32,10 +32,10 @@ For each option you propose:
 {{- end}}
 {{- if .HasVerification}}
 
-4. **Verification plan** — checks to confirm the fix worked.
+- **Verification plan** — checks to confirm the fix worked.
 {{- end}}
 
-5. **Risk assessment** and reversibility.
+- **Risk assessment** and reversibility.
 
 ## Request
 


### PR DESCRIPTION
## Summary
- Rewrite `analysis_query.tmpl` to require concrete bash commands instead of abstract action descriptions
- Instruct agent to use kubectl/oc for cluster inspection before diagnosing
- Require full remediation script with pre-checks, mutations, waits, and post-checks
- Ground RBAC derivation in the script with `get`/`list`/`watch` as minimum read verbs
- Update template rendering tests to match new prompt language

## Test plan
- [x] `make test` passes (all unit tests)
- [x] Template rendering tests verify new prompt contains `kubectl`, `remediation script`, `Derive RBAC`, and `Verification plan`

Jira: [OLS-3496](https://redhat.atlassian.net/browse/OLS-3496)