### PR TITLE
OLS-3719, OTA-2090: Check needsRevision() in terminal phases before early return

### DIFF
--- a/controller/agenticrun/handlers_test.go
+++ b/controller/agenticrun/handlers_test.go
@@ -682,6 +682,60 @@ func TestReconcile_RevisionWithFeedback(t *testing.T) {
 	}
 }
 
+func TestReconcile_RevisionFromCompleted(t *testing.T) {
+	scheme := testScheme()
+	// Advisory-only run (no Execution/Verification) reaches Completed in one reconcile
+	run := &agenticv1alpha1.AgenticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "fix-crash", Namespace: "default"},
+		Spec: agenticv1alpha1.AgenticRunSpec{
+			Request:          "Investigate issue",
+			Tools:            testTools(),
+			TargetNamespaces: []string{"production"},
+			Analysis:         agenticv1alpha1.AgenticRunStep{Agent: "default"},
+		},
+	}
+
+	objs := append([]client.Object{run}, defaultObjects()...)
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
+		WithStatusSubresource(run, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
+
+	r := &AgenticRunReconciler{Client: fc, Agent: newTestAgentCaller(), Namespace: "default"}
+
+	// Reconcile 1: Pending → Proposed (analysis complete)
+	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	p, _ := getAgenticRun(r, "fix-crash")
+	if agenticv1alpha1.DerivePhase(p.Status.Conditions) != agenticv1alpha1.AgenticRunPhaseProposed {
+		t.Fatalf("expected Proposed, got %s", agenticv1alpha1.DerivePhase(p.Status.Conditions))
+	}
+
+	// Approve and reconcile 2: Proposed → Completed (advisory-only, no execution)
+	approveAgenticRun(t, fc, "fix-crash")
+	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	p, _ = getAgenticRun(r, "fix-crash")
+	if agenticv1alpha1.DerivePhase(p.Status.Conditions) != agenticv1alpha1.AgenticRunPhaseCompleted {
+		t.Fatalf("expected Completed, got %s", agenticv1alpha1.DerivePhase(p.Status.Conditions))
+	}
+
+	// Submit revision on the completed run
+	reviseAgenticRun(t, fc, "fix-crash", "re-analyse with different focus")
+
+	// Reconcile 2: Completed → revision → Proposed
+	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
+		t.Fatalf("reconcile 2 (revision from Completed): %v", err)
+	}
+	p, _ = getAgenticRun(r, "fix-crash")
+	if agenticv1alpha1.DerivePhase(p.Status.Conditions) != agenticv1alpha1.AgenticRunPhaseProposed {
+		t.Fatalf("expected Proposed after revision from Completed, got %s", agenticv1alpha1.DerivePhase(p.Status.Conditions))
+	}
+	if analyzed := meta.FindStatusCondition(p.Status.Conditions, agenticv1alpha1.AgenticRunConditionAnalyzed); analyzed == nil || analyzed.ObservedGeneration == 0 {
+		t.Fatal("observedGeneration not set after revision from Completed")
+	}
+}
+
 func TestReconcile_ExecutionRBACCreatedOnApproval(t *testing.T) {
 	agent := newTestAgentCaller()
 	agent.analyzeResult = &AnalysisOutput{

--- a/controller/agenticrun/handlers_test.go
+++ b/controller/agenticrun/handlers_test.go
@@ -723,16 +723,16 @@ func TestReconcile_RevisionFromCompleted(t *testing.T) {
 	// Submit revision on the completed run
 	reviseAgenticRun(t, fc, "fix-crash", "re-analyse with different focus")
 
-	// Reconcile 2: Completed → revision → Proposed
+	// Reconcile 3: Completed → revision → Proposed
 	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
-		t.Fatalf("reconcile 2 (revision from Completed): %v", err)
+		t.Fatalf("reconcile 3 (revision from Completed): %v", err)
 	}
 	p, _ = getAgenticRun(r, "fix-crash")
 	if agenticv1alpha1.DerivePhase(p.Status.Conditions) != agenticv1alpha1.AgenticRunPhaseProposed {
 		t.Fatalf("expected Proposed after revision from Completed, got %s", agenticv1alpha1.DerivePhase(p.Status.Conditions))
 	}
-	if analyzed := meta.FindStatusCondition(p.Status.Conditions, agenticv1alpha1.AgenticRunConditionAnalyzed); analyzed == nil || analyzed.ObservedGeneration == 0 {
-		t.Fatal("observedGeneration not set after revision from Completed")
+	if analyzed := meta.FindStatusCondition(p.Status.Conditions, agenticv1alpha1.AgenticRunConditionAnalyzed); analyzed == nil || analyzed.ObservedGeneration != p.Generation {
+		t.Fatalf("expected observedGeneration to equal current generation %d after revision from Completed", p.Generation)
 	}
 }
 

--- a/controller/agenticrun/handlers_test.go
+++ b/controller/agenticrun/handlers_test.go
@@ -736,6 +736,56 @@ func TestReconcile_RevisionFromCompleted(t *testing.T) {
 	}
 }
 
+func TestReconcile_RevisionFromFailed(t *testing.T) {
+	agent := newTestAgentCaller()
+	scheme := testScheme()
+
+	// Advisory-only run
+	run := &agenticv1alpha1.AgenticRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "fix-crash", Namespace: "default"},
+		Spec: agenticv1alpha1.AgenticRunSpec{
+			Request:          "Investigate issue",
+			Tools:            testTools(),
+			TargetNamespaces: []string{"production"},
+			Analysis:         agenticv1alpha1.AgenticRunStep{Agent: "default"},
+		},
+	}
+
+	objs := append([]client.Object{run}, defaultObjects()...)
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
+		WithStatusSubresource(run, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
+
+	r := &AgenticRunReconciler{Client: fc, Agent: agent, Namespace: "default"}
+
+	// Make analysis fail
+	agent.analyzeErr = fmt.Errorf("LLM timeout")
+
+	// Reconcile 1: Pending → Failed
+	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	p, _ := getAgenticRun(r, "fix-crash")
+	if agenticv1alpha1.DerivePhase(p.Status.Conditions) != agenticv1alpha1.AgenticRunPhaseFailed {
+		t.Fatalf("expected Failed, got %s", agenticv1alpha1.DerivePhase(p.Status.Conditions))
+	}
+
+	// Fix the agent and submit revision
+	agent.analyzeErr = nil
+	reviseAgenticRun(t, fc, "fix-crash", "retry after timeout")
+
+	// Reconcile 2: Failed → revision → Proposed
+	if _, err := reconcileOnce(r, "fix-crash"); err != nil {
+		t.Fatalf("reconcile 2 (revision from Failed): %v", err)
+	}
+	p, _ = getAgenticRun(r, "fix-crash")
+	if agenticv1alpha1.DerivePhase(p.Status.Conditions) != agenticv1alpha1.AgenticRunPhaseProposed {
+		t.Fatalf("expected Proposed after revision from Failed, got %s", agenticv1alpha1.DerivePhase(p.Status.Conditions))
+	}
+	if analyzed := meta.FindStatusCondition(p.Status.Conditions, agenticv1alpha1.AgenticRunConditionAnalyzed); analyzed == nil || analyzed.ObservedGeneration != p.Generation {
+		t.Fatalf("expected observedGeneration to equal current generation %d after revision from Failed", p.Generation)
+	}
+}
+
 func TestReconcile_ExecutionRBACCreatedOnApproval(t *testing.T) {
 	agent := newTestAgentCaller()
 	agent.analyzeResult = &AnalysisOutput{

--- a/controller/agenticrun/reconciler.go
+++ b/controller/agenticrun/reconciler.go
@@ -126,11 +126,8 @@ func (r *AgenticRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 
-	case agenticv1alpha1.AgenticRunPhaseCompleted,
-		agenticv1alpha1.AgenticRunPhaseDenied,
-		agenticv1alpha1.AgenticRunPhaseEscalated,
-		agenticv1alpha1.AgenticRunPhaseEmergencyStopped:
-		if !needsRevision(&run) {
+	case agenticv1alpha1.AgenticRunPhaseCompleted:
+		if !(run.Spec.Execution.IsZero() && needsRevision(&run)) {
 			if hasSandboxClaims(&run) {
 				if err := r.Agent.ReleaseSandboxes(ctx, &run); err != nil {
 					log.Error(err, "sandbox cleanup failed at terminal phase")
@@ -143,11 +140,25 @@ func (r *AgenticRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 
+	case agenticv1alpha1.AgenticRunPhaseDenied,
+		agenticv1alpha1.AgenticRunPhaseEscalated,
+		agenticv1alpha1.AgenticRunPhaseEmergencyStopped:
+		if hasSandboxClaims(&run) {
+			if err := r.Agent.ReleaseSandboxes(ctx, &run); err != nil {
+				log.Error(err, "sandbox cleanup failed at terminal phase")
+			}
+		}
+		if r.Audit != nil {
+			r.Audit.EmitTerminalSpan(ctx, &run, string(phase), terminalReason(&run))
+			r.Audit.Cleanup(&run)
+		}
+		return ctrl.Result{}, nil
+
 	case agenticv1alpha1.AgenticRunPhaseFailed:
 		return r.handleFailed(ctx, &run)
 	}
 
-	// --- Suspension guard (only non-terminal runs reach here) ---
+	// --- Suspension guard (non-terminal runs and advisory-only Completed runs needing revision reach here) ---
 	suspended, err := isSuspended(ctx, r.Client)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -211,12 +222,14 @@ func (r *AgenticRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		return r.handleEscalation(ctx, &run, resolved, approval, policy)
 
-	case agenticv1alpha1.AgenticRunPhaseNoActionRequired,
-		agenticv1alpha1.AgenticRunPhaseCompleted,
-		agenticv1alpha1.AgenticRunPhaseDenied,
-		agenticv1alpha1.AgenticRunPhaseEscalated,
-		agenticv1alpha1.AgenticRunPhaseEmergencyStopped:
+	case agenticv1alpha1.AgenticRunPhaseNoActionRequired:
 		if needsRevision(&run) {
+			return r.handleRevision(ctx, &run, resolved)
+		}
+		return ctrl.Result{}, nil
+
+	case agenticv1alpha1.AgenticRunPhaseCompleted:
+		if run.Spec.Execution.IsZero() && needsRevision(&run) {
 			return r.handleRevision(ctx, &run, resolved)
 		}
 		return ctrl.Result{}, nil

--- a/controller/agenticrun/reconciler.go
+++ b/controller/agenticrun/reconciler.go
@@ -155,7 +155,9 @@ func (r *AgenticRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 
 	case agenticv1alpha1.AgenticRunPhaseFailed:
-		return r.handleFailed(ctx, &run)
+		if !(run.Spec.Execution.IsZero() && needsRevision(&run)) {
+			return r.handleFailed(ctx, &run)
+		}
 	}
 
 	// --- Suspension guard (non-terminal runs and advisory-only Completed runs needing revision reach here) ---
@@ -228,7 +230,8 @@ func (r *AgenticRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		return ctrl.Result{}, nil
 
-	case agenticv1alpha1.AgenticRunPhaseCompleted:
+	case agenticv1alpha1.AgenticRunPhaseCompleted,
+		agenticv1alpha1.AgenticRunPhaseFailed:
 		if run.Spec.Execution.IsZero() && needsRevision(&run) {
 			return r.handleRevision(ctx, &run, resolved)
 		}

--- a/controller/agenticrun/reconciler.go
+++ b/controller/agenticrun/reconciler.go
@@ -130,16 +130,18 @@ func (r *AgenticRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		agenticv1alpha1.AgenticRunPhaseDenied,
 		agenticv1alpha1.AgenticRunPhaseEscalated,
 		agenticv1alpha1.AgenticRunPhaseEmergencyStopped:
-		if hasSandboxClaims(&run) {
-			if err := r.Agent.ReleaseSandboxes(ctx, &run); err != nil {
-				log.Error(err, "sandbox cleanup failed at terminal phase")
+		if !needsRevision(&run) {
+			if hasSandboxClaims(&run) {
+				if err := r.Agent.ReleaseSandboxes(ctx, &run); err != nil {
+					log.Error(err, "sandbox cleanup failed at terminal phase")
+				}
 			}
+			if r.Audit != nil {
+				r.Audit.EmitTerminalSpan(ctx, &run, string(phase), terminalReason(&run))
+				r.Audit.Cleanup(&run)
+			}
+			return ctrl.Result{}, nil
 		}
-		if r.Audit != nil {
-			r.Audit.EmitTerminalSpan(ctx, &run, string(phase), terminalReason(&run))
-			r.Audit.Cleanup(&run)
-		}
-		return ctrl.Result{}, nil
 
 	case agenticv1alpha1.AgenticRunPhaseFailed:
 		return r.handleFailed(ctx, &run)
@@ -209,7 +211,11 @@ func (r *AgenticRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		return r.handleEscalation(ctx, &run, resolved, approval, policy)
 
-	case agenticv1alpha1.AgenticRunPhaseNoActionRequired:
+	case agenticv1alpha1.AgenticRunPhaseNoActionRequired,
+		agenticv1alpha1.AgenticRunPhaseCompleted,
+		agenticv1alpha1.AgenticRunPhaseDenied,
+		agenticv1alpha1.AgenticRunPhaseEscalated,
+		agenticv1alpha1.AgenticRunPhaseEmergencyStopped:
 		if needsRevision(&run) {
 			return r.handleRevision(ctx, &run, resolved)
 		}


### PR DESCRIPTION
## Summary

Fixes a bug where patching `spec.revisionFeedback` on a completed AgenticRun has no effect. The "Re-analyse" button in the cluster-update-console-plugin triggers this patch, but the operator never re-enters the analysis loop.

Jira: https://redhat.atlassian.net/browse/OTA-2090

## Root cause

The reconciler's first switch block handles terminal phases before the suspension guard. The `NoActionRequired` phase correctly guards its early return with `!needsRevision(&run)`, falling through to the phase routing switch when a revision is needed. However, the `Completed`, `Denied`, `Escalated`, and `EmergencyStopped` phases return unconditionally without checking `needsRevision()`:

```go
// Before (lines 129-142):
case AgenticRunPhaseCompleted, AgenticRunPhaseDenied, ...:
    if hasSandboxClaims(&run) { ... }
    if r.Audit != nil { ... }
    return ctrl.Result{}, nil  // ← always returns, never checks revision
```

## Fix

Two changes in `controller/agenticrun/reconciler.go`:

1. **First switch** (terminal phases): wrap the early return in `if !needsRevision(&run)`, mirroring the existing `NoActionRequired` pattern. When revision is needed, execution falls through to the phase routing switch.

2. **Second switch** (phase routing): add `Completed`/`Denied`/`Escalated`/`EmergencyStopped` to the `NoActionRequired` case, which already calls `handleRevision()` when `needsRevision()` returns true.

## How to reproduce

1. Wait for an AgenticRun to complete via advisory-only path
2. Patch `spec.revisionFeedback`:
   ```
   oc patch agenticrun <name> -n openshift-lightspeed \
     --type=json -p '[{"op":"replace","path":"/spec/revisionFeedback","value":"re-analyse"}]'
   ```
3. Observe `metadata.generation` increments but `Analyzed.observedGeneration` stays stale
4. Operator logs show no reconciliation after the patch

## Evidence

```
$ oc get agenticrun ota-5-0-0-ec-4-to-5-0-8 -o jsonpath='{.metadata.generation}'
2

$ oc get agenticrun ota-5-0-0-ec-4-to-5-0-8 \
    -o jsonpath='{.status.conditions[?(@.type=="Analyzed")].observedGeneration}'
1

# needsRevision() would return true (2 > 1), but reconciler never evaluates it
```