### PR TITLE
OLS-3487: Add reasoning config to Agent CRD and sandbox execution specs

### DIFF
--- a/.ai/spec/what/crd-api.md
+++ b/.ai/spec/what/crd-api.md
@@ -21,10 +21,11 @@ Kubernetes API surface for the agentic operator. **Lifecycle and gates** are in 
 15. **Agent — `spec.model`**: Required provider-specific model identifier string; validation restricts charset.
 16. **Agent — `spec.timeouts`**: Optional per-step and chat timeouts in seconds with min/max bounds per field.
 17. **Agent — `spec.maxTurns`**: Optional bound on tool-use turns per invocation.
-18. **Agent — `status.conditions`**: [PLANNED] Observed readiness; `Ready` condition is defined on the API but no controller currently reconciles Agent status. When implemented, it SHOULD document whether referenced provider resources are accessible.
-19. **LLMProvider — discriminator**: `spec.type` MUST match exactly one embedded config: `anthropic`, `googleCloudVertex`, `openAI`, `azureOpenAI`, or `awsBedrock`; CEL enforces mutual exclusion.
-20. **LLMProvider — secrets**: Each provider’s `credentialsSecret` references a `Secret` **by name** in the operator namespace (documented on fields as the deployment namespace for the operator, e.g. OpenShift Lightspeed namespace); required secret **keys** are defined per provider type on the API field comments (e.g. API key env file key names).
-21. **LLMProvider — endpoints**: Optional URL overrides per provider; validation enforces HTTP/HTTPS URL shape. Azure requires `endpoint`; optional separate URL override field exists where defined.
+18. **Agent — `spec.reasoningConfig`**: Optional freeform map (`map[string]interface{}`, JSON key `reasoningConfig`). When present, the operator MUST serialize it as `LIGHTSPEED_REASONING_CONFIG` JSON env var on the sandbox pod (see `sandbox-execution.md` rule 16a). When absent, the env var MUST be omitted and the sandbox uses SDK defaults. Contents are provider- and model-specific (e.g., Claude `thinking`/`effort`, Gemini `thinking_budget`/`thinking_level`, OpenAI `reasoning.effort`/`verbosity`); the operator passes the map as-is without validation — the sandbox and upstream SDK/API validate at invocation time. This field is aligned with the classic OLS operator's `ModelParametersSpec.ReasoningConfig` ([OLS-3452]).
+19. **Agent — `status.conditions`**: [PLANNED] Observed readiness; `Ready` condition is defined on the API but no controller currently reconciles Agent status. When implemented, it SHOULD document whether referenced provider resources are accessible.
+20. **LLMProvider — discriminator**: `spec.type` MUST match exactly one embedded config: `anthropic`, `googleCloudVertex`, `openAI`, `azureOpenAI`, or `awsBedrock`; CEL enforces mutual exclusion.
+21. **LLMProvider — secrets**: Each provider’s `credentialsSecret` references a `Secret` **by name** in the operator namespace (documented on fields as the deployment namespace for the operator, e.g. OpenShift Lightspeed namespace); required secret **keys** are defined per provider type on the API field comments (e.g. API key env file key names).
+22. **LLMProvider — endpoints**: Optional URL overrides per provider; validation enforces HTTP/HTTPS URL shape. Azure requires `endpoint`; optional separate URL override field exists where defined.
 22. **ApprovalPolicy — singleton name**: CRD validation requires `metadata.name` equals `cluster`.
 23. **ApprovalPolicy — `spec.stages`**: Optional list keyed by `name` (`SandboxStep`). Each entry sets `approval` to `Automatic` or `Manual`. Stages not listed default to **Manual** per API comments.
 24. **ApprovalPolicy — `spec.maxAttempts`**: Upper bound for execution attempts (initial + retries) when verification fails; default behavior when unset is defined in controller (see `approval.md`).
@@ -60,7 +61,7 @@ Kubernetes API surface for the agentic operator. **Lifecycle and gates** are in 
 - `status.conditions`, `status.steps.analysis|execution|verification|escalation.*`
 
 ### Agent
-- `metadata.name`, `spec.llmProvider.name`, `spec.model`, `spec.timeouts.*`, `spec.maxTurns`, `status.conditions`
+- `metadata.name`, `spec.llmProvider.name`, `spec.model`, `spec.reasoningConfig`, `spec.timeouts.*`, `spec.maxTurns`, `status.conditions`
 
 ### LLMProvider
 - `metadata.name`, `spec.type`, `spec.anthropic.*`, `spec.googleCloudVertex.*`, `spec.openAI.*`, `spec.azureOpenAI.*`, `spec.awsBedrock.*`

--- a/.ai/spec/what/sandbox-execution.md
+++ b/.ai/spec/what/sandbox-execution.md
@@ -31,6 +31,7 @@ Behavioral specification for how workflow steps run inside ephemeral **sandboxes
     | `LIGHTSPEED_PROVIDER_PROJECT` | When provider=`vertex` | `googleCloudVertex.projectID` (passed as-is) |
     | `LIGHTSPEED_PROVIDER_REGION` | When provider=`vertex` or `bedrock` | `googleCloudVertex.region` or `awsBedrock.region` (passed as-is) |
     | `LIGHTSPEED_PROVIDER_API_VERSION` | When provider=`azure` | `azureOpenAI.apiVersion` (passed as-is) |
+    | `LIGHTSPEED_REASONING_CONFIG` | When `Agent.spec.reasoningConfig` is set | `Agent.spec.reasoningConfig` serialized as JSON string |
 
     Provider type mapping from CRD `spec.type`:
 
@@ -78,7 +79,7 @@ Behavioral specification for how workflow steps run inside ephemeral **sandboxes
 - `spec.tools`, per-step `spec.*.tools` (`SkillsSource`, `MCPServerConfig`, `SecretRequirement`)
 - `spec.targetNamespaces` and RBAC materialization targets
 - `spec.analysisOutput` (analysis schema behavior)
-- `Agent.spec.model` → `LIGHTSPEED_MODEL`, `LLMProvider.spec.type` → `LIGHTSPEED_PROVIDER`, `LLMProvider.spec.*.credentialsSecret` (envFrom + volume mount), optional `LIGHTSPEED_PROVIDER_URL`, `LIGHTSPEED_PROVIDER_PROJECT`, `LIGHTSPEED_PROVIDER_REGION`, `LIGHTSPEED_PROVIDER_API_VERSION`, `LIGHTSPEED_MODEL_PROVIDER` (see rule 16a)
+- `Agent.spec.model` → `LIGHTSPEED_MODEL`, `LLMProvider.spec.type` → `LIGHTSPEED_PROVIDER`, `LLMProvider.spec.*.credentialsSecret` (envFrom + volume mount), optional `LIGHTSPEED_PROVIDER_URL`, `LIGHTSPEED_PROVIDER_PROJECT`, `LIGHTSPEED_PROVIDER_REGION`, `LIGHTSPEED_PROVIDER_API_VERSION`, `LIGHTSPEED_MODEL_PROVIDER` (see rule 16a), `Agent.spec.reasoningConfig` → `LIGHTSPEED_REASONING_CONFIG`
 - `AgenticRun` annotation `agentic.openshift.io/rbac-namespaces` (RBAC scope for cleanup)
 - `AgenticRun` finalizer string `agentic.openshift.io/execution-rbac-cleanup`
 


### PR DESCRIPTION
## Summary
- Adds `spec.reasoningConfig` freeform map (`map[string]interface{}`) to the Agent CRD spec (rule 18 in `crd-api.md`)
- Adds `LIGHTSPEED_REASONING_CONFIG` env var propagation to sandbox pod template (rule 16a in `sandbox-execution.md`)
- Aligned with classic OLS `ModelParametersSpec.ReasoningConfig` ([OLS-3452](https://redhat.atlassian.net/browse/OLS-3452))

Companion sandbox PR will follow in `openshift/lightspeed-agentic-sandbox`.

## Test plan
- [ ] Spec review only — no code changes in this PR
- [ ] Verify spec rules are internally consistent and cross-references are correct


Made with [Cursor](https://cursor.com)