### PR TITLE
OLS-3589: Wire LIGHTSPEED_REASONING_CONFIG env var to sandbox pod

### DIFF
--- a/controller/agenticrun/podspec_builder.go
+++ b/controller/agenticrun/podspec_builder.go
@@ -76,6 +76,17 @@ func (b *PodSpecBuilder) Build(
 	)
 	b.addProviderSpecificEnv(&container, llm)
 
+	if len(agent.Spec.ReasoningConfig) > 0 {
+		rcJSON, err := json.Marshal(agent.Spec.ReasoningConfig)
+		if err != nil {
+			return nil, fmt.Errorf("marshal reasoningConfig: %w", err)
+		}
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "LIGHTSPEED_REASONING_CONFIG",
+			Value: string(rcJSON),
+		})
+	}
+
 	secretName := credentialsSecretName(llm)
 	container.EnvFrom = append(container.EnvFrom, corev1.EnvFromSource{
 		SecretRef: &corev1.SecretEnvSource{

--- a/controller/agenticrun/podspec_builder_test.go
+++ b/controller/agenticrun/podspec_builder_test.go
@@ -1,9 +1,11 @@
 package agenticrun
 
 import (
+	"encoding/json"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
@@ -567,5 +569,63 @@ func TestPodSpecBuilder_RequiredSecrets_FileMount(t *testing.T) {
 	}
 	if !foundMount {
 		t.Error("missing /etc/kubeconfig mount")
+	}
+}
+
+func TestPodSpecBuilder_ReasoningConfig_Present(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{
+		Spec: agenticv1alpha1.AgentSpec{
+			Model: "claude-opus-4-6",
+			ReasoningConfig: map[string]apiextensionsv1.JSON{
+				"thinking": {Raw: []byte(`"enabled"`)},
+				"effort":   {Raw: []byte(`"high"`)},
+			},
+		},
+	}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+
+	podSpec, err := builder.Build(agent, llm, nil, "analysis", defaultSandboxSA)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	container := podSpec.Containers[0]
+	envMap := envToMap(container.Env)
+	raw, ok := envMap["LIGHTSPEED_REASONING_CONFIG"]
+	if !ok {
+		t.Fatal("LIGHTSPEED_REASONING_CONFIG env var not set")
+	}
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		t.Fatalf("LIGHTSPEED_REASONING_CONFIG is not valid JSON: %v", err)
+	}
+	if string(parsed["thinking"]) != `"enabled"` {
+		t.Errorf("thinking = %s, want \"enabled\"", parsed["thinking"])
+	}
+	if string(parsed["effort"]) != `"high"` {
+		t.Errorf("effort = %s, want \"high\"", parsed["effort"])
+	}
+}
+
+func TestPodSpecBuilder_ReasoningConfig_Absent(t *testing.T) {
+	builder := PodSpecBuilder{Image: "quay.io/lightspeed/agent:latest"}
+	agent := &agenticv1alpha1.Agent{
+		Spec: agenticv1alpha1.AgentSpec{
+			Model: "claude-opus-4-6",
+		},
+	}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+
+	podSpec, err := builder.Build(agent, llm, nil, "analysis", defaultSandboxSA)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	container := podSpec.Containers[0]
+	envMap := envToMap(container.Env)
+	if _, ok := envMap["LIGHTSPEED_REASONING_CONFIG"]; ok {
+		t.Error("LIGHTSPEED_REASONING_CONFIG should not be set when reasoningConfig is absent")
 	}
 }

--- a/controller/agenticrun/sandbox_templates.go
+++ b/controller/agenticrun/sandbox_templates.go
@@ -92,6 +92,7 @@ type templateHashInput struct {
 	Skills              []agenticv1alpha1.SkillsSource      `json:"skills"`
 	MCPServers          []agenticv1alpha1.MCPServerConfig   `json:"mcpServers,omitempty"`
 	RequiredSecrets     []agenticv1alpha1.SecretRequirement `json:"requiredSecrets,omitempty"`
+	ReasoningConfig     string                              `json:"reasoningConfig,omitempty"`
 	Step                string                              `json:"step"`
 	BaseResourceVersion string                              `json:"baseRV"`
 	ServiceAccount      string                              `json:"serviceAccount"`
@@ -105,6 +106,7 @@ func computeTemplateHash(
 	skills []agenticv1alpha1.SkillsSource,
 	mcpServers []agenticv1alpha1.MCPServerConfig,
 	requiredSecrets []agenticv1alpha1.SecretRequirement,
+	reasoningConfigJSON string,
 	step string,
 	baseResourceVersion string,
 	serviceAccount string,
@@ -116,6 +118,7 @@ func computeTemplateHash(
 		Skills:              skills,
 		MCPServers:          mcpServers,
 		RequiredSecrets:     requiredSecrets,
+		ReasoningConfig:     reasoningConfigJSON,
 		Step:                step,
 		BaseResourceVersion: baseResourceVersion,
 		ServiceAccount:      serviceAccount,
@@ -173,11 +176,20 @@ func EnsureAgentTemplate(
 		requiredSecrets = tools.RequiredSecrets
 	}
 
+	var reasoningConfigJSON string
+	if len(agent.Spec.ReasoningConfig) > 0 {
+		rcData, err := json.Marshal(agent.Spec.ReasoningConfig)
+		if err != nil {
+			return "", fmt.Errorf("marshal reasoningConfig: %w", err)
+		}
+		reasoningConfigJSON = string(rcData)
+	}
+
 	audit, err := readAuditConfig(ctx, c)
 	if err != nil {
 		return "", fmt.Errorf("read audit config: %w", err)
 	}
-	hash, err := computeTemplateHash(llm, agent.Spec.Model, skills, mcpServers, requiredSecrets, step, base.GetResourceVersion(), serviceAccount, audit)
+	hash, err := computeTemplateHash(llm, agent.Spec.Model, skills, mcpServers, requiredSecrets, reasoningConfigJSON, step, base.GetResourceVersion(), serviceAccount, audit)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", ErrComputeTemplateHash, err)
 	}
@@ -229,6 +241,14 @@ func EnsureAgentTemplate(
 
 	if err := patchLLMCredentials(derived, llm, agent.Spec.Model); err != nil {
 		return "", fmt.Errorf("%s: %w", ErrPatchLLMCredentials, err)
+	}
+
+	if reasoningConfigJSON != "" {
+		if err := setEnvVar(derived, "LIGHTSPEED_REASONING_CONFIG", reasoningConfigJSON); err != nil {
+			return "", fmt.Errorf("set LIGHTSPEED_REASONING_CONFIG: %w", err)
+		}
+	} else {
+		removeEnvVar(derived, "LIGHTSPEED_REASONING_CONFIG")
 	}
 
 	if err := patchAuditEnvVars(derived, audit); err != nil {
@@ -536,6 +556,26 @@ func setEnvVar(tmpl *unstructured.Unstructured, name, value string) error {
 		"name":  name,
 		"value": value,
 	})
+}
+
+func removeEnvVar(tmpl *unstructured.Unstructured, name string) {
+	container, containers, err := firstContainer(tmpl)
+	if err != nil {
+		return
+	}
+	envList, _, _ := unstructured.NestedSlice(container, "env")
+	filtered := make([]any, 0, len(envList))
+	for _, e := range envList {
+		env, ok := e.(map[string]any)
+		if !ok || env["name"] != name {
+			filtered = append(filtered, e)
+		}
+	}
+	if len(filtered) == len(envList) {
+		return
+	}
+	_ = unstructured.SetNestedSlice(container, filtered, "env")
+	_ = writeContainers(tmpl, container, containers)
 }
 
 func addEnvVarFromSecret(tmpl *unstructured.Unstructured, envName, secretName, key string) error {

--- a/controller/agenticrun/sandbox_templates_test.go
+++ b/controller/agenticrun/sandbox_templates_test.go
@@ -77,7 +77,7 @@ func emptyTemplate() *unstructured.Unstructured {
 
 func mustHash(t *testing.T, llm *agenticv1alpha1.LLMProvider, model string, skills []agenticv1alpha1.SkillsSource, requiredSecrets []agenticv1alpha1.SecretRequirement, phase string) string {
 	t.Helper()
-	h, err := computeTemplateHash(llm, model, skills, nil, requiredSecrets, phase, "", "", nil)
+	h, err := computeTemplateHash(llm, model, skills, nil, requiredSecrets, "", phase, "", "", nil)
 	if err != nil {
 		t.Fatalf("computeTemplateHash: %v", err)
 	}
@@ -627,11 +627,11 @@ func TestComputeTemplateHash_DifferentBaseResourceVersion(t *testing.T) {
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex)
 	skills := []agenticv1alpha1.SkillsSource{{Image: "quay.io/test/skills:latest"}}
 
-	h1, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "analysis", "1000", "", nil)
+	h1, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "", "analysis", "1000", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	h2, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "analysis", "2000", "", nil)
+	h2, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "", "analysis", "2000", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -645,11 +645,11 @@ func TestComputeTemplateHash_SameBaseResourceVersion(t *testing.T) {
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex)
 	skills := []agenticv1alpha1.SkillsSource{{Image: "quay.io/test/skills:latest"}}
 
-	h1, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "analysis", "1000", "", nil)
+	h1, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "", "analysis", "1000", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	h2, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "analysis", "1000", "", nil)
+	h2, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "", "analysis", "1000", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -663,20 +663,101 @@ func TestComputeTemplateHash_DifferentAuditConfig(t *testing.T) {
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 	skills := []agenticv1alpha1.SkillsSource{{Image: "quay.io/test/skills:latest"}}
 
-	h1, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "analysis", "1000", "", nil)
+	h1, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "", "analysis", "1000", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	audit := &agenticv1alpha1.AuditConfig{
 		OTEL: agenticv1alpha1.AuditOTELConfig{Endpoint: "jaeger:4317"},
 	}
-	h2, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "analysis", "1000", "", audit)
+	h2, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "", "analysis", "1000", "", audit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if h1 == h2 {
 		t.Error("different audit config should produce different hashes")
+	}
+}
+
+func TestComputeTemplateHash_DifferentReasoningConfig(t *testing.T) {
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+	skills := []agenticv1alpha1.SkillsSource{{Image: "quay.io/test/skills:latest"}}
+
+	h1, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, "", "analysis", "1000", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, `{"thinking":"enabled"}`, "analysis", "1000", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if h1 == h2 {
+		t.Error("empty vs non-empty reasoning config should produce different hashes")
+	}
+
+	h3, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, `{"thinking":"enabled","effort":"high"}`, "analysis", "1000", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h2 == h3 {
+		t.Error("two different non-empty reasoning configs should produce different hashes")
+	}
+
+	h4, err := computeTemplateHash(llm, "claude-opus-4-6", skills, nil, nil, `{"thinking":"enabled"}`, "analysis", "1000", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h2 != h4 {
+		t.Error("identical reasoning configs should produce the same hash")
+	}
+}
+
+func TestReasoningConfigEnvVar_SetOnTemplate(t *testing.T) {
+	tmpl := emptyTemplate()
+	reasoningJSON := `{"thinking":"enabled","effort":"high"}`
+
+	if err := setEnvVar(tmpl, "LIGHTSPEED_REASONING_CONFIG", reasoningJSON); err != nil {
+		t.Fatalf("setEnvVar: %v", err)
+	}
+
+	envs := getEnvVars(tmpl)
+	e, ok := findEnv(envs, "LIGHTSPEED_REASONING_CONFIG")
+	if !ok {
+		t.Fatal("LIGHTSPEED_REASONING_CONFIG not found on template")
+	}
+	if e["value"] != reasoningJSON {
+		t.Errorf("value = %v, want %s", e["value"], reasoningJSON)
+	}
+}
+
+func TestReasoningConfigEnvVar_RemovedWhenAbsent(t *testing.T) {
+	tmpl := emptyTemplate()
+
+	if err := setEnvVar(tmpl, "LIGHTSPEED_REASONING_CONFIG", `{"old":"value"}`); err != nil {
+		t.Fatalf("setEnvVar: %v", err)
+	}
+
+	removeEnvVar(tmpl, "LIGHTSPEED_REASONING_CONFIG")
+
+	envs := getEnvVars(tmpl)
+	if _, ok := findEnv(envs, "LIGHTSPEED_REASONING_CONFIG"); ok {
+		t.Error("LIGHTSPEED_REASONING_CONFIG should have been removed")
+	}
+}
+
+func TestReasoningConfigEnvVar_BaseTemplatePollutionCleaned(t *testing.T) {
+	tmpl := emptyTemplate()
+	if err := setEnvVar(tmpl, "LIGHTSPEED_REASONING_CONFIG", `{"leaked":"from_base"}`); err != nil {
+		t.Fatalf("setEnvVar (simulate base pollution): %v", err)
+	}
+
+	removeEnvVar(tmpl, "LIGHTSPEED_REASONING_CONFIG")
+
+	envs := getEnvVars(tmpl)
+	if _, ok := findEnv(envs, "LIGHTSPEED_REASONING_CONFIG"); ok {
+		t.Error("LIGHTSPEED_REASONING_CONFIG leaked from base template should be removed when agent has no reasoningConfig")
 	}
 }
 

--- a/hack/quickstart/examples/openai.yaml
+++ b/hack/quickstart/examples/openai.yaml
@@ -21,6 +21,9 @@ spec:
   llmProvider:
     name: openai
   model: "gpt-5.4"
+  reasoningConfig:
+    effort: "high"
+    summary: "auto"
   timeouts:
     analysisSeconds: 120
     executionSeconds: 120


### PR DESCRIPTION
## Summary

- Serializes `Agent.spec.reasoningConfig` as JSON and sets `LIGHTSPEED_REASONING_CONFIG` env var on the sandbox container
- Covers both `bare-pod` mode (PodSpecBuilder) and `sandbox-claim` mode (EnsureAgentTemplate)
- Includes reasoning config in template content hash for proper cache invalidation
- When `reasoningConfig` is absent, the env var is omitted entirely

Implements [OLS-3589](https://redhat.atlassian.net/browse/OLS-3589). Part of the reasoning effort epic [OLS-3587](https://redhat.atlassian.net/browse/OLS-3587).

Spec: `sandbox-execution.md` rule 16a (merged in #332).

**Depends on:** [OLS-3588](https://redhat.atlassian.net/browse/OLS-3588) (#335, merged)

## Test plan

- [x] `make test` passes (all unit tests)
- [x] `TestPodSpecBuilder_ReasoningConfig_Present` — env var set with correct JSON
- [x] `TestPodSpecBuilder_ReasoningConfig_Absent` — env var omitted
- [x] `TestComputeTemplateHash_DifferentReasoningConfig` — hash changes when config differs
- [ ] E2E: Agent CR with `reasoningConfig` → pod has `LIGHTSPEED_REASONING_CONFIG` env var
- [ ] E2E: Agent CR without `reasoningConfig` → pod does not have the env var


Made with [Cursor](https://cursor.com)