### PR TITLE
OLS-3733 fix: add restricted security context to operator-sdk run bundle

### DIFF
--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -290,7 +290,7 @@ install_or_update_ols() {
 
   if [ "${mode}" = "update" ]; then
     echo "  Updating Lightspeed Operator via operator-sdk run bundle-upgrade..."
-    if ! "${OPERATOR_SDK_BIN}" run bundle-upgrade --timeout="${BUNDLE_TIMEOUT}" --namespace "${NAMESPACE}" "${bundle_image}"; then
+    if ! "${OPERATOR_SDK_BIN}" run bundle-upgrade --security-context-config=restricted --timeout="${BUNDLE_TIMEOUT}" --namespace "${NAMESPACE}" "${bundle_image}"; then
       fail "Lightspeed Operator bundle-upgrade failed.
 
   Refusing to fall back to a fresh 'run bundle' (that can leave a conflicting OLM install).
@@ -304,7 +304,7 @@ install_or_update_ols() {
   fi
 
   echo "  Installing Lightspeed Operator via operator-sdk run bundle..."
-  "${OPERATOR_SDK_BIN}" run bundle --timeout="${BUNDLE_TIMEOUT}" --namespace "${NAMESPACE}" "${bundle_image}" \
+  "${OPERATOR_SDK_BIN}" run bundle --security-context-config=restricted --timeout="${BUNDLE_TIMEOUT}" --namespace "${NAMESPACE}" "${bundle_image}" \
     || fail "Lightspeed Operator bundle install failed"
   info "Lightspeed Operator installed"
   OLS_ACTION="install"


### PR DESCRIPTION
## Summary

Adds `--security-context-config=restricted` to both `operator-sdk run bundle` and `run bundle-upgrade` invocations in the quickstart install script. Without this flag, operator-sdk defaults to `legacy` Pod Security context for the OLM catalog pod, which can fail on clusters enforcing the restricted Pod Security Standard.

The flag is an operator-sdk CLI option (available since v1.22, 2022) and is not OCP-version-dependent. It works safely on 4.21, 4.22, and 5.x.