### PR TITLE
OLS-3654 Fix empty top-level diagnosis CRD validation failure

### DIFF
--- a/controller/agenticrun/results.go
+++ b/controller/agenticrun/results.go
@@ -112,7 +112,7 @@ func (r *AgenticRunReconciler) createAnalysisResult(
 	if result != nil {
 		cr.Status.Options = result.Options
 		cr.Status.ActionRequired = agenticv1alpha1.ActionRequiredFromBool(result.IsActionRequired())
-		if result.Diagnosis != nil {
+		if result.Diagnosis != nil && result.Diagnosis.Summary != "" && result.Diagnosis.RootCause != "" && result.Diagnosis.Confidence != "" {
 			cr.Status.Diagnosis = *result.Diagnosis
 		}
 	}

--- a/controller/agenticrun/results_test.go
+++ b/controller/agenticrun/results_test.go
@@ -191,6 +191,78 @@ func TestCreateIdempotent_AlreadyExists_OverwritesStaleFailure(t *testing.T) {
 	}
 }
 
+// TestCreateAnalysisResult_EmptyTopLevelDiagnosis reproduces OLS-3654:
+// when the agent returns a top-level diagnosis with empty summary or
+// rootCause, the CRD's MinLength=1 rejects the status patch.
+func TestCreateAnalysisResult_EmptyTopLevelDiagnosis(t *testing.T) {
+	cases := []struct {
+		name      string
+		diagnosis *agenticv1alpha1.DiagnosisResult
+	}{
+		{"both empty", &agenticv1alpha1.DiagnosisResult{Confidence: agenticv1alpha1.ConfidenceLevelLow, RootCause: "", Summary: ""}},
+		{"summary only empty", &agenticv1alpha1.DiagnosisResult{Confidence: agenticv1alpha1.ConfidenceLevelLow, RootCause: "some cause", Summary: ""}},
+		{"rootCause only empty", &agenticv1alpha1.DiagnosisResult{Confidence: agenticv1alpha1.ConfidenceLevelLow, RootCause: "", Summary: "some summary"}},
+		{"confidence empty", &agenticv1alpha1.DiagnosisResult{Confidence: "", RootCause: "some cause", Summary: "some summary"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := testScheme()
+			fc := fake.NewClientBuilder().WithScheme(scheme).
+				WithStatusSubresource(&agenticv1alpha1.AnalysisResult{}).Build()
+
+			run := testAgenticRun()
+			run.UID = "test-uid"
+
+			actionRequired := true
+			result := &AnalysisOutput{
+				Success:        true,
+				ActionRequired: &actionRequired,
+				Diagnosis:      tc.diagnosis,
+				Options: []agenticv1alpha1.RemediationOption{{
+					Title: "Increase connection pool limits",
+					Diagnosis: agenticv1alpha1.DiagnosisResult{
+						Confidence: agenticv1alpha1.ConfidenceLevelHigh,
+						RootCause:  "reporting-service v1.0.2 opens a new PostgreSQL transaction every 10s",
+						Summary:    "PostgresqlTooManyConnections is firing in payments",
+					},
+					RemediationPlan: agenticv1alpha1.RemediationPlan{
+						Description: "Increase max_connections",
+						Actions:     []agenticv1alpha1.ProposedAction{{Command: "kubectl patch", Type: "patch", Description: "Patch configmap"}},
+						Risk:        agenticv1alpha1.RiskLevelLow,
+					},
+				}},
+			}
+
+			r := &AgenticRunReconciler{Client: fc}
+			startTime := metav1.Now()
+			completionTime := metav1.Now()
+			_, snapshot, err := r.createAnalysisResult(
+				context.Background(), run, result,
+				agenticv1alpha1.SandboxInfo{ClaimName: "test-sandbox", Namespace: "openshift-lightspeed"},
+				&startTime, &completionTime, "",
+			)
+			if err != nil {
+				t.Fatalf("createAnalysisResult: %v", err)
+			}
+
+			if snapshot.Status.Diagnosis.Summary != "" || snapshot.Status.Diagnosis.RootCause != "" || snapshot.Status.Diagnosis.Confidence != "" {
+				t.Errorf("expected zero-value diagnosis in status, got confidence=%q summary=%q rootCause=%q",
+					snapshot.Status.Diagnosis.Confidence,
+					snapshot.Status.Diagnosis.Summary,
+					snapshot.Status.Diagnosis.RootCause)
+			}
+
+			if len(snapshot.Status.Options) != 1 {
+				t.Fatalf("expected 1 option, got %d", len(snapshot.Status.Options))
+			}
+			if snapshot.Status.Options[0].Diagnosis.RootCause == "" {
+				t.Error("per-option diagnosis should be preserved")
+			}
+		})
+	}
+}
+
 func TestCreateIdempotent_ExecutionResult(t *testing.T) {
 	scheme := testScheme()
 	fc := fake.NewClientBuilder().WithScheme(scheme).

--- a/controller/agenticrun/sandbox_agent.go
+++ b/controller/agenticrun/sandbox_agent.go
@@ -102,6 +102,11 @@ func (s *SandboxAgentCaller) Analyze(ctx context.Context, run *agenticv1alpha1.A
 		}
 	}
 
+	if resp.Diagnosis != nil && (resp.Diagnosis.Summary == "" || resp.Diagnosis.RootCause == "" || resp.Diagnosis.Confidence == "") {
+		log.Info("ignoring empty top-level diagnosis (per-option diagnoses used instead)", "run", run.Name)
+		resp.Diagnosis = nil
+	}
+
 	actionRequired := resp.ActionRequired == nil || *resp.ActionRequired
 	if resp.Diagnosis == nil && !actionRequired {
 		log.Error(nil, "analysis response missing diagnosis for no-action-required result", "run", run.Name)

--- a/controller/agenticrun/sandbox_agent_test.go
+++ b/controller/agenticrun/sandbox_agent_test.go
@@ -406,6 +406,57 @@ func TestSandboxAgentCaller_ExecutePassesApprovedOption(t *testing.T) {
 	}
 }
 
+// --- OLS-3654: empty top-level diagnosis parsing ---
+
+func TestSandboxAgentCaller_Analyze_EmptyTopLevelDiagnosis(t *testing.T) {
+	cases := []struct {
+		name      string
+		diagnosis string
+	}{
+		{"both empty", `{"confidence": "Low", "rootCause": "", "summary": ""}`},
+		{"summary only empty", `{"confidence": "Low", "rootCause": "some cause", "summary": ""}`},
+		{"rootCause only empty", `{"confidence": "Low", "rootCause": "", "summary": "some summary"}`},
+		{"confidence empty", `{"confidence": "", "rootCause": "some cause", "summary": "some summary"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sandbox := &mockSandboxProvider{claimName: "ls-analysis-fix-crash", endpoint: "http://sandbox:8080"}
+			httpClient := &mockHTTPClient{
+				response: &agentRunResponse{
+					Response: json.RawMessage(fmt.Sprintf(`{
+						"success": true,
+						"actionRequired": true,
+						"diagnosis": %s,
+						"options": [{
+							"title": "Increase connection pool limits",
+							"diagnosis": {"confidence": "High", "rootCause": "reporting-service opens too many connections", "summary": "PostgresqlTooManyConnections firing"},
+							"remediationPlan": {"description": "Increase limits", "actions": [{"command": "kubectl patch", "type": "patch", "description": "patch configmap"}], "risk": "Low"}
+						}]
+					}`, tc.diagnosis)),
+				},
+			}
+
+			caller := newTestSandboxAgentCaller(sandbox, httpClient)
+			result, err := caller.Analyze(context.Background(), testSandboxAgenticRun(), testSandboxStep(), "Too many connections", defaultSandboxSA)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result.Diagnosis != nil {
+				t.Errorf("expected nil Diagnosis, got confidence=%q summary=%q rootCause=%q",
+					result.Diagnosis.Confidence, result.Diagnosis.Summary, result.Diagnosis.RootCause)
+			}
+			if len(result.Options) != 1 {
+				t.Fatalf("expected 1 option, got %d", len(result.Options))
+			}
+			if result.Options[0].Diagnosis.RootCause == "" {
+				t.Error("per-option diagnosis should be preserved")
+			}
+		})
+	}
+}
+
 // --- Per-phase query construction tests ---
 
 func TestSandboxAgentCaller_AnalysisQueryFraming(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix [OLS-3654](https://redhat.atlassian.net/browse/OLS-3654): when the analysis agent returns `actionRequired: true` with per-option diagnoses but an incomplete top-level diagnosis (empty `summary`, `rootCause`, or `confidence`), the CRD's `MinLength=1` / required-enum validation rejects the status patch, losing the agent's work
- Defense-in-depth: sanitize incomplete diagnosis to nil at the parsing layer (`sandbox_agent.go`) and guard against it at the results layer (`results.go`)
- Table-driven tests cover all single-field-empty cases (both empty, summary-only, rootCause-only, confidence-only)

## Test plan
- [x] `TestCreateAnalysisResult_EmptyTopLevelDiagnosis` — verifies `createAnalysisResult` does not write incomplete diagnosis fields to status
- [x] `TestSandboxAgentCaller_Analyze_EmptyTopLevelDiagnosis` — verifies `Analyze()` normalizes incomplete diagnosis to nil
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)