### PR TITLE
OLS-0000: Add .ai/spec/decisions/ directory

### DIFF
--- a/.ai/spec/decisions/README.md
+++ b/.ai/spec/decisions/README.md
@@ -1,0 +1,5 @@
+# Architectural Decision Records
+
+This directory holds lightweight decision records for lightspeed-agentic-operator.
+
+Each file follows the naming convention `NNNN-slug.md` (e.g., `0001-mcp-transport-choice.md`).


### PR DESCRIPTION
## Summary
- Adds `.ai/spec/decisions/` directory with a README explaining the naming convention
- Scaffolds the location for architectural decision records (ADRs)

## Test plan
- [ ] Verify `.ai/spec/decisions/README.md` exists and has content