### PR TITLE
OLS-3681: Install or update Lightspeed Operator in quickstart

### DIFF
--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -1,54 +1,116 @@
 # Quickstart
 
 Deploy Agentic OLS onto an OpenShift cluster using pre-built Konflux images.
-No building, no cloning required.
+Installs or updates Lightspeed Operator via OLM (`operator-sdk run bundle` /
+`bundle-upgrade`) when needed, then deploys the agentic operator. Pass
+`--ols-bundle-image` to choose the OLS bundle; otherwise the script resolves
+`lightspeed-operator-bundle` from git `related_images.json` and prompts
+(decline / option 3 stops). No building or cloning of this repo is required.
 
 ## Prerequisites
 
 - `oc` CLI on PATH
 - Logged into the target OpenShift cluster
 - cluster-admin privileges
+- `python3` on PATH only when `--ols-bundle-image` is omitted (related_images fallback)
 
 ## Install
 
+Download the script, then run it (required for interactive Lightspeed Operator prompts):
+
 ```bash
-bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
+curl -fsSL -o install-agentic.sh \
+  https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh
+bash install-agentic.sh
 ```
 
-The script installs CRDs, deploys the operator, and creates an ApprovalPolicy.
+Prefer an explicit OLS bundle (recommended when `related_images.json` may lag):
+
+```bash
+bash install-agentic.sh \
+  --ols-bundle-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-operator-bundle:main
+```
+
+Do **not** use `curl … | bash` — stdin is the script, so `y`/`n` prompts cannot work.
+
+The script:
+
+1. Detects whether Lightspeed Operator is installed (`OLSConfig` CRD).
+2. Installs or updates OLS via `operator-sdk run bundle` / `bundle-upgrade`:
+   - **`--ols-bundle-image` / `OLS_BUNDLE_IMAGE` set:** always install (if missing)
+     or update (if present) with that image — no confirmation.
+   - **No user image, OLS missing:** resolves
+     [`lightspeed-operator-bundle` from `related_images.json`](https://github.com/openshift/lightspeed-operator/blob/main/related_images.json)
+     (git ref `OLS_GIT_REF`, default `main`), shows the concrete image, and asks
+     to install it. Declining **stops** the script (re-run with
+     `--ols-bundle-image=…`).
+   - **No user image, OLS present:** three-way choice — (1) leave OLS as-is and
+     continue to agentic, (2) update to the related_images bundle, or (3) stop
+     and re-run with `--ols-bundle-image=…`.
+3. After a successful OLS install/update: writes/exports an `OLSConfig` file
+   (`OLS_CONFIG_FILE`), lets you edit/apply in a loop, and waits until
+   `status.overallStatus=Ready` (dumps diagnostics on failure).
+4. Installs Agentic Operator CRDs, Deployment, ApprovalPolicy, and webhook.
+
 After completion it prints instructions for configuring an LLM provider and
 submitting a test run.
 
 ## Uninstall
 
+Download the script, then run it (required for interactive Lightspeed Operator prompts):
+
 ```bash
-bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh)
+curl -fsSL -o uninstall-agentic.sh \
+  https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh
+bash uninstall-agentic.sh
 ```
 
-Skip the confirmation prompt with `QUICKSTART_FORCE=1`.
+Do **not** use `curl … | bash` — stdin is the script, so `y`/`n` prompts cannot work.
+
+The script removes Agentic Operator resources and CRDs, and asks whether to also
+uninstall Lightspeed Operator via `operator-sdk cleanup`. Declining leaves OLS
+installed and keeps the namespace.
+
+Skip the top-level confirmation with `QUICKSTART_FORCE=1`. For non-interactive
+OLS decisions, set `REMOVE_OLS=1` (uninstall OLS) or `REMOVE_OLS=0` (keep OLS).
+
+## CLI options
+
+| Flag | Description |
+|---|---|
+| `--ols-bundle-image=IMAGE` | Lightspeed Operator OLM bundle for `operator-sdk run bundle` / `bundle-upgrade`. Required non-empty when set. If omitted, resolves `lightspeed-operator-bundle` from `related_images.json` and prompts (see Install flow above). |
+| `-h`, `--help` | Show usage and exit |
 
 ## Environment Variables
 
 | Variable | Default | Description |
 |---|---|---|
 | `NAMESPACE` | `openshift-lightspeed` | Target namespace |
-| `OPERATOR_IMAGE` | Konflux `:main` | Operator container image |
+| `OPERATOR_IMAGE` | Konflux `:main` | Agentic operator container image |
 | `SANDBOX_IMAGE` | Konflux `:main` | Agent sandbox container image |
 | `SANDBOX_MODE` | `bare-pod` | Sandbox mode (`bare-pod` or `sandbox-claim`) |
 | `IMAGE_PULL_POLICY` | *(empty — Kubernetes default)* | Image pull policy for operator and sandbox pods (`Always`, `IfNotPresent`, `Never`) |
+| `OLS_BUNDLE_IMAGE` | *(empty)* | Same as `--ols-bundle-image`; the flag overrides this env var |
+| `OLS_GIT_REF` | `main` | Git ref for `openshift/lightspeed-operator` `related_images.json` (fallback only) |
+| `OLS_RELATED_IMAGES_URL` | raw GitHub URL for that ref | Override the related_images.json URL (fallback only) |
+| `BUNDLE_TIMEOUT` | `30m` | `operator-sdk run bundle` timeout |
+| `OLS_CONFIG_FILE` | `$TMPDIR/olsconfig-quickstart.yaml` | Path for the editable OLSConfig manifest |
+| `OLS_CONFIG_TIMEOUT_SEC` | `900` | Seconds to wait for `OLSConfig` `overallStatus=Ready` |
+| `AGENTIC_ROLLOUT_TIMEOUT` | `300s` | `oc rollout status` timeout for the agentic Deployment |
+| `REMOVE_OLS` | *(unset — prompt)* | Uninstall: `1` remove Lightspeed Operator, `0` keep it |
+| `CLEANUP_TIMEOUT` | `5m` | Uninstall: `operator-sdk cleanup` timeout |
 
 Example with overrides:
 
 ```bash
-NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim \
-  bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
+NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim bash install-agentic.sh \
+  --ols-bundle-image=quay.io/example/lightspeed-operator-bundle:main
 ```
 
 For dev environments with floating tags like `:main`, force fresh pulls:
 
 ```bash
-IMAGE_PULL_POLICY=Always \
-  bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
+IMAGE_PULL_POLICY=Always bash install-agentic.sh
 ```
 
 ## LLM Provider Examples

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
 #
 # Quickstart installer for Agentic OLS.
-# Deploys the operator and its CRDs onto an OpenShift cluster using
-# pre-built Konflux images. No building, no cloning.
+# Installs or updates Lightspeed Operator via OLM (operator-sdk run bundle /
+# bundle-upgrade) when needed, then deploys the agentic operator from pre-built
+# Konflux images. Pass --ols-bundle-image=IMAGE to choose the OLS bundle;
+# otherwise the script resolves lightspeed-operator-bundle from
+# related_images.json and prompts (decline / option 3 stops). No building or
+# cloning of this repo is required; operator-sdk is downloaded on demand if
+# missing from PATH.
 #
-# Usage:
-#   bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh)
+# Usage (download then run — required for interactive OLS prompts):
+#   curl -fsSL -o install-agentic.sh \
+#     https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh
+#   bash install-agentic.sh
+#   bash install-agentic.sh --ols-bundle-image=quay.io/.../lightspeed-operator-bundle:tag
+#
+# Do not use: curl … | bash  (stdin is the script; prompts cannot read y/n)
 #
 # Prerequisites:
 #   - oc CLI on PATH
+#   - python3 on PATH only when --ols-bundle-image is omitted (related_images.json fallback)
 #   - Logged into the target OpenShift cluster
 #   - cluster-admin privileges
+#   - Interactive terminal (TTY) for Lightspeed Operator install/update prompts
 #
 # Note: The console plugin requires OpenShift 4.22+.
 #       Set CONSOLE_IMAGE="" to skip console deployment on older clusters.
@@ -26,6 +38,82 @@ SANDBOX_MODE="${SANDBOX_MODE:-bare-pod}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-}"
 
 GITHUB_RAW="${GITHUB_RAW:-https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main}"
+# Preferred OLS bundle image. Flag --ols-bundle-image overrides; env OLS_BUNDLE_IMAGE is a fallback.
+# When neither is set, install/update resolves the bundle from related_images.json.
+OLS_BUNDLE_IMAGE="${OLS_BUNDLE_IMAGE:-}"
+# Git ref for openshift/lightspeed-operator related_images.json (used only when OLS_BUNDLE_IMAGE is empty).
+OLS_GIT_REF="${OLS_GIT_REF:-main}"
+OLS_RELATED_IMAGES_URL="${OLS_RELATED_IMAGES_URL:-https://raw.githubusercontent.com/openshift/lightspeed-operator/${OLS_GIT_REF}/related_images.json}"
+OPERATOR_SDK_VERSION="${OPERATOR_SDK_VERSION:-1.36.1}"
+BUNDLE_TIMEOUT="${BUNDLE_TIMEOUT:-30m}"
+OLS_CONFIG_FILE="${OLS_CONFIG_FILE:-${TMPDIR:-/tmp}/olsconfig-quickstart.yaml}"
+# How long to wait for OLSConfig status.overallStatus=Ready after each apply.
+OLS_CONFIG_TIMEOUT_SEC="${OLS_CONFIG_TIMEOUT_SEC:-900}"
+
+info()  { echo "  ✓ $*"; }
+step()  { echo "[${1}] ${2}"; }
+fail()  { echo "  ✗ $*" >&2; exit 1; }
+warn()  { echo "  ⚠ $*" >&2; }
+
+usage() {
+  cat <<EOF
+Usage: bash install-agentic.sh [options]
+
+Options:
+  --ols-bundle-image=IMAGE   Lightspeed Operator OLM bundle image for
+                             operator-sdk run bundle / bundle-upgrade.
+                             Always install/update when set (no prompt).
+                             If omitted, resolves lightspeed-operator-bundle
+                             from related_images.json (${OLS_RELATED_IMAGES_URL})
+                             and prompts (decline / option 3 stops the script).
+  -h, --help                 Show this help and exit
+
+Environment variables (OPERATOR_IMAGE, SANDBOX_IMAGE, NAMESPACE, …) are
+documented in hack/quickstart/README.md.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ols-bundle-image=*)
+      OLS_BUNDLE_IMAGE="${1#*=}"
+      [ -n "${OLS_BUNDLE_IMAGE}" ] || fail "--ols-bundle-image requires a non-empty image"
+      shift
+      ;;
+    --ols-bundle-image)
+      [ $# -ge 2 ] || fail "--ols-bundle-image requires an image argument"
+      OLS_BUNDLE_IMAGE="$2"
+      [ -n "${OLS_BUNDLE_IMAGE}" ] || fail "--ols-bundle-image requires a non-empty image"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1 (try --help)"
+      ;;
+  esac
+done
+
+# Trim leading/trailing whitespace from flag or env. Whitespace-only → empty → error
+# if the user provided a blank value; truly unset/empty stays on the related_images path.
+_ols_bundle_raw="${OLS_BUNDLE_IMAGE}"
+OLS_BUNDLE_IMAGE="${OLS_BUNDLE_IMAGE#"${OLS_BUNDLE_IMAGE%%[![:space:]]*}"}"
+OLS_BUNDLE_IMAGE="${OLS_BUNDLE_IMAGE%"${OLS_BUNDLE_IMAGE##*[![:space:]]}"}"
+if [ -n "${_ols_bundle_raw}" ] && [ -z "${OLS_BUNDLE_IMAGE}" ]; then
+  fail "--ols-bundle-image / OLS_BUNDLE_IMAGE must be non-empty"
+fi
+unset _ols_bundle_raw
+
+if [ -n "${OLS_BUNDLE_IMAGE}" ] && [[ "${OLS_BUNDLE_IMAGE}" != *[:/]* ]]; then
+  fail "OLS_BUNDLE_IMAGE looks invalid: ${OLS_BUNDLE_IMAGE}"
+fi
+
+# Set when a related_images.json bundle is resolved (for logging / summary).
+OLS_RELATED_BUNDLE_IMAGE=""
+# install | update | left-as-is | none — what happened to OLS in this run.
+OLS_ACTION="none"
 
 CRD_FILES=(
   agentic.openshift.io_agenticolsconfigs.yaml
@@ -40,16 +128,330 @@ CRD_FILES=(
   agentic.openshift.io_verificationresults.yaml
 )
 
-info()  { echo "  ✓ $*"; }
-step()  { echo "[${1}] ${2}"; }
-fail()  { echo "  ✗ $*" >&2; exit 1; }
+# Prefer local CRD files when running from a checkout; fall back to GitHub.
+REPO_ROOT=""
+if [ -n "${BASH_SOURCE[0]:-}" ]; then
+  _candidate="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  if [ -d "${_candidate}/config/crd/bases" ]; then
+    REPO_ROOT="${_candidate}"
+  fi
+fi
+
+ols_crd_installed() {
+  oc get crd olsconfigs.ols.openshift.io >/dev/null 2>&1
+}
+
+require_tty_for_prompts() {
+  if [[ ! -t 0 ]]; then
+    fail "Interactive prompts require a terminal.
+
+  Do not pipe the script into bash (curl … | bash).
+  Download it, then run it:
+
+    curl -fsSL -o install-agentic.sh \\
+      ${GITHUB_RAW}/hack/quickstart/install.sh
+    bash install-agentic.sh"
+  fi
+}
+
+prompt_yes_no() {
+  # $1 = prompt text. Returns 0 for yes, 1 for no.
+  require_tty_for_prompts
+  local reply
+  while true; do
+    printf '%s [y/n]: ' "$1"
+    read -r reply
+    case "${reply}" in
+      [yY]|[yY][eE][sS]) return 0 ;;
+      [nN]|[nN][oO]) return 1 ;;
+      *) echo "  Unexpected input: '${reply}'. Please answer y or n." >&2 ;;
+    esac
+  done
+}
+
+ensure_operator_sdk() {
+  if command -v operator-sdk >/dev/null 2>&1; then
+    OPERATOR_SDK_BIN="$(command -v operator-sdk)"
+    return 0
+  fi
+  command -v curl >/dev/null 2>&1 || fail "curl is required to download operator-sdk"
+  local os arch dest url
+  case "$(uname -s)" in
+    Linux) os=linux ;;
+    Darwin) os=darwin ;;
+    *) fail "unsupported OS for operator-sdk download: $(uname -s)" ;;
+  esac
+  case "$(uname -m)" in
+    x86_64|amd64) arch=amd64 ;;
+    aarch64|arm64) arch=arm64 ;;
+    *) fail "unsupported arch for operator-sdk download: $(uname -m)" ;;
+  esac
+  dest="${TMPDIR:-/tmp}/operator-sdk-${OPERATOR_SDK_VERSION}"
+  url="https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_${os}_${arch}"
+  echo "  Downloading operator-sdk v${OPERATOR_SDK_VERSION}..."
+  curl -fsSL -o "${dest}" "${url}"
+  chmod +x "${dest}"
+  OPERATOR_SDK_BIN="${dest}"
+  info "operator-sdk ready (${OPERATOR_SDK_BIN})"
+}
+
+ols_bundle_image_from_git() {
+  command -v python3 >/dev/null 2>&1 \
+    || fail "python3 not found (needed to read related_images.json when --ols-bundle-image is omitted)"
+  python3 - "${OLS_RELATED_IMAGES_URL}" <<'PY'
+import json, sys, urllib.error, urllib.request
+url = sys.argv[1]
+try:
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        data = json.load(resp)
+except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
+    sys.stderr.write(f"error: fetch related_images.json: {e}\n")
+    sys.exit(1)
+for entry in data:
+    if entry.get("name") == "lightspeed-operator-bundle" and entry.get("image"):
+        print(entry["image"])
+        sys.exit(0)
+sys.stderr.write("error: lightspeed-operator-bundle not found in related_images.json\n")
+sys.exit(1)
+PY
+}
+
+fetch_related_images_bundle() {
+  info "OLS bundle source: related_images.json (git)"
+  echo "  Fetching related_images.json from ${OLS_RELATED_IMAGES_URL}"
+  OLS_RELATED_BUNDLE_IMAGE="$(ols_bundle_image_from_git)"
+  info "Resolved OLS bundle image: ${OLS_RELATED_BUNDLE_IMAGE}"
+}
+
+stop_for_custom_ols_bundle() {
+  local resolved="${1:-}"
+  local msg
+  msg="Stopping. Re-run with your preferred OLS bundle image, for example:
+
+  bash install-agentic.sh --ols-bundle-image=quay.io/<org>/lightspeed-operator-bundle:<tag>
+
+  Related_images URL:
+    ${OLS_RELATED_IMAGES_URL}"
+  if [ -n "${resolved}" ]; then
+    msg="${msg}
+  Resolved related_images bundle (not used):
+    ${resolved}"
+  fi
+  fail "${msg}"
+}
+
+ols_bundle_source_desc() {
+  if [ -n "${OLS_BUNDLE_IMAGE}" ]; then
+    echo "user-provided ${OLS_BUNDLE_IMAGE}"
+  elif [ -n "${OLS_RELATED_BUNDLE_IMAGE}" ]; then
+    echo "related_images.json ${OLS_RELATED_BUNDLE_IMAGE}"
+  else
+    echo "related_images.json ${OLS_RELATED_IMAGES_URL}"
+  fi
+}
+
+install_or_update_ols() {
+  # $1 = install | update
+  # $2 = bundle image
+  local mode="$1"
+  local bundle_image="$2"
+  ensure_operator_sdk
+  info "OLS bundle image: ${bundle_image}"
+
+  if [ "${mode}" = "update" ]; then
+    echo "  Updating Lightspeed Operator via operator-sdk run bundle-upgrade..."
+    if ! "${OPERATOR_SDK_BIN}" run bundle-upgrade --timeout="${BUNDLE_TIMEOUT}" --namespace "${NAMESPACE}" "${bundle_image}"; then
+      fail "Lightspeed Operator bundle-upgrade failed.
+
+  Refusing to fall back to a fresh 'run bundle' (that can leave a conflicting OLM install).
+  Fix or reinstall OLS manually, then re-run this script.
+  Bundle image: ${bundle_image}
+  Bundle source: $(ols_bundle_source_desc)"
+    fi
+    info "Lightspeed Operator updated"
+    OLS_ACTION="update"
+    return 0
+  fi
+
+  echo "  Installing Lightspeed Operator via operator-sdk run bundle..."
+  "${OPERATOR_SDK_BIN}" run bundle --timeout="${BUNDLE_TIMEOUT}" --namespace "${NAMESPACE}" "${bundle_image}" \
+    || fail "Lightspeed Operator bundle install failed"
+  info "Lightspeed Operator installed"
+  OLS_ACTION="install"
+}
+
+prompt_ols_already_installed() {
+  # $1 = related_images bundle. Prints leave | update | stop on stdout.
+  local bundle_image="$1"
+  require_tty_for_prompts
+  cat <<EOF >&2
+
+  Lightspeed Operator is already installed (OLSConfig CRD present).
+  related_images.json resolved to:
+    ${bundle_image}
+
+  Choose:
+    1) Leave current OLS as-is (continue to agentic)
+    2) Update OLS to the related_images bundle above
+    3) Stop and re-run with --ols-bundle-image=<your-image>
+
+EOF
+  local reply
+  while true; do
+    printf 'Choice [1/2/3]: ' >&2
+    read -r reply
+    case "${reply}" in
+      1) echo leave; return 0 ;;
+      2) echo update; return 0 ;;
+      3) echo stop; return 0 ;;
+      *) echo "  Unexpected input: '${reply}'. Please answer 1, 2, or 3." >&2 ;;
+    esac
+  done
+}
+
+write_olsconfig_template() {
+  cat >"${OLS_CONFIG_FILE}" <<EOF
+# Quickstart OLSConfig — edit provider/secret/model as needed, then apply from the installer prompt.
+#
+# Create the LLM credentials Secret in ${NAMESPACE} first, for example (OpenAI):
+#   oc create secret generic llm-creds -n ${NAMESPACE} --from-literal=apitoken=sk-...
+#
+# credentialsSecretRef.name below must match that Secret.
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+spec:
+  llm:
+    providers:
+      - name: openai
+        type: openai
+        credentialsSecretRef:
+          name: llm-creds
+        url: https://api.openai.com/v1
+        models:
+          - name: gpt-4o-mini
+  ols:
+    defaultProvider: openai
+    defaultModel: gpt-4o-mini
+EOF
+}
+
+seed_olsconfig_file() {
+  if oc get olsconfig cluster >/dev/null 2>&1; then
+    oc get olsconfig cluster -o yaml >"${OLS_CONFIG_FILE}"
+    info "Exported existing OLSConfig cluster to ${OLS_CONFIG_FILE}"
+  else
+    write_olsconfig_template
+    info "Wrote starter OLSConfig to ${OLS_CONFIG_FILE}"
+  fi
+}
+
+dump_ols_diagnostics() {
+  echo ""
+  warn "OLS diagnostics (${NAMESPACE}):"
+  echo "---- oc get olsconfig cluster -o yaml ----"
+  oc get olsconfig cluster -o yaml 2>&1 || true
+  echo "---- oc get pods -n ${NAMESPACE} ----"
+  oc get pods -n "${NAMESPACE}" -o wide 2>&1 || true
+  echo "---- recent events -n ${NAMESPACE} ----"
+  oc get events -n "${NAMESPACE}" --sort-by=.metadata.creationTimestamp 2>&1 | tail -40 || true
+  echo ""
+}
+
+wait_olsconfig_ready() {
+  local elapsed=0
+  local status=""
+  echo "  Waiting up to ${OLS_CONFIG_TIMEOUT_SEC}s for OLSConfig status.overallStatus=Ready..."
+  while (( elapsed < OLS_CONFIG_TIMEOUT_SEC )); do
+    status="$(oc get olsconfig cluster -o jsonpath='{.status.overallStatus}' 2>/dev/null || true)"
+    if [[ "${status}" == "Ready" ]]; then
+      info "OLS is ready (overallStatus=Ready)"
+      return 0
+    fi
+    sleep 10
+    elapsed=$((elapsed + 10))
+    if (( elapsed % 60 == 0 )); then
+      echo "  … still waiting (overallStatus=${status:-unset}, ${elapsed}s/${OLS_CONFIG_TIMEOUT_SEC}s)"
+    fi
+  done
+  warn "OLS failed to become Ready within ${OLS_CONFIG_TIMEOUT_SEC}s (last overallStatus=${status:-unset})"
+  dump_ols_diagnostics
+  return 1
+}
+
+# Interactive loop: edit OLSConfig file, apply, wait for overallStatus=Ready.
+configure_olsconfig_interactive() {
+  require_tty_for_prompts
+  seed_olsconfig_file
+
+  while true; do
+    cat <<EOF
+
+  OLSConfig file: ${OLS_CONFIG_FILE}
+
+  Before applying, you must:
+    1. Create a Secret in ${NAMESPACE} with your LLM API key, for example (OpenAI):
+         oc create secret generic llm-creds -n ${NAMESPACE} \\
+           --from-literal=apitoken=sk-...
+    2. Edit ${OLS_CONFIG_FILE} and set provider information to match:
+         - spec.llm.providers[].type / name / url / models
+         - spec.llm.providers[].credentialsSecretRef.name (must match the Secret)
+         - spec.ols.defaultProvider and spec.ols.defaultModel
+
+  Open the file in another terminal to accept the starter values or customize them.
+  OLS will stay NotReady until the Secret and provider config are correct.
+
+EOF
+    local reply
+    while true; do
+      printf 'Apply OLSConfig from this file now? [y=apply / e=edit first / a=abort]: '
+      read -r reply
+      case "${reply}" in
+        [yY]|[yY][eE][sS]) break ;;
+        [eE]|[eE][dD][iI][tT])
+          echo "  Create the LLM Secret and edit provider fields in ${OLS_CONFIG_FILE}, then choose y to apply."
+          continue 2
+          ;;
+        [aA]|[aA][bB][oO][rR][tT])
+          fail "Aborted OLSConfig setup. Re-run the installer when ready."
+          ;;
+        *) echo "  Unexpected input: '${reply}'. Please answer y, e, or a." >&2 ;;
+      esac
+    done
+
+    echo "  Applying ${OLS_CONFIG_FILE}..."
+    if ! oc apply -f "${OLS_CONFIG_FILE}"; then
+      warn "oc apply failed — fix the file and try again"
+      continue
+    fi
+    info "OLSConfig applied"
+
+    if wait_olsconfig_ready; then
+      return 0
+    fi
+
+    warn "OLS is not Ready. Fix the OLSConfig (and Secrets), then apply again."
+    if ! prompt_yes_no "Return to the OLSConfig edit/apply loop?"; then
+      fail "OLSConfig did not become Ready. Fix OLS, then re-run this script."
+    fi
+  done
+}
 
 # --- Step 1: Prerequisites ---------------------------------------------------
 
-step "1/7" "Checking prerequisites..."
+step "1/9" "Checking prerequisites..."
 
 command -v oc >/dev/null 2>&1 || fail "oc CLI not found. Install it first."
 info "oc CLI found"
+
+if [ -z "${OLS_BUNDLE_IMAGE}" ]; then
+  command -v python3 >/dev/null 2>&1 \
+    || fail "python3 not found (needed to read related_images.json when --ols-bundle-image is omitted)"
+  info "python3 found (related_images.json fallback)"
+else
+  info "OLS bundle image override: ${OLS_BUNDLE_IMAGE}"
+fi
 
 oc whoami >/dev/null 2>&1 || fail "Not logged into a cluster. Run: oc login ..."
 info "Logged in as $(oc whoami)"
@@ -59,18 +461,82 @@ if ! oc auth can-i create clusterrolebindings >/dev/null 2>&1; then
 fi
 info "cluster-admin privileges confirmed"
 
-# --- Step 2: Agentic Operator CRDs --------------------------------------------
+# --- Step 2: Namespace --------------------------------------------------------
 
-step "2/7" "Installing Agentic Operator CRDs..."
+step "2/9" "Ensuring namespace ${NAMESPACE}..."
 
-# Prefer local CRD files when running from a checkout; fall back to GitHub.
-REPO_ROOT=""
-if [ -n "${BASH_SOURCE[0]:-}" ]; then
-  _candidate="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-  if [ -d "${_candidate}/config/crd/bases" ]; then
-    REPO_ROOT="${_candidate}"
+if oc create namespace "${NAMESPACE}" 2>/dev/null; then
+  info "Namespace created"
+elif oc get namespace "${NAMESPACE}" >/dev/null 2>&1; then
+  info "Namespace already exists"
+else
+  fail "Failed to create namespace ${NAMESPACE}"
+fi
+
+# --- Step 3: Lightspeed Operator ----------------------------------------------
+
+step "3/9" "Lightspeed Operator..."
+
+CONFIGURE_OLSCONFIG=0
+
+if [ -n "${OLS_BUNDLE_IMAGE}" ]; then
+  # User supplied an image — always install or update; they know what they are doing.
+  info "OLS bundle source: user-provided (--ols-bundle-image / OLS_BUNDLE_IMAGE)"
+  if ols_crd_installed; then
+    info "OLSConfig CRD present — updating Lightspeed Operator"
+    install_or_update_ols update "${OLS_BUNDLE_IMAGE}"
+  else
+    info "OLSConfig CRD not found — installing Lightspeed Operator"
+    install_or_update_ols install "${OLS_BUNDLE_IMAGE}"
+  fi
+  CONFIGURE_OLSCONFIG=1
+else
+  # related_images.json path — resolve concrete image before any install/update decision.
+  fetch_related_images_bundle
+
+  if ols_crd_installed; then
+    info "OLSConfig CRD present"
+    case "$(prompt_ols_already_installed "${OLS_RELATED_BUNDLE_IMAGE}")" in
+      leave)
+        warn "Leaving current Lightspeed Operator as-is"
+        OLS_ACTION="left-as-is"
+        ;;
+      update)
+        install_or_update_ols update "${OLS_RELATED_BUNDLE_IMAGE}"
+        CONFIGURE_OLSCONFIG=1
+        ;;
+      stop)
+        stop_for_custom_ols_bundle "${OLS_RELATED_BUNDLE_IMAGE}"
+        ;;
+    esac
+  else
+    info "OLSConfig CRD not found"
+    cat <<EOF
+
+  Lightspeed Operator is not installed.
+  Installing from related_images.json would use:
+    ${OLS_RELATED_BUNDLE_IMAGE}
+
+  Declining stops this script — re-run with --ols-bundle-image=<your-image>
+  if you want a different bundle.
+
+EOF
+    if prompt_yes_no "Install Lightspeed Operator using ${OLS_RELATED_BUNDLE_IMAGE}?"; then
+      install_or_update_ols install "${OLS_RELATED_BUNDLE_IMAGE}"
+      CONFIGURE_OLSCONFIG=1
+    else
+      stop_for_custom_ols_bundle "${OLS_RELATED_BUNDLE_IMAGE}"
+    fi
   fi
 fi
+
+if [ "${CONFIGURE_OLSCONFIG}" = "1" ]; then
+  configure_olsconfig_interactive
+fi
+
+# --- Step 4: Agentic Operator CRDs --------------------------------------------
+
+step "4/9" "Installing Agentic Operator CRDs..."
 
 for crd in "${CRD_FILES[@]}"; do
   if [ -n "${REPO_ROOT}" ]; then
@@ -85,17 +551,9 @@ else
   info "${#CRD_FILES[@]} CRDs applied (from GitHub)"
 fi
 
-# --- Step 3: Namespace + operator deployment ----------------------------------
+# --- Step 5: Agentic operator deployment --------------------------------------
 
-step "3/7" "Deploying operator to ${NAMESPACE} (sandbox-mode=${SANDBOX_MODE})..."
-
-if oc create namespace "${NAMESPACE}" 2>/dev/null; then
-  info "Namespace created"
-elif oc get namespace "${NAMESPACE}" >/dev/null 2>&1; then
-  info "Namespace already exists"
-else
-  fail "Failed to create namespace ${NAMESPACE}"
-fi
+step "5/9" "Deploying agentic operator to ${NAMESPACE} (sandbox-mode=${SANDBOX_MODE})..."
 
 oc apply -f - <<EOF
 apiVersion: v1
@@ -198,7 +656,7 @@ $([ -n "${IMAGE_PULL_POLICY}" ] && echo '        - "--image-pull-policy='"${IMAG
 EOF
 info "Operator deployment applied"
 
-# --- Step 3b: Agent read RBAC -------------------------------------------------
+# --- Step 5b: Agent read RBAC -------------------------------------------------
 
 info "Binding read permissions to lightspeed-agent SA..."
 
@@ -231,9 +689,9 @@ subjects:
 EOF
 info "Agent read RBAC applied (cluster-reader + cluster-monitoring-view)"
 
-# --- Step 4: ApprovalPolicy ---------------------------------------------------
+# --- Step 6: ApprovalPolicy ---------------------------------------------------
 
-step "4/7" "Creating ApprovalPolicy..."
+step "6/9" "Creating ApprovalPolicy..."
 
 oc apply -f - <<'EOF'
 apiVersion: agentic.openshift.io/v1alpha1
@@ -253,9 +711,9 @@ spec:
 EOF
 info "ApprovalPolicy created"
 
-# --- Step 5: Webhook Service --------------------------------------------------
+# --- Step 7: Webhook Service --------------------------------------------------
 
-step "5/7" "Creating webhook Service..."
+step "7/9" "Creating webhook Service..."
 
 oc apply -f - <<EOF
 apiVersion: v1
@@ -275,36 +733,26 @@ spec:
 EOF
 info "Webhook Service created"
 
-# Create telemetry ConfigMap (operator blocks at startup until this exists).
-# Empty data disables export (IsValid=false). In production, lightspeed-operator
-# populates collector-endpoint / admin-endpoint / ca.crt.
-oc apply -f - <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: lightspeed-otel-collector-client
-  namespace: ${NAMESPACE}
-data: {}
-EOF
-info "Telemetry ConfigMap created (standalone mode)"
+# --- Step 8: Wait for operator ------------------------------------------------
 
-# --- Step 6: Wait for operator ------------------------------------------------
+step "8/9" "Waiting for agentic operator to become ready..."
 
-step "6/7" "Waiting for operator to become ready..."
+# Agentic blocks at startup on lightspeed-otel-collector-client (up to ~5m).
+AGENTIC_ROLLOUT_TIMEOUT="${AGENTIC_ROLLOUT_TIMEOUT:-300s}"
+if ! oc rollout status deployment/lightspeed-agentic-operator \
+    -n "${NAMESPACE}" --timeout="${AGENTIC_ROLLOUT_TIMEOUT}" >/dev/null 2>&1; then
+  fail "Agentic operator did not become ready within ${AGENTIC_ROLLOUT_TIMEOUT}.
 
-if oc rollout status deployment/lightspeed-agentic-operator \
-    -n "${NAMESPACE}" --timeout=120s >/dev/null 2>&1; then
-  info "Operator is running"
-else
-  echo ""
-  echo "  ⚠ Operator did not become ready within 120s."
-  echo "    Check logs: oc logs deployment/lightspeed-agentic-operator -n ${NAMESPACE}"
-  echo ""
+  Check:
+    oc logs deployment/lightspeed-agentic-operator -n ${NAMESPACE}
+    oc get configmap lightspeed-otel-collector-client -n ${NAMESPACE}
+    oc get olsconfig cluster -o yaml"
 fi
+info "Agentic operator is running"
 
-# --- Step 7: Webhook Configuration (after operator is ready) ------------------
+# --- Step 9: Webhook Configuration (after operator is ready) ------------------
 
-step "7/7" "Registering fail-closed MutatingWebhookConfiguration..."
+step "9/9" "Registering fail-closed MutatingWebhookConfiguration..."
 
 oc apply -f - <<EOF
 apiVersion: admissionregistration.k8s.io/v1
@@ -359,6 +807,15 @@ else
   EXAMPLES_BASE="${GITHUB_RAW}/hack/quickstart/examples"
 fi
 
+if [ "${OLS_ACTION}" = "left-as-is" ]; then
+  OLS_SUMMARY_BUNDLE="(not changed)"
+  OLS_SUMMARY_SUGGESTED="
+  related_images suggested: ${OLS_RELATED_BUNDLE_IMAGE}"
+else
+  OLS_SUMMARY_BUNDLE="$(ols_bundle_source_desc)"
+  OLS_SUMMARY_SUGGESTED=""
+fi
+
 cat <<DONE
 
 ════════════════════════════════════════════════════════════════
@@ -369,11 +826,18 @@ cat <<DONE
   Operator image: ${OPERATOR_IMAGE}
   Sandbox image : ${SANDBOX_IMAGE}
   Console image : ${CONSOLE_IMAGE}
+  OLS bundle    : ${OLS_SUMMARY_BUNDLE}${OLS_SUMMARY_SUGGESTED}
+  OLS action    : ${OLS_ACTION}
+  OLSConfig file: ${OLS_CONFIG_FILE}
 
   > Console works only on OpenShift 4.22+
 ════════════════════════════════════════════════════════════════
 
-  NEXT: Configure your LLM provider. Pick one:
+  OLS status (if Lightspeed Operator was installed/updated):
+    oc get olsconfig cluster -o jsonpath='{.status.overallStatus}{"\\n"}'
+    oc get olsconfig cluster -o yaml
+
+  NEXT: Configure your agentic LLM provider. Pick one:
 
   ── Vertex AI / Claude ─────────────────────────────────────
   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service-account-key.json

--- a/hack/quickstart/uninstall.sh
+++ b/hack/quickstart/uninstall.sh
@@ -1,21 +1,109 @@
 #!/usr/bin/env bash
 #
 # Uninstall Agentic OLS quickstart deployment.
+# Optionally uninstalls Lightspeed Operator if it was installed via OLM
+# (operator-sdk run bundle), matching hack/quickstart/install.sh.
 #
-# Usage:
-#   bash <(curl -sL https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh)
+# Usage (download then run — required for interactive OLS prompts):
+#   curl -fsSL -o uninstall-agentic.sh \
+#     https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh
+#   bash uninstall-agentic.sh
+#
+# Do not use: curl … | bash  (stdin is the script; prompts cannot read y/n)
+#
+# Env:
+#   NAMESPACE       (default: openshift-lightspeed)
+#   QUICKSTART_FORCE=1  skip the top-level confirmation
+#   REMOVE_OLS=1|0      non-interactive OLS uninstall decision (skips the y/n prompt)
+#   OPERATOR_SDK_VERSION, CLEANUP_TIMEOUT
 
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
+OPERATOR_SDK_VERSION="${OPERATOR_SDK_VERSION:-1.36.1}"
+CLEANUP_TIMEOUT="${CLEANUP_TIMEOUT:-5m}"
+# OLM package name used by operator-sdk run bundle for Lightspeed Operator.
+OLS_PACKAGE_NAME="${OLS_PACKAGE_NAME:-lightspeed-operator}"
 
 info()  { echo "  ✓ $*"; }
+warn()  { echo "  ⚠ $*" >&2; }
 step()  { echo "[${1}] ${2}"; }
 fail()  { echo "  ✗ $*" >&2; exit 1; }
 
+require_tty_for_prompts() {
+  if [[ ! -t 0 ]]; then
+    fail "Interactive prompts require a terminal.
+
+  Do not pipe the script into bash (curl … | bash).
+  Download it, then run it:
+
+    curl -fsSL -o uninstall-agentic.sh \\
+      https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh
+    bash uninstall-agentic.sh
+
+  Or set REMOVE_OLS=0|1 for a non-interactive OLS decision."
+  fi
+}
+
+prompt_yes_no() {
+  # $1 = prompt text. Returns 0 for yes, 1 for no.
+  require_tty_for_prompts
+  local reply
+  while true; do
+    printf '%s [y/n]: ' "$1"
+    read -r reply
+    case "${reply}" in
+      [yY]|[yY][eE][sS]) return 0 ;;
+      [nN]|[nN][oO]) return 1 ;;
+      *) echo "  Please answer y or n." ;;
+    esac
+  done
+}
+
+ensure_operator_sdk() {
+  if command -v operator-sdk >/dev/null 2>&1; then
+    OPERATOR_SDK_BIN="$(command -v operator-sdk)"
+    return 0
+  fi
+  command -v curl >/dev/null 2>&1 || fail "curl is required to download operator-sdk"
+  local os arch dest url
+  case "$(uname -s)" in
+    Linux) os=linux ;;
+    Darwin) os=darwin ;;
+    *) fail "unsupported OS for operator-sdk download: $(uname -s)" ;;
+  esac
+  case "$(uname -m)" in
+    x86_64|amd64) arch=amd64 ;;
+    aarch64|arm64) arch=arm64 ;;
+    *) fail "unsupported arch for operator-sdk download: $(uname -m)" ;;
+  esac
+  dest="${TMPDIR:-/tmp}/operator-sdk-${OPERATOR_SDK_VERSION}"
+  url="https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_${os}_${arch}"
+  echo "  Downloading operator-sdk v${OPERATOR_SDK_VERSION}..."
+  curl -fsSL -o "${dest}" "${url}"
+  chmod +x "${dest}"
+  OPERATOR_SDK_BIN="${dest}"
+  info "operator-sdk ready (${OPERATOR_SDK_BIN})"
+}
+
+uninstall_ols() {
+  ensure_operator_sdk
+  echo "  Deleting OLSConfig (if present)..."
+  oc delete olsconfig cluster --ignore-not-found 2>/dev/null || true
+  echo "  Running: operator-sdk cleanup ${OLS_PACKAGE_NAME} -n ${NAMESPACE}..."
+  "${OPERATOR_SDK_BIN}" cleanup "${OLS_PACKAGE_NAME}" \
+    --namespace "${NAMESPACE}" \
+    --timeout="${CLEANUP_TIMEOUT}" \
+    || fail "operator-sdk cleanup failed for ${OLS_PACKAGE_NAME}.
+  Fix OLM leftovers manually, then re-run this script (or set REMOVE_OLS=0 to skip OLS)."
+  info "Lightspeed Operator uninstalled"
+}
+
 if [ "${QUICKSTART_FORCE:-}" != "1" ]; then
+  require_tty_for_prompts
   echo "This will delete ALL Agentic OLS resources in namespace ${NAMESPACE},"
-  echo "remove the console plugin, operator CRDs cluster-wide, and the namespace itself."
+  echo "remove the console plugin, and operator CRDs cluster-wide."
+  echo "You will be asked separately whether to also uninstall Lightspeed Operator."
   echo ""
   read -rp "Continue? [y/N] " confirm
   case "${confirm}" in
@@ -24,9 +112,42 @@ if [ "${QUICKSTART_FORCE:-}" != "1" ]; then
   esac
 fi
 
-# --- Step 1: Delete CRs ------------------------------------------------------
+REMOVE_OLS_OPERATOR=0
 
-step "1/7" "Deleting custom resources..."
+# Ask the user (unless REMOVE_OLS is set for non-interactive runs).
+# No cluster probes — the answer alone decides whether OLS is cleaned up.
+case "${REMOVE_OLS:-}" in
+  1|true|yes|YES)
+    REMOVE_OLS_OPERATOR=1
+    ;;
+  0|false|no|NO)
+    REMOVE_OLS_OPERATOR=0
+    ;;
+  "")
+    cat <<EOF
+
+  Quickstart may also have installed Lightspeed Operator (OLS) via OLM.
+  Answer n to leave OLS installed (namespace ${NAMESPACE} will be kept).
+
+EOF
+    if prompt_yes_no "Uninstall Lightspeed Operator as well?"; then
+      REMOVE_OLS_OPERATOR=1
+    else
+      REMOVE_OLS_OPERATOR=0
+    fi
+    ;;
+  *)
+    fail "REMOVE_OLS must be 0 or 1 (got: ${REMOVE_OLS})"
+    ;;
+esac
+
+if [ "${REMOVE_OLS_OPERATOR}" = "0" ]; then
+  warn "Lightspeed Operator will be left installed; namespace ${NAMESPACE} will be kept"
+fi
+
+# --- Step 1: Delete Agentic CRs ----------------------------------------------
+
+step "1/8" "Deleting Agentic custom resources..."
 
 for kind in agenticruns agenticrunapprovals analysisresults executionresults verificationresults escalationresults; do
   oc delete "${kind}" --all -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
@@ -39,18 +160,28 @@ oc delete approvalpolicy cluster --ignore-not-found 2>/dev/null || true
 oc delete agenticolsconfig cluster --ignore-not-found 2>/dev/null || true
 info "Agents, LLMProviders, ApprovalPolicy, AgenticOLSConfig deleted"
 
-# --- Step 2: Delete secrets ---------------------------------------------------
+# --- Step 2: Optional Lightspeed Operator ------------------------------------
 
-step "2/7" "Deleting credential secrets..."
+step "2/8" "Optional Lightspeed Operator uninstall..."
+
+if [ "${REMOVE_OLS_OPERATOR}" = "1" ]; then
+  uninstall_ols
+else
+  info "Skipped Lightspeed Operator uninstall"
+fi
+
+# --- Step 3: Delete secrets ---------------------------------------------------
+
+step "3/8" "Deleting credential secrets..."
 
 for secret in llm-creds-vertex llm-creds-openai llm-creds-azure llm-creds-bedrock llm-creds-anthropic; do
   oc delete secret "${secret}" -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
 done
 info "Credential secrets deleted"
 
-# --- Step 3: Remove console plugin --------------------------------------------
+# --- Step 4: Remove console plugin --------------------------------------------
 
-step "3/7" "Removing console plugin..."
+step "4/8" "Removing console plugin..."
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ -f "${SCRIPT_DIR}/undeploy-console.sh" ]; then
@@ -59,30 +190,30 @@ else
   info "undeploy-console.sh not found — skipping console cleanup"
 fi
 
-# --- Step 4: Delete webhook resources -----------------------------------------
+# --- Step 5: Delete webhook resources -----------------------------------------
 # Delete the MutatingWebhookConfiguration BEFORE the operator so the fail-closed
 # webhook doesn't block API calls while its backend is gone.
 
-step "4/7" "Deleting webhook resources..."
+step "5/8" "Deleting webhook resources..."
 oc delete mutatingwebhookconfiguration agentic-operator-mutating-webhook --ignore-not-found 2>/dev/null || true
 oc delete service agentic-operator-webhook-service -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
 oc delete secret agentic-operator-webhook-certs -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
 info "Webhook resources deleted"
 
-# --- Step 5: Delete operator --------------------------------------------------
+# --- Step 6: Delete operator --------------------------------------------------
 
-step "5/7" "Deleting operator deployment..."
+step "6/8" "Deleting agentic operator deployment..."
 
 oc delete deployment lightspeed-agentic-operator -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
 oc delete sa lightspeed-agentic-operator -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
 oc delete clusterrolebinding lightspeed-agentic-operator --ignore-not-found 2>/dev/null || true
 oc delete clusterrolebinding lightspeed-agent-cluster-reader --ignore-not-found 2>/dev/null || true
 oc delete clusterrolebinding lightspeed-agent-monitoring-view --ignore-not-found 2>/dev/null || true
-info "Operator removed"
+info "Agentic operator removed"
 
-# --- Step 6: Delete CRDs -----------------------------------------------------
+# --- Step 7: Delete CRDs -----------------------------------------------------
 
-step "6/7" "Deleting Agentic Operator CRDs..."
+step "7/8" "Deleting Agentic Operator CRDs..."
 
 for crd in \
   agenticolsconfigs.agentic.openshift.io \
@@ -97,17 +228,27 @@ for crd in \
   verificationresults.agentic.openshift.io; do
   oc delete crd "${crd}" --ignore-not-found --timeout=30s 2>/dev/null || true
 done
-info "CRDs deleted"
+info "Agentic CRDs deleted"
 
-# --- Step 7: Delete namespace -------------------------------------------------
+# --- Step 8: Delete namespace -------------------------------------------------
 
-step "7/7" "Deleting namespace ${NAMESPACE}..."
+step "8/8" "Namespace ${NAMESPACE}..."
 
-oc delete namespace "${NAMESPACE}" --ignore-not-found --timeout=60s 2>/dev/null || true
-info "Namespace deleted"
+if [ "${REMOVE_OLS_OPERATOR}" = "0" ]; then
+  warn "Keeping namespace ${NAMESPACE} (Lightspeed Operator left installed)"
+else
+  oc delete namespace "${NAMESPACE}" --ignore-not-found --timeout=60s 2>/dev/null || true
+  info "Namespace deleted"
+fi
 
 cat <<DONE
 
   Agentic OLS has been uninstalled.
-
 DONE
+
+if [ "${REMOVE_OLS_OPERATOR}" = "1" ]; then
+  echo "  Lightspeed Operator was also uninstalled."
+else
+  echo "  Lightspeed Operator was left installed in ${NAMESPACE}."
+fi
+echo ""


### PR DESCRIPTION
**Summary**
- Quickstart optionally detects Lightspeed Operator (`OLSConfig` CRD) and prompts to install or update it from `openshift/lightspeed-operator` `related_images.json` via `operator-sdk run bundle` / `bundle-upgrade`.
- After install/update, guides OLSConfig edit/apply until `status.overallStatus=Ready`, then deploys the agentic operator.
- Download-then-run only (no `curl | bash`) so interactive prompts work; declining a fresh OLS install creates an empty `lightspeed-otel-collector-client` ConfigMap.

**Important**
Use the **latest Lightspeed Operator bundle that includes the OTEL collector** (and creates `lightspeed-otel-collector-client`). Older `related_images.json` bundles without OTEL leave the agentic operator stuck waiting for that ConfigMap.
Current operator main needs to be updated
