### PR TITLE
OLS-3441 Improve analysis prompt for precise RBAC derivation

### DIFF
--- a/controller/agenticrun/templates/analysis_query.tmpl
+++ b/controller/agenticrun/templates/analysis_query.tmpl
@@ -18,17 +18,34 @@ For each option you propose:
    Bad:  Update the deployment image to the latest version
 {{- if .HasExecution}}
 
-- **Derive RBAC from your script** — for EVERY command in your script, list EVERY Kubernetes resource it touches. Include:
-   - The primary resource (e.g., deployments for kubectl set image)
-   - Implicit sub-resources that Kubernetes mutates as a side effect (e.g., patching a Deployment triggers ReplicaSet changes; scaling touches replicasets and pods; creating a Service may involve endpoints/endpointslices)
-   - Resources accessed by wait/status commands (e.g., kubectl rollout status reads pods and replicasets)
-   - Any secrets, configmaps, or service accounts referenced or read by the commands
+- **Derive RBAC from your script** — walk through EVERY command and determine the exact API calls it makes. Use these rules:
 
-   For every resource in your RBAC, always include `get`, `list`, and `watch` as the minimum read verbs — kubectl commands internally use list and watch calls even for seemingly simple operations like `rollout status` or label-selector queries.
+   **Command → API mapping** (use ONLY the verbs each command needs):
+   - `kubectl get <res> <name>` → verb `get`, resourceNames: [name]
+   - `kubectl get <res>` or `kubectl get <res> -l <selector>` → verb `list`, NO resourceNames
+   - `kubectl describe <res> <name>` → verb `get`, resourceNames: [name]
+   - `kubectl patch <res> <name>` → verb `patch`, resourceNames: [name]
+   - `kubectl delete <res> <name>` → verb `delete`, resourceNames: [name]
+   - `kubectl scale <res> <name>` → verbs `get`, `update` on subresource `<res>/scale`, resourceNames: [name]
+   - `kubectl rollout status <res>/<name>` → `get` + `watch` on `<res>`, plus `list` + `watch` on replicasets
+   - `kubectl rollout undo <res>/<name>` → `patch` on `<res>`, plus `get` + `list` on replicasets (replicaset names are auto-generated — never restrict by resourceNames)
+   - `kubectl rollout restart <res>/<name>` → `patch` on `<res>`, resourceNames: [name]
+   - `kubectl logs deploy/<name>` → `get` on the deployment + `list` pods (no resourceNames) + `get` pods/log
+   - `kubectl logs <pod>` → `get` pods/log, resourceNames: [pod]
+   - `kubectl exec <pod> -- <cmd>` → `get` pods + `create` pods/exec, resourceNames: [pod]
+   - `kubectl apply/create -f` → `create` (or `patch` for apply) on the resource type being applied
+   - `kubectl label/annotate <res> <name>` → `patch`, resourceNames: [name]
 
-   Cross-check before finalizing:
-   - Every RBAC entry must trace to a specific command in your script.
-   - Every command in your script must have all its permissions covered. Walk through each command and ask "what API calls does this generate?" — not just the obvious resource, but every sub-request the API server will make.
+   **K8s RBAC constraints** (violating these causes silent permission failures):
+   - `list` and `watch` verbs CANNOT be restricted by `resourceNames` — Kubernetes ignores resourceNames for these verbs unless the request uses a `metadata.name` field selector, which kubectl does not do. Always emit `list`/`watch` without resourceNames. If you also need `get` (with resourceNames) on the same resource, emit TWO separate RBAC rules.
+   - `create` CANNOT be restricted by `resourceNames` for standard resources — only for subresources like `pods/exec`. Only use `resourceNames` with `get`, `patch`, `update`, `delete`, and `create` on subresources.
+   - Replicasets accessed by `rollout` commands have auto-generated names — never use resourceNames for replicasets.
+
+   **Scope rule**: only include RBAC for API calls YOUR commands make. Do not add permissions for internal Kubernetes side-effects (e.g., patching a Deployment does not require separate replicaset permissions unless your script explicitly runs a rollout command that watches replicasets).
+
+   **Cross-check** before finalizing:
+   - Every RBAC rule must trace back to a specific command — include a justification naming the command(s).
+   - Every command must have all its API calls covered. Walk through each one using the mapping above.
 {{- end}}
 {{- if .HasVerification}}
 


### PR DESCRIPTION
## Summary

- Replaces vague RBAC instructions in the analysis prompt with an explicit kubectl command → API operation mapping table
- Adds K8s RBAC constraint rules: `list`/`watch` can't use `resourceNames`, replicasets from rollout commands have auto-generated names, `scale` uses `<res>/scale` subresource
- Adds scope rule: only include RBAC for commands in the script, not internal K8s side-effects

## Why

Testing with a deterministic RBAC derivation tool (`rbac-from-commands`) against a real analysis result showed the old prompt produced:
- ~20 over-granted permissions per remediation option
- Missing `deployments/scale` subresource for `kubectl scale` (execution would 403)
- `list`/`watch` paired with `resourceNames` — K8s silently ignores this, so permissions appear granted but aren't

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [ ] Run an AgenticRun with execution enabled, verify the generated RBAC covers the script commands without over-granting

🤖 Generated with [Claude Code](https://claude.com/claude-code)