### PR TITLE
fix: use numeric UID in mock agent Dockerfile

### DIFF
--- a/test/agent/Dockerfile
+++ b/test/agent/Dockerfile
@@ -22,6 +22,6 @@ FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /mock-agent /mock-agent
 COPY --from=builder /workspace/test/agent/skills/ /skills/
 EXPOSE 8080
-USER nonroot:nonroot
+USER 65532:65532
 ENTRYPOINT ["/mock-agent"]
 CMD ["-addr", ":8080"]


### PR DESCRIPTION
## Summary

- The mock agent Dockerfile uses `USER nonroot:nonroot` (string), but the operator's `podspec_builder.go` sets `runAsNonRoot: true` on sandbox pods (since PR #246). Kubernetes can't verify a string username is non-root, causing `CreateContainerConfigError` and 5m pod timeouts in all E2E tests.
- Switch to `USER 65532:65532` — the numeric UID that `nonroot` maps to in `gcr.io/distroless/static-debian12:nonroot`.

## Context

Since PR #246 merged (June 30), every Konflux E2E run has failed with:

```
container has runAsNonRoot and image has non-numeric user (nonroot),
cannot verify user is non-root
```

PR #285 was force-merged via `/override` to work around this.

## Test plan

- [ ] Rebuild and push `quay.io/openshift-lightspeed/ols-qe:lightspeed-mock-agent` with this fix
- [ ] Verify Konflux E2E passes (pods start without `CreateContainerConfigError`)

Made with [Cursor](https://cursor.com)