### PR TITLE
OLS-3618 Fix oc-agentic run deny CEL validation failure

### DIFF
--- a/cli/run/deny.go
+++ b/cli/run/deny.go
@@ -95,11 +95,11 @@ func (o *DenyOptions) Run(ctx context.Context) error {
 	entry := agenticv1alpha1.ApprovalStage{Type: stageType, Decision: agenticv1alpha1.ApprovalDecisionDenied}
 	switch stageType {
 	case agenticv1alpha1.ApprovalStageAnalysis:
-		entry.Analysis = agenticv1alpha1.AnalysisApproval{}
+		entry.Analysis = agenticv1alpha1.AnalysisApproval{Agent: "default"}
 	case agenticv1alpha1.ApprovalStageExecution:
-		entry.Execution = agenticv1alpha1.ExecutionApproval{}
+		entry.Execution = agenticv1alpha1.ExecutionApproval{Agent: "default"}
 	case agenticv1alpha1.ApprovalStageVerification:
-		entry.Verification = agenticv1alpha1.VerificationApproval{}
+		entry.Verification = agenticv1alpha1.VerificationApproval{Agent: "default"}
 	}
 
 	patch := client.MergeFrom(approval.DeepCopy())


### PR DESCRIPTION
## Summary
- `oc-agentic run deny` was failing with CRD validation errors because approval stage entries were created with empty structs (`ExecutionApproval{}`), violating the `MinProperties=1` XValidation rule
- Set `Agent: "default"` on each approval struct to satisfy the constraint

## Test plan
- [ ] Run `oc-agentic run deny` against a live cluster and verify no validation error
- [ ] Verify the patched Approval CR has valid stage entries with `agent` field set

🤖 Generated with [Claude Code](https://claude.com/claude-code)