### PR TITLE
OLS-3443: Add MCP server connectivity for agentic sandbox

### DIFF
--- a/api/v1alpha1/tools_types.go
+++ b/api/v1alpha1/tools_types.go
@@ -147,8 +147,16 @@ type ToolsSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=20
 	RequiredSecrets []SecretRequirement `json:"requiredSecrets,omitempty"`
+
+	// disableDefaultMCP suppresses auto-injection of the default OpenShift
+	// MCP server entry into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
+	// When true, the operator will not prepend the built-in ocp-mcp server even
+	// if OLSConfig.introspectionEnabled is true. User-defined mcpServers are
+	// unaffected. Default is false.
+	// +optional
+	DisableDefaultMCP bool `json:"disableDefaultMCP,omitempty"`
 }
 
 func (t ToolsSpec) IsZero() bool {
-	return len(t.Skills) == 0 && len(t.MCPServers) == 0 && len(t.RequiredSecrets) == 0
+	return len(t.Skills) == 0 && len(t.MCPServers) == 0 && len(t.RequiredSecrets) == 0 && !t.DisableDefaultMCP
 }

--- a/api/v1alpha1/tools_types.go
+++ b/api/v1alpha1/tools_types.go
@@ -108,6 +108,24 @@ type SecretRequirement struct {
 	MountAs SecretMountSpec `json:"mountAs,omitzero"`
 }
 
+// DefaultMCPMode controls whether the operator auto-injects the default
+// OpenShift MCP server entry into the sandbox pod's LIGHTSPEED_MCP_SERVERS
+// env var.
+//
+// Allowed values:
+//   - "Enabled"  — The default ocp-mcp server is prepended when
+//     OLSConfig.introspectionEnabled is true.
+//   - "Disabled" — The default ocp-mcp server is never injected.
+//     User-defined mcpServers are unaffected.
+//
+// +kubebuilder:validation:Enum=Enabled;Disabled
+type DefaultMCPMode string
+
+const (
+	DefaultMCPModeEnabled  DefaultMCPMode = "Enabled"
+	DefaultMCPModeDisabled DefaultMCPMode = "Disabled"
+)
+
 // ToolsSpec defines the tools available to an agent in its sandbox pod.
 // This includes skills images, MCP servers, and required secrets.
 //
@@ -148,15 +166,15 @@ type ToolsSpec struct {
 	// +kubebuilder:validation:MaxItems=20
 	RequiredSecrets []SecretRequirement `json:"requiredSecrets,omitempty"`
 
-	// disableDefaultMCP suppresses auto-injection of the default OpenShift
-	// MCP server entry into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
-	// When true, the operator will not prepend the built-in ocp-mcp server even
-	// if OLSConfig.introspectionEnabled is true. User-defined mcpServers are
-	// unaffected. Default is false.
+	// defaultMCP controls whether the default OpenShift MCP server is
+	// auto-injected into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
+	// When set to "Disabled", the operator will not prepend the built-in
+	// ocp-mcp server even if OLSConfig.introspectionEnabled is true.
+	// User-defined mcpServers are unaffected. Default is "Enabled".
 	// +optional
-	DisableDefaultMCP bool `json:"disableDefaultMCP,omitempty"`
+	DefaultMCP DefaultMCPMode `json:"defaultMCP,omitempty"`
 }
 
 func (t ToolsSpec) IsZero() bool {
-	return len(t.Skills) == 0 && len(t.MCPServers) == 0 && len(t.RequiredSecrets) == 0 && !t.DisableDefaultMCP
+	return len(t.Skills) == 0 && len(t.MCPServers) == 0 && len(t.RequiredSecrets) == 0 && t.DefaultMCP == ""
 }

--- a/config/crd/bases/agentic.openshift.io_proposals.yaml
+++ b/config/crd/bases/agentic.openshift.io_proposals.yaml
@@ -89,14 +89,17 @@ spec:
                       for this step. Use this when different steps need different skills.
                     minProperties: 1
                     properties:
-                      disableDefaultMCP:
+                      defaultMCP:
                         description: |-
-                          disableDefaultMCP suppresses auto-injection of the default OpenShift
-                          MCP server entry into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
-                          When true, the operator will not prepend the built-in ocp-mcp server even
-                          if OLSConfig.introspectionEnabled is true. User-defined mcpServers are
-                          unaffected. Default is false.
-                        type: boolean
+                          defaultMCP controls whether the default OpenShift MCP server is
+                          auto-injected into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
+                          When set to "Disabled", the operator will not prepend the built-in
+                          ocp-mcp server even if OLSConfig.introspectionEnabled is true.
+                          User-defined mcpServers are unaffected. Default is "Enabled".
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
                       mcpServers:
                         description: |-
                           mcpServers defines external MCP (Model Context Protocol) servers the
@@ -514,14 +517,17 @@ spec:
                       for this step. Use this when different steps need different skills.
                     minProperties: 1
                     properties:
-                      disableDefaultMCP:
+                      defaultMCP:
                         description: |-
-                          disableDefaultMCP suppresses auto-injection of the default OpenShift
-                          MCP server entry into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
-                          When true, the operator will not prepend the built-in ocp-mcp server even
-                          if OLSConfig.introspectionEnabled is true. User-defined mcpServers are
-                          unaffected. Default is false.
-                        type: boolean
+                          defaultMCP controls whether the default OpenShift MCP server is
+                          auto-injected into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
+                          When set to "Disabled", the operator will not prepend the built-in
+                          ocp-mcp server even if OLSConfig.introspectionEnabled is true.
+                          User-defined mcpServers are unaffected. Default is "Enabled".
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
                       mcpServers:
                         description: |-
                           mcpServers defines external MCP (Model Context Protocol) servers the
@@ -941,14 +947,17 @@ spec:
                   assumptions of an in-progress analysis or execution.
                 minProperties: 1
                 properties:
-                  disableDefaultMCP:
+                  defaultMCP:
                     description: |-
-                      disableDefaultMCP suppresses auto-injection of the default OpenShift
-                      MCP server entry into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
-                      When true, the operator will not prepend the built-in ocp-mcp server even
-                      if OLSConfig.introspectionEnabled is true. User-defined mcpServers are
-                      unaffected. Default is false.
-                    type: boolean
+                      defaultMCP controls whether the default OpenShift MCP server is
+                      auto-injected into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
+                      When set to "Disabled", the operator will not prepend the built-in
+                      ocp-mcp server even if OLSConfig.introspectionEnabled is true.
+                      User-defined mcpServers are unaffected. Default is "Enabled".
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
                   mcpServers:
                     description: |-
                       mcpServers defines external MCP (Model Context Protocol) servers the
@@ -1324,14 +1333,17 @@ spec:
                       for this step. Use this when different steps need different skills.
                     minProperties: 1
                     properties:
-                      disableDefaultMCP:
+                      defaultMCP:
                         description: |-
-                          disableDefaultMCP suppresses auto-injection of the default OpenShift
-                          MCP server entry into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
-                          When true, the operator will not prepend the built-in ocp-mcp server even
-                          if OLSConfig.introspectionEnabled is true. User-defined mcpServers are
-                          unaffected. Default is false.
-                        type: boolean
+                          defaultMCP controls whether the default OpenShift MCP server is
+                          auto-injected into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
+                          When set to "Disabled", the operator will not prepend the built-in
+                          ocp-mcp server even if OLSConfig.introspectionEnabled is true.
+                          User-defined mcpServers are unaffected. Default is "Enabled".
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
                       mcpServers:
                         description: |-
                           mcpServers defines external MCP (Model Context Protocol) servers the

--- a/config/crd/bases/agentic.openshift.io_proposals.yaml
+++ b/config/crd/bases/agentic.openshift.io_proposals.yaml
@@ -89,6 +89,14 @@ spec:
                       for this step. Use this when different steps need different skills.
                     minProperties: 1
                     properties:
+                      disableDefaultMCP:
+                        description: |-
+                          disableDefaultMCP suppresses auto-injection of the default OpenShift
+                          MCP server entry into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
+                          When true, the operator will not prepend the built-in ocp-mcp server even
+                          if OLSConfig.introspectionEnabled is true. User-defined mcpServers are
+                          unaffected. Default is false.
+                        type: boolean
                       mcpServers:
                         description: |-
                           mcpServers defines external MCP (Model Context Protocol) servers the
@@ -506,6 +514,14 @@ spec:
                       for this step. Use this when different steps need different skills.
                     minProperties: 1
                     properties:
+                      disableDefaultMCP:
+                        description: |-
+                          disableDefaultMCP suppresses auto-injection of the default OpenShift
+                          MCP server entry into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
+                          When true, the operator will not prepend the built-in ocp-mcp server even
+                          if OLSConfig.introspectionEnabled is true. User-defined mcpServers are
+                          unaffected. Default is false.
+                        type: boolean
                       mcpServers:
                         description: |-
                           mcpServers defines external MCP (Model Context Protocol) servers the
@@ -925,6 +941,14 @@ spec:
                   assumptions of an in-progress analysis or execution.
                 minProperties: 1
                 properties:
+                  disableDefaultMCP:
+                    description: |-
+                      disableDefaultMCP suppresses auto-injection of the default OpenShift
+                      MCP server entry into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
+                      When true, the operator will not prepend the built-in ocp-mcp server even
+                      if OLSConfig.introspectionEnabled is true. User-defined mcpServers are
+                      unaffected. Default is false.
+                    type: boolean
                   mcpServers:
                     description: |-
                       mcpServers defines external MCP (Model Context Protocol) servers the
@@ -1300,6 +1324,14 @@ spec:
                       for this step. Use this when different steps need different skills.
                     minProperties: 1
                     properties:
+                      disableDefaultMCP:
+                        description: |-
+                          disableDefaultMCP suppresses auto-injection of the default OpenShift
+                          MCP server entry into the sandbox pod's LIGHTSPEED_MCP_SERVERS env var.
+                          When true, the operator will not prepend the built-in ocp-mcp server even
+                          if OLSConfig.introspectionEnabled is true. User-defined mcpServers are
+                          unaffected. Default is false.
+                        type: boolean
                       mcpServers:
                         description: |-
                           mcpServers defines external MCP (Model Context Protocol) servers the

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -115,6 +115,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ols.openshift.io
+  resources:
+  - olsconfigs
+  verbs:
+  - get
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/controller/proposal/bare_pod_manager.go
+++ b/controller/proposal/bare_pod_manager.go
@@ -62,7 +62,8 @@ func (m *BarePodManager) Claim(ctx context.Context, proposalName, step, _ string
 
 	podName := truncateK8sName(fmt.Sprintf("ls-%s-%s", step, proposalName))
 
-	podSpec, err := m.Builder.Build(m.agent, m.llm, m.tools, step, m.serviceAccount)
+	tools := effectiveTools(ctx, m.Client, m.Namespace, m.tools)
+	podSpec, err := m.Builder.Build(m.agent, m.llm, tools, step, m.serviceAccount)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", ErrBuildPodSpec, err)
 	}

--- a/controller/proposal/default_mcp.go
+++ b/controller/proposal/default_mcp.go
@@ -1,0 +1,96 @@
+package proposal
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+var olsConfigGVK = schema.GroupVersionKind{
+	Group: "ols.openshift.io", Version: "v1alpha1", Kind: "OLSConfig",
+}
+
+const (
+	defaultMCPServerName = "openshift"
+	defaultMCPServerPort = 8080
+	olsConfigName        = "cluster"
+)
+
+// +kubebuilder:rbac:groups=ols.openshift.io,resources=olsconfigs,verbs=get;watch
+
+// readIntrospectionEnabled reads the classic OLSConfig CR and returns
+// the value of spec.olsConfig.introspectionEnabled (defaults to true).
+func readIntrospectionEnabled(ctx context.Context, c client.Client) (bool, error) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(olsConfigGVK)
+	if err := c.Get(ctx, types.NamespacedName{Name: olsConfigName}, obj); err != nil {
+		return false, fmt.Errorf("get OLSConfig %q: %w", olsConfigName, err)
+	}
+
+	val, found, err := unstructured.NestedBool(obj.Object, "spec", "olsConfig", "introspectionEnabled")
+	if err != nil {
+		return true, nil
+	}
+	if !found {
+		return true, nil
+	}
+	return val, nil
+}
+
+// defaultMCPServer builds an MCPServerConfig entry for the built-in
+// ocp-mcp sidecar Service created by the classic operator.
+func defaultMCPServer(namespace string) agenticv1alpha1.MCPServerConfig {
+	return agenticv1alpha1.MCPServerConfig{
+		Name:           defaultMCPServerName,
+		URL:            fmt.Sprintf("http://openshift-mcp-server.%s.svc:%d/mcp", namespace, defaultMCPServerPort),
+		TimeoutSeconds: 60,
+		Headers: []agenticv1alpha1.MCPHeader{
+			{
+				Name: "Authorization",
+				ValueFrom: agenticv1alpha1.MCPHeaderValueSource{
+					Type: agenticv1alpha1.MCPHeaderSourceTypeServiceAccountToken,
+				},
+			},
+		},
+	}
+}
+
+// effectiveTools returns a copy of the given ToolsSpec with the default
+// ocp-mcp server prepended when introspection is enabled and the Proposal
+// has not opted out via disableDefaultMCP. Returns the original pointer
+// unmodified when no injection is needed.
+func effectiveTools(ctx context.Context, c client.Client, namespace string, tools *agenticv1alpha1.ToolsSpec) *agenticv1alpha1.ToolsSpec {
+	log := logf.FromContext(ctx).WithName("default-mcp")
+
+	if tools != nil && tools.DisableDefaultMCP {
+		return tools
+	}
+
+	enabled, err := readIntrospectionEnabled(ctx, c)
+	if err != nil {
+		log.V(1).Info("Cannot read OLSConfig, skipping default MCP injection", "error", err)
+		return tools
+	}
+	if !enabled {
+		return tools
+	}
+
+	server := defaultMCPServer(namespace)
+
+	if tools == nil {
+		return &agenticv1alpha1.ToolsSpec{
+			MCPServers: []agenticv1alpha1.MCPServerConfig{server},
+		}
+	}
+
+	merged := tools.DeepCopy()
+	merged.MCPServers = append([]agenticv1alpha1.MCPServerConfig{server}, merged.MCPServers...)
+	return merged
+}

--- a/controller/proposal/default_mcp.go
+++ b/controller/proposal/default_mcp.go
@@ -64,12 +64,12 @@ func defaultMCPServer(namespace string) agenticv1alpha1.MCPServerConfig {
 
 // effectiveTools returns a copy of the given ToolsSpec with the default
 // ocp-mcp server prepended when introspection is enabled and the Proposal
-// has not opted out via disableDefaultMCP. Returns the original pointer
+// has not opted out via defaultMCP: Disabled. Returns the original pointer
 // unmodified when no injection is needed.
 func effectiveTools(ctx context.Context, c client.Client, namespace string, tools *agenticv1alpha1.ToolsSpec) *agenticv1alpha1.ToolsSpec {
 	log := logf.FromContext(ctx).WithName("default-mcp")
 
-	if tools != nil && tools.DisableDefaultMCP {
+	if tools != nil && tools.DefaultMCP == agenticv1alpha1.DefaultMCPModeDisabled {
 		return tools
 	}
 

--- a/controller/proposal/default_mcp.go
+++ b/controller/proposal/default_mcp.go
@@ -19,7 +19,7 @@ var olsConfigGVK = schema.GroupVersionKind{
 
 const (
 	defaultMCPServerName = "openshift"
-	defaultMCPServerPort = 8080
+	defaultMCPServerPort = 8443
 	olsConfigName        = "cluster"
 )
 
@@ -49,7 +49,7 @@ func readIntrospectionEnabled(ctx context.Context, c client.Client) (bool, error
 func defaultMCPServer(namespace string) agenticv1alpha1.MCPServerConfig {
 	return agenticv1alpha1.MCPServerConfig{
 		Name:           defaultMCPServerName,
-		URL:            fmt.Sprintf("http://openshift-mcp-server.%s.svc:%d/mcp", namespace, defaultMCPServerPort),
+		URL:            fmt.Sprintf("https://openshift-mcp-server.%s.svc:%d/mcp", namespace, defaultMCPServerPort),
 		TimeoutSeconds: 60,
 		Headers: []agenticv1alpha1.MCPHeader{
 			{

--- a/controller/proposal/default_mcp_test.go
+++ b/controller/proposal/default_mcp_test.go
@@ -1,0 +1,134 @@
+package proposal
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+func olsConfigUnstructured(introspectionEnabled *bool) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(olsConfigGVK)
+	obj.SetName(olsConfigName)
+	spec := map[string]any{"olsConfig": map[string]any{}}
+	if introspectionEnabled != nil {
+		spec["olsConfig"].(map[string]any)["introspectionEnabled"] = *introspectionEnabled
+	}
+	obj.Object["spec"] = spec
+	return obj
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestEffectiveTools_IntrospectionEnabled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	config := olsConfigUnstructured(boolPtr(true))
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
+
+	result := effectiveTools(context.Background(), fc, "openshift-lightspeed", nil)
+	if result == nil {
+		t.Fatal("expected non-nil ToolsSpec")
+	}
+	if len(result.MCPServers) != 1 {
+		t.Fatalf("expected 1 MCP server, got %d", len(result.MCPServers))
+	}
+	if result.MCPServers[0].Name != defaultMCPServerName {
+		t.Errorf("expected server name %q, got %q", defaultMCPServerName, result.MCPServers[0].Name)
+	}
+	if result.MCPServers[0].URL != "http://openshift-mcp-server.openshift-lightspeed.svc:8080/mcp" {
+		t.Errorf("unexpected URL: %s", result.MCPServers[0].URL)
+	}
+}
+
+func TestEffectiveTools_IntrospectionDisabled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	config := olsConfigUnstructured(boolPtr(false))
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
+
+	result := effectiveTools(context.Background(), fc, "openshift-lightspeed", nil)
+	if result != nil {
+		t.Fatalf("expected nil ToolsSpec when introspection disabled, got %+v", result)
+	}
+}
+
+func TestEffectiveTools_IntrospectionOmitted_DefaultsTrue(t *testing.T) {
+	scheme := runtime.NewScheme()
+	config := olsConfigUnstructured(nil)
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
+
+	result := effectiveTools(context.Background(), fc, "openshift-lightspeed", nil)
+	if result == nil {
+		t.Fatal("expected non-nil ToolsSpec when introspectionEnabled is omitted (defaults to true)")
+	}
+	if len(result.MCPServers) != 1 {
+		t.Fatalf("expected 1 MCP server, got %d", len(result.MCPServers))
+	}
+}
+
+func TestEffectiveTools_DisableDefaultMCP(t *testing.T) {
+	scheme := runtime.NewScheme()
+	config := olsConfigUnstructured(boolPtr(true))
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
+
+	tools := &agenticv1alpha1.ToolsSpec{DisableDefaultMCP: true}
+	result := effectiveTools(context.Background(), fc, "openshift-lightspeed", tools)
+	if result != tools {
+		t.Error("expected original tools pointer returned when DisableDefaultMCP is true")
+	}
+}
+
+func TestEffectiveTools_PrependToExisting(t *testing.T) {
+	scheme := runtime.NewScheme()
+	config := olsConfigUnstructured(boolPtr(true))
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
+
+	existing := &agenticv1alpha1.ToolsSpec{
+		MCPServers: []agenticv1alpha1.MCPServerConfig{
+			{Name: "custom", URL: "http://custom:9090/mcp"},
+		},
+	}
+	result := effectiveTools(context.Background(), fc, "openshift-lightspeed", existing)
+	if len(result.MCPServers) != 2 {
+		t.Fatalf("expected 2 MCP servers (default + custom), got %d", len(result.MCPServers))
+	}
+	if result.MCPServers[0].Name != defaultMCPServerName {
+		t.Errorf("default should be first, got %q", result.MCPServers[0].Name)
+	}
+	if result.MCPServers[1].Name != "custom" {
+		t.Errorf("custom should be second, got %q", result.MCPServers[1].Name)
+	}
+	if len(existing.MCPServers) != 1 {
+		t.Error("original tools must not be mutated")
+	}
+}
+
+func TestEffectiveTools_OLSConfigNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	result := effectiveTools(context.Background(), fc, "openshift-lightspeed", nil)
+	if result != nil {
+		t.Error("expected nil (passthrough) when OLSConfig cannot be read")
+	}
+}
+
+func TestDefaultMCPServer(t *testing.T) {
+	server := defaultMCPServer("my-namespace")
+	if server.Name != defaultMCPServerName {
+		t.Errorf("unexpected name: %s", server.Name)
+	}
+	if server.URL != "http://openshift-mcp-server.my-namespace.svc:8080/mcp" {
+		t.Errorf("unexpected URL: %s", server.URL)
+	}
+	if len(server.Headers) != 1 {
+		t.Fatalf("expected 1 header, got %d", len(server.Headers))
+	}
+	if server.Headers[0].ValueFrom.Type != agenticv1alpha1.MCPHeaderSourceTypeServiceAccountToken {
+		t.Errorf("expected ServiceAccountToken header, got %s", server.Headers[0].ValueFrom.Type)
+	}
+}

--- a/controller/proposal/default_mcp_test.go
+++ b/controller/proposal/default_mcp_test.go
@@ -70,15 +70,15 @@ func TestEffectiveTools_IntrospectionOmitted_DefaultsTrue(t *testing.T) {
 	}
 }
 
-func TestEffectiveTools_DisableDefaultMCP(t *testing.T) {
+func TestEffectiveTools_DefaultMCPDisabled(t *testing.T) {
 	scheme := runtime.NewScheme()
 	config := olsConfigUnstructured(boolPtr(true))
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
 
-	tools := &agenticv1alpha1.ToolsSpec{DisableDefaultMCP: true}
+	tools := &agenticv1alpha1.ToolsSpec{DefaultMCP: agenticv1alpha1.DefaultMCPModeDisabled}
 	result := effectiveTools(context.Background(), fc, "openshift-lightspeed", tools)
 	if result != tools {
-		t.Error("expected original tools pointer returned when DisableDefaultMCP is true")
+		t.Error("expected original tools pointer returned when DefaultMCP is Disabled")
 	}
 }
 

--- a/controller/proposal/default_mcp_test.go
+++ b/controller/proposal/default_mcp_test.go
@@ -40,7 +40,7 @@ func TestEffectiveTools_IntrospectionEnabled(t *testing.T) {
 	if result.MCPServers[0].Name != defaultMCPServerName {
 		t.Errorf("expected server name %q, got %q", defaultMCPServerName, result.MCPServers[0].Name)
 	}
-	if result.MCPServers[0].URL != "http://openshift-mcp-server.openshift-lightspeed.svc:8080/mcp" {
+	if result.MCPServers[0].URL != "https://openshift-mcp-server.openshift-lightspeed.svc:8443/mcp" {
 		t.Errorf("unexpected URL: %s", result.MCPServers[0].URL)
 	}
 }
@@ -122,7 +122,7 @@ func TestDefaultMCPServer(t *testing.T) {
 	if server.Name != defaultMCPServerName {
 		t.Errorf("unexpected name: %s", server.Name)
 	}
-	if server.URL != "http://openshift-mcp-server.my-namespace.svc:8080/mcp" {
+	if server.URL != "https://openshift-mcp-server.my-namespace.svc:8443/mcp" {
 		t.Errorf("unexpected URL: %s", server.URL)
 	}
 	if len(server.Headers) != 1 {

--- a/controller/proposal/sandbox_templates.go
+++ b/controller/proposal/sandbox_templates.go
@@ -164,6 +164,8 @@ func EnsureAgentTemplate(
 		return "", fmt.Errorf("%s %q: %w", ErrReadBaseTemplate, baseTemplateName, err)
 	}
 
+	tools = effectiveTools(ctx, c, namespace, tools)
+
 	var skills []agenticv1alpha1.SkillsSource
 	var mcpServers []agenticv1alpha1.MCPServerConfig
 	var requiredSecrets []agenticv1alpha1.SecretRequirement


### PR DESCRIPTION
## Summary
- **[OLS-3446](https://redhat.atlassian.net/browse/OLS-3446)**: Add `disableDefaultMCP` boolean field to `ToolsSpec` CRD, regenerated deepcopy and CRD manifests
- **[OLS-3447](https://redhat.atlassian.net/browse/OLS-3447)**: Auto-inject default ocp-mcp server into sandbox pods when `OLSConfig.introspectionEnabled=true` and `disableDefaultMCP=false`
  - Reads classic `OLSConfig` CR via unstructured access
  - Prepends default server to `LIGHTSPEED_MCP_SERVERS` in both bare-pod and sandbox-claim paths
  - Adds RBAC (`get;watch` on `olsconfigs` in `ols.openshift.io`)

## Jira
[OLS-3443](https://redhat.atlassian.net/browse/OLS-3443) (epic) — [OLS-3446](https://redhat.atlassian.net/browse/OLS-3446), [OLS-3447](https://redhat.atlassian.net/browse/OLS-3447)

## Test plan
- [x] 7 unit tests for default MCP injection logic (introspection on/off, disableDefaultMCP, prepend ordering, OLSConfig missing)
- [x] All existing agentic operator tests pass (`make test`)

Made with [Cursor](https://cursor.com)