### PR TITLE
OLS-162 Drop estimatedImpact; align LLM output schemas with CRDs

### DIFF
--- a/api/v1alpha1/agenticrun_analysis_types.go
+++ b/api/v1alpha1/agenticrun_analysis_types.go
@@ -146,14 +146,6 @@ type RemediationPlan struct {
 	// Must be one of: Reversible, Irreversible, Partial.
 	// +optional
 	Reversible Reversibility `json:"reversible,omitempty"`
-	// estimatedImpact is a Markdown-formatted description of the expected
-	// impact of the remediation on the system
-	// (e.g., "Brief pod restart, ~30s downtime").
-	// Maximum 1024 characters.
-	// +required
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=1024
-	EstimatedImpact string `json:"estimatedImpact,omitempty"`
 	// rollbackPlan describes how to undo the remediation if execution fails
 	// or causes unexpected issues. Only the execution step mutates cluster
 	// state, so rollback lives here alongside the actions it would undo.

--- a/config/crd/bases/agentic.openshift.io_analysisresults.yaml
+++ b/config/crd/bases/agentic.openshift.io_analysisresults.yaml
@@ -452,15 +452,6 @@ spec:
                           maxLength: 8192
                           minLength: 1
                           type: string
-                        estimatedImpact:
-                          description: |-
-                            estimatedImpact is a Markdown-formatted description of the expected
-                            impact of the remediation on the system
-                            (e.g., "Brief pod restart, ~30s downtime").
-                            Maximum 1024 characters.
-                          maxLength: 1024
-                          minLength: 1
-                          type: string
                         reversible:
                           description: |-
                             reversible indicates whether the remediation can be rolled back
@@ -507,7 +498,6 @@ spec:
                       required:
                       - actions
                       - description
-                      - estimatedImpact
                       - risk
                       type: object
                     summary:

--- a/controller/agenticrun/schema_crd_drift_test.go
+++ b/controller/agenticrun/schema_crd_drift_test.go
@@ -126,6 +126,7 @@ func TestSchemasCoverCRDRequiredFields(t *testing.T) {
 				t.Fatal("LLM schema is missing the expected comparison node")
 			}
 
+			checked := false
 			for _, v := range crd.Spec.Versions {
 				if v.Schema == nil || v.Schema.OpenAPIV3Schema == nil {
 					continue
@@ -134,11 +135,15 @@ func TestSchemasCoverCRDRequiredFields(t *testing.T) {
 				if !ok {
 					continue
 				}
+				checked = true
 				crdStart, ok := tc.crdNode(&status)
 				if !ok {
 					t.Fatalf("CRD version %s is missing the expected status schema node", v.Name)
 				}
 				assertRequiredCoverage(t, tc.path, crdStart, llmStart)
+			}
+			if !checked {
+				t.Fatal("no CRD version contained a comparable status schema")
 			}
 		})
 	}
@@ -160,6 +165,7 @@ func assertRequiredCoverage(t *testing.T, path string, crd *apiextensionsv1.JSON
 		}
 		llmItems, ok := asJSONObject(llm["items"])
 		if !ok {
+			t.Errorf("schema/CRD drift at %s: LLM schema is missing object-shaped array items", path)
 			return
 		}
 		assertRequiredCoverage(t, path+"[]", crd.Items.Schema, llmItems)

--- a/controller/agenticrun/schema_crd_drift_test.go
+++ b/controller/agenticrun/schema_crd_drift_test.go
@@ -1,0 +1,263 @@
+package agenticrun
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// crdBasesDir resolves config/crd/bases relative to this source file rather
+// than the test's working directory, so the lookup survives changes to how or
+// from where the tests are invoked.
+func crdBasesDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve test source path via runtime.Caller")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "config", "crd", "bases")
+}
+
+// TestSchemasCoverCRDRequiredFields guards against the schema/CRD contract
+// drift described in lightspeed-agentic-operator#162: the JSON schema sent to
+// the LLM for structured output must mark as required every field the result
+// CRD requires. When the two disagree, a valid LLM response can be rejected by
+// CRD validation at status-patch time, which fails the step and orphans the
+// sandbox pod.
+//
+// The generated CRDs (which encode the +required markers) are the source of
+// truth. For every object node a schema pair shares, the CRD's required set
+// must be a subset of the LLM schema's required set. This covers all four LLM
+// output schemas, catching the original estimatedImpact incident as well as
+// the latent verification (checks source/value) and execution (verification
+// conditionOutcome/summary) gaps.
+func TestSchemasCoverCRDRequiredFields(t *testing.T) {
+	cases := []struct {
+		name      string
+		crdFile   string
+		llmSchema json.RawMessage
+		// crdNode selects the CRD schema node to start the comparison from,
+		// given the decoded status schema for a CRD version.
+		crdNode func(status *apiextensionsv1.JSONSchemaProps) (*apiextensionsv1.JSONSchemaProps, bool)
+		// llmNode selects the matching LLM schema node, given the decoded root.
+		llmNode func(root map[string]any) (map[string]any, bool)
+		// path labels the comparison root in failure messages.
+		path string
+	}{
+		{
+			// Analysis emits an array of options; the per-option shape that
+			// maps onto the CRD lives at properties.options.items.
+			name:      "analysis",
+			crdFile:   "agentic.openshift.io_analysisresults.yaml",
+			llmSchema: AnalysisOutputSchema,
+			crdNode: func(status *apiextensionsv1.JSONSchemaProps) (*apiextensionsv1.JSONSchemaProps, bool) {
+				options, ok := status.Properties["options"]
+				if !ok || options.Items == nil || options.Items.Schema == nil {
+					return nil, false
+				}
+				return options.Items.Schema, true
+			},
+			llmNode: func(root map[string]any) (map[string]any, bool) {
+				return digObject(root, "properties", "options", "items")
+			},
+			path: "options[]",
+		},
+		{
+			// Execution, verification, and escalation each emit a single
+			// object whose shape maps directly onto the CRD status.
+			name:      "execution",
+			crdFile:   "agentic.openshift.io_executionresults.yaml",
+			llmSchema: ExecutionOutputSchema,
+			crdNode: func(status *apiextensionsv1.JSONSchemaProps) (*apiextensionsv1.JSONSchemaProps, bool) {
+				return status, true
+			},
+			llmNode: func(root map[string]any) (map[string]any, bool) { return root, true },
+			path:    "status",
+		},
+		{
+			name:      "verification",
+			crdFile:   "agentic.openshift.io_verificationresults.yaml",
+			llmSchema: VerificationOutputSchema,
+			crdNode: func(status *apiextensionsv1.JSONSchemaProps) (*apiextensionsv1.JSONSchemaProps, bool) {
+				return status, true
+			},
+			llmNode: func(root map[string]any) (map[string]any, bool) { return root, true },
+			path:    "status",
+		},
+		{
+			name:      "escalation",
+			crdFile:   "agentic.openshift.io_escalationresults.yaml",
+			llmSchema: EscalationOutputSchema,
+			crdNode: func(status *apiextensionsv1.JSONSchemaProps) (*apiextensionsv1.JSONSchemaProps, bool) {
+				return status, true
+			},
+			llmNode: func(root map[string]any) (map[string]any, bool) { return root, true },
+			path:    "status",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			crdPath := filepath.Join(crdBasesDir(t), tc.crdFile)
+			raw, err := os.ReadFile(crdPath)
+			if err != nil {
+				t.Fatalf("read CRD: %v", err)
+			}
+
+			var crd apiextensionsv1.CustomResourceDefinition
+			if err := yaml.Unmarshal(raw, &crd); err != nil {
+				t.Fatalf("unmarshal CRD: %v", err)
+			}
+			if len(crd.Spec.Versions) == 0 {
+				t.Fatal("CRD declares no versions")
+			}
+
+			var llm map[string]any
+			if err := json.Unmarshal(tc.llmSchema, &llm); err != nil {
+				t.Fatalf("unmarshal LLM schema: %v", err)
+			}
+			llmStart, ok := tc.llmNode(llm)
+			if !ok {
+				t.Fatal("LLM schema is missing the expected comparison node")
+			}
+
+			for _, v := range crd.Spec.Versions {
+				if v.Schema == nil || v.Schema.OpenAPIV3Schema == nil {
+					continue
+				}
+				status, ok := v.Schema.OpenAPIV3Schema.Properties["status"]
+				if !ok {
+					continue
+				}
+				crdStart, ok := tc.crdNode(&status)
+				if !ok {
+					t.Fatalf("CRD version %s is missing the expected status schema node", v.Name)
+				}
+				assertRequiredCoverage(t, tc.path, crdStart, llmStart)
+			}
+		})
+	}
+}
+
+// assertRequiredCoverage walks a CRD schema node and the corresponding LLM
+// schema node in parallel, asserting that every field required by the CRD is
+// also required by the LLM schema (for fields the LLM schema actually models).
+func assertRequiredCoverage(t *testing.T, path string, crd *apiextensionsv1.JSONSchemaProps, llm map[string]any) {
+	t.Helper()
+	if crd == nil || llm == nil {
+		return
+	}
+
+	// Arrays: descend into the element schema on both sides.
+	if crd.Type == "array" {
+		if crd.Items == nil || crd.Items.Schema == nil {
+			return
+		}
+		llmItems, ok := asJSONObject(llm["items"])
+		if !ok {
+			return
+		}
+		assertRequiredCoverage(t, path+"[]", crd.Items.Schema, llmItems)
+		return
+	}
+
+	llmProps, _ := asJSONObject(llm["properties"])
+	llmRequired := requiredSet(llm["required"])
+	for _, req := range crd.Required {
+		// A field the CRD requires must be both modeled and required in the LLM
+		// output schema. If it is absent entirely the agent is never asked for
+		// it, so the status patch is rejected at runtime — the exact drift this
+		// guard exists to catch.
+		if _, modeled := llmProps[req]; !modeled {
+			t.Errorf("schema/CRD drift at %s: CRD requires %q but the LLM output schema does not model the field", path, req)
+			continue
+		}
+		if !llmRequired[req] {
+			t.Errorf("schema/CRD drift at %s: CRD requires %q but the LLM output schema does not mark it required", path, req)
+		}
+	}
+
+	// Reverse direction: a property the LLM schema models that does not exist
+	// in the CRD is silently pruned by the API server on the status patch —
+	// silent data loss instead of a rejection. Skip CRD nodes that
+	// legitimately accept arbitrary fields.
+	if len(crd.Properties) > 0 && !acceptsUnknownFields(crd) {
+		for name := range llmProps {
+			if llmOnlyControlFields[name] {
+				continue
+			}
+			if _, ok := crd.Properties[name]; !ok {
+				t.Errorf("schema/CRD drift at %s: LLM output schema models %q but the CRD has no such property (silently pruned on status patch)", path, name)
+			}
+		}
+	}
+
+	// Recurse into properties present in both schemas.
+	for name := range crd.Properties {
+		child := crd.Properties[name]
+		llmChild, ok := asJSONObject(llmProps[name])
+		if !ok {
+			continue
+		}
+		assertRequiredCoverage(t, path+"."+name, &child, llmChild)
+	}
+}
+
+// llmOnlyControlFields are properties the LLM output schemas model that are
+// deliberately not persisted to any CRD: the operator consumes them for
+// control flow (see executionResponse/verificationResponse in
+// sandbox_agent.go) before building the status patch, so the pruning check
+// does not apply to them.
+var llmOnlyControlFields = map[string]bool{
+	"success": true,
+}
+
+// acceptsUnknownFields reports whether a CRD schema node tolerates properties
+// beyond those it declares, in which case the reverse (LLM→CRD) pruning check
+// does not apply.
+func acceptsUnknownFields(crd *apiextensionsv1.JSONSchemaProps) bool {
+	if crd.XPreserveUnknownFields != nil && *crd.XPreserveUnknownFields {
+		return true
+	}
+	if crd.AdditionalProperties != nil {
+		return crd.AdditionalProperties.Allows || crd.AdditionalProperties.Schema != nil
+	}
+	return false
+}
+
+// digObject walks nested object properties of a decoded JSON schema.
+func digObject(m map[string]any, keys ...string) (map[string]any, bool) {
+	cur := m
+	for _, k := range keys {
+		next, ok := asJSONObject(cur[k])
+		if !ok {
+			return nil, false
+		}
+		cur = next
+	}
+	return cur, true
+}
+
+func asJSONObject(v any) (map[string]any, bool) {
+	m, ok := v.(map[string]any)
+	return m, ok
+}
+
+func requiredSet(v any) map[string]bool {
+	out := map[string]bool{}
+	arr, ok := v.([]any)
+	if !ok {
+		return out
+	}
+	for _, e := range arr {
+		if s, ok := e.(string); ok {
+			out[s] = true
+		}
+	}
+	return out
+}

--- a/controller/agenticrun/schemas.go
+++ b/controller/agenticrun/schemas.go
@@ -51,7 +51,6 @@ var AnalysisOutputSchema = json.RawMessage(`{
               },
               "risk": { "type": "string", "enum": ["Low", "Medium", "High", "Critical"], "description": "Risk assessment. Low: safe to apply. Medium: review recommended. High: careful review required. Critical: manual approval strongly recommended" },
               "reversible": { "type": "string", "enum": ["Reversible", "Irreversible", "Partial"], "description": "Whether this remediation can be rolled back. Reversible: fully undoable. Irreversible: cannot undo. Partial: some actions undoable" },
-              "estimatedImpact": { "type": "string", "description": "Expected impact on the system (e.g., 'Brief pod restart, ~30s downtime')" },
               "rollbackPlan": {
                 "type": "object",
                 "description": "How to undo the remediation if it fails or causes issues. Required when reversible is Reversible or Partial.",
@@ -78,10 +77,12 @@ var AnalysisOutputSchema = json.RawMessage(`{
                     "command": { "type": "string", "description": "Command or API call to run (e.g., 'oc get pod -n production -l app=web -o jsonpath={.status.phase}')" },
                     "expected": { "type": "string", "description": "Expected output or condition (e.g., 'Running', 'ready=true')" },
                     "type": { "type": "string", "description": "Check category (e.g., 'command', 'metric', 'condition')" }
-                  }
+                  },
+                  "required": ["name", "type"]
                 }
               }
-            }
+            },
+            "required": ["description"]
           },
           "rbac": {
             "type": "object",
@@ -176,7 +177,8 @@ var ExecutionOutputSchema = json.RawMessage(`{
       "properties": {
         "conditionOutcome": { "type": "string", "enum": ["Improved", "Unchanged", "Degraded"], "description": "Whether the target condition improved after remediation" },
         "summary": { "type": "string", "description": "Brief inline verification summary of what you observed after applying the fix" }
-      }
+      },
+      "required": ["conditionOutcome", "summary"]
     }
   },
   "required": ["success", "actionsTaken"]
@@ -197,7 +199,7 @@ var VerificationOutputSchema = json.RawMessage(`{
           "value": { "type": "string", "description": "Actual observed value (e.g., 'Running', '3 replicas')" },
           "result": { "type": "string", "enum": ["Passed", "Failed"], "description": "Whether the observed value matches expectations" }
         },
-        "required": ["name", "result"]
+        "required": ["name", "result", "source", "value"]
       }
     },
     "summary": { "type": "string", "description": "Overall verification summary in Markdown" }

--- a/test/agent/main.go
+++ b/test/agent/main.go
@@ -257,8 +257,7 @@ func cannedResponse(phase, targetNS string) []byte {
           { "command": "kubectl get configmap mock-cm -n %s -o jsonpath='{.data.key}'", "type": "post-check", "description": "Verify configmap was patched" }
         ],
         "risk": "Low",
-        "reversible": "Reversible",
-        "estimatedImpact": "Brief pod restart, ~30s downtime"
+        "reversible": "Reversible"
       },
       "verification": {
         "description": "mock verification plan",


### PR DESCRIPTION
## Problem

`ProposalResult.EstimatedImpact` was `+required` in the `AnalysisResult` CRD but only *optional* in the LLM output schema (`controller/proposal/schemas.go`). When the analysis agent omitted it (non-deterministic), the operator's status patch was rejected by CRD validation — `AnalysisResult` persisted with **0 options**, the proposal was marked **Failed**, and the analysis sandbox pod was **orphaned**.

## Changes

- Remove `estimatedImpact` from the API type (`proposal_analysis_types.go`), the LLM output schema (`schemas.go`), the generated CRD, and the mock agent (`test/agent/main.go`).
- Tighten the `verification` branch of the analysis LLM schema to match the CRD (`steps[]` require `name`+`type`; `verification` requires `description`).
- Fix the same drift class in other schemas: the execution schema's inline verification object now requires `conditionOutcome` and `summary`, and verification checks now require `source` and `value`.
- Add `schema_crd_drift_test.go`: a guard test covering all four LLM output schemas (analysis, execution, verification, escalation) against their generated CRDs, both directions:
  - A CRD-required field missing or not required in the LLM schema fails (the estimatedImpact class — rejected at status-patch time)
  - An LLM-schema property the CRD does not declare fails too (silently pruned on status patch), with a documented exemption for operator-consumed control fields
  - CRD paths resolve relative to the test source file via `runtime.Caller(0)` so the guard survives layout or invocation changes.

## Verification

- `make manifests`, `make api-lint` (0 issues), `make vet`/`fmt-check`, full `controller/proposal` tests pass; guard test negative-tested (injected drift fails with precise path).
- Deployed to a 4.22 cluster and ran a Default-mode analysis: the agent produced a proposal **without** `estimatedImpact`, the `AnalysisResult` persisted **Succeeded with 1 option**, and the proposal advanced to `Proposed` (no orphaned pod).

Supersedes #174.
Sibling PR: openshift/lightspeed-agentic-sandbox (eval schema sync)

Made with [Cursor](https://cursor.com)