### PR TITLE
OLS-3497: Update execution prompt for script following and dry-run

### DIFF
--- a/controller/proposal/sandbox_agent_test.go
+++ b/controller/proposal/sandbox_agent_test.go
@@ -456,6 +456,9 @@ func TestSandboxAgentCaller_ExecutionQueryFraming(t *testing.T) {
 	if strings.Contains(httpClient.lastQuery, "Pod crashing with OOMKilled") {
 		t.Error("execution query should NOT contain the original request")
 	}
+	if !strings.Contains(httpClient.lastQuery, "dry-run") {
+		t.Error("execution query should instruct dry-run before mutations")
+	}
 }
 
 func TestSandboxAgentCaller_VerificationQueryFraming(t *testing.T) {

--- a/controller/proposal/templates/execution_query.tmpl
+++ b/controller/proposal/templates/execution_query.tmpl
@@ -4,7 +4,7 @@ The approved option contains a concrete remediation script — an ordered list o
 
 1. **Execute commands in order.** Do not skip, reorder, or substitute commands. Run each command exactly as written.
 
-2. **Dry-run every mutation** before applying. For any command that modifies cluster state (create, patch, apply, set, scale, delete, etc.), first run it with `--dry-run=server`. If the dry-run fails, diagnose the error, fix the command, and retry the dry-run until it succeeds. Only then run the command for real.
+2. **Dry-run every mutation** before applying. For any command that modifies cluster state (create, patch, apply, set, scale, delete, etc.), first run it with `--dry-run=server`. If the dry-run fails, you may fix **only non-semantic errors** (e.g., a missing `--namespace` flag already implied by the target namespace context). You MUST NOT change the command's intent, target resource, or action. If the failure indicates the command's intent cannot succeed as-written, **stop and report failure**. Any command you modify must be flagged in your output with both the original and modified versions.
 
 3. **Watch for runtime failures** after mutations. After applying a change, briefly verify it took effect (e.g., check pod status, watch for ImagePullBackOff, CrashLoopBackOff, or other error states). If the mutation succeeds but the workload enters a failure state, report it.
 

--- a/controller/proposal/templates/execution_query.tmpl
+++ b/controller/proposal/templates/execution_query.tmpl
@@ -1,6 +1,16 @@
-You are an execution agent. Your job is to execute the approved remediation option below — nothing more, nothing less. Follow the plan exactly as approved. Do not re-analyze the problem or propose alternative solutions.
+You are an execution agent. Your job is to execute the approved remediation option below — nothing more, nothing less. Do not re-analyze the problem or propose alternative solutions.
 
-Report each action you take, its outcome (Succeeded/Failed), and any output or errors.
+The approved option contains a concrete remediation script — an ordered list of exact bash commands. Follow these rules:
+
+1. **Execute commands in order.** Do not skip, reorder, or substitute commands. Run each command exactly as written.
+
+2. **Dry-run every mutation** before applying. For any command that modifies cluster state (create, patch, apply, set, scale, delete, etc.), first run it with `--dry-run=server`. If the dry-run fails, diagnose the error, fix the command, and retry the dry-run until it succeeds. Only then run the command for real.
+
+3. **Watch for runtime failures** after mutations. After applying a change, briefly verify it took effect (e.g., check pod status, watch for ImagePullBackOff, CrashLoopBackOff, or other error states). If the mutation succeeds but the workload enters a failure state, report it.
+
+4. **Stop on failure** unless the error is clearly non-blocking. If a command fails and cannot be fixed, stop execution and report all actions taken so far.
+
+5. **Report each action** you take, its outcome (Succeeded/Failed), and any output or errors.
 
 ## Approved Option
 


### PR DESCRIPTION
## Summary
- Rewrite `execution_query.tmpl` with structured rules for script-following execution
- Instruct agent to execute commands in exact order without substitution
- Require `--dry-run=server` before every mutation, with fix-and-retry on failure
- Instruct agent to watch for runtime failures (ImagePullBackOff, CrashLoopBackOff) after mutations
- Add test assertion for dry-run instruction in execution query

## Test plan
- [x] `make test` passes (all unit tests)
- [x] Execution query framing test verifies `dry-run` instruction is present

Jira: [OLS-3497](https://redhat.atlassian.net/browse/OLS-3497)