### PR TITLE
OLS-3495: Add empty-command warning and update mock agent

### DIFF
--- a/controller/proposal/sandbox_agent.go
+++ b/controller/proposal/sandbox_agent.go
@@ -91,6 +91,15 @@ func (s *SandboxAgentCaller) Analyze(ctx context.Context, proposal *agenticv1alp
 		return nil, fmt.Errorf("%s: %w", ErrParseAnalysisResponse, err)
 	}
 
+	log := logf.FromContext(ctx)
+	for i, opt := range resp.Options {
+		for j, action := range opt.Proposal.Actions {
+			if action.Command == "" {
+				log.Info("analysis action missing command field", "option", i, "action", j, "type", action.Type, "proposal", proposal.Name)
+			}
+		}
+	}
+
 	return &AnalysisOutput{
 		Success: resp.Success,
 		Options: resp.Options,

--- a/test/agent/main.go
+++ b/test/agent/main.go
@@ -252,7 +252,9 @@ func cannedResponse(phase, targetNS string) []byte {
       "proposal": {
         "description": "mock proposal description",
         "actions": [
-          { "type": "patch", "description": "mock proposed action" }
+          { "command": "kubectl get configmap -n %s", "type": "pre-check", "description": "Check current configmap state" },
+          { "command": "kubectl patch configmap mock-cm -n %s -p '{\"data\":{\"key\":\"value\"}}'", "type": "mutation", "description": "Patch configmap with fix" },
+          { "command": "kubectl get configmap mock-cm -n %s -o jsonpath='{.data.key}'", "type": "post-check", "description": "Verify configmap was patched" }
         ],
         "risk": "Low",
         "reversible": "Reversible",
@@ -275,14 +277,14 @@ func cannedResponse(phase, targetNS string) []byte {
             "namespace": %q,
             "apiGroups": [""],
             "resources": ["configmaps"],
-            "verbs": ["get", "list"],
-            "justification": "mock e2e RBAC"
+            "verbs": ["get", "list", "patch"],
+            "justification": "Read and patch configmaps for mock remediation"
           }
         ],
         "clusterScoped": []
       }
     }
   ]
-}`, targetNS))
+}`, targetNS, targetNS, targetNS, targetNS))
 	}
 }


### PR DESCRIPTION
## Summary
- Add warning log in analysis parse path when actions are missing the `command` field, catching providers that fail to honor the output schema early
- Update e2e mock agent to include `command` fields with proper action types (`pre-check`, `mutation`, `post-check`) matching the script-grounded RBAC contract

Follow-up to #288 addressing review comments from @blublinsky.

## Test plan
- [x] `make test` passes
- [ ] CI green