### PR TITLE
fix: add cluster-reader CRB to E2E install script

### DIFF
--- a/.tekton/integration-tests/scripts/install-operator.sh
+++ b/.tekton/integration-tests/scripts/install-operator.sh
@@ -55,6 +55,23 @@ subjects:
   namespace: ${OPERATOR_NAMESPACE}
 EOF
 
+# Grant cluster-reader to agent SA (required by execution RBAC discovery).
+echo "Granting cluster-reader to agent SA..."
+oc apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lightspeed-agent-cluster-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+subjects:
+- kind: ServiceAccount
+  name: lightspeed-agent
+  namespace: ${OPERATOR_NAMESPACE}
+EOF
+
 # Wait for rollout.
 echo "Waiting for operator rollout..."
 oc rollout status deployment/controller-manager -n "${OPERATOR_NAMESPACE}" --timeout=120s


### PR DESCRIPTION
## Summary

- The execution step's RBAC discovery (`discoverReaderBinding`) requires a `ClusterRoleBinding` with the `lightspeed-agent` SA as subject. The quickstart `install.sh` creates `lightspeed-agent-cluster-reader`, but the Konflux E2E install script was missing it.
- This caused `TestExecutionFlow` and `TestVerificationFlow` to fail with: `no ClusterRoleBinding found with subject openshift-lightspeed/lightspeed-agent — ensure reader RBAC is configured`
- Confirmed on PR #321 (pure main code, no feature changes) — this is a pre-existing bug, not specific to any feature PR.

## Test plan

- [ ] Konflux E2E passes — `TestExecutionFlow_ProposedToVerifying` and `TestVerificationFlow_VerifyingToCompleted` should now proceed past the approval stage

Made with [Cursor](https://cursor.com)