### PR TITLE
OLS-3735 increase VerifyCheck.Source maxLength from 256 to 4096

### DIFF
--- a/api/v1alpha1/agenticrun_status_types.go
+++ b/api/v1alpha1/agenticrun_status_types.go
@@ -119,11 +119,12 @@ type VerifyCheck struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name,omitempty"`
-	// source is what performed the check (e.g., "oc", "promql", "curl").
-	// Maximum 256 characters.
+	// source is the command or query that was run for this check
+	// (e.g., "oc get pod -n production -o jsonpath='{.status.phase}'").
+	// Maximum 4096 characters.
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=256
+	// +kubebuilder:validation:MaxLength=4096
 	Source string `json:"source,omitempty"`
 	// value is the actual observed value (e.g., "Running", "3 replicas").
 	// Maximum 4096 characters.

--- a/config/crd/bases/agentic.openshift.io_verificationresults.yaml
+++ b/config/crd/bases/agentic.openshift.io_verificationresults.yaml
@@ -104,9 +104,10 @@ spec:
                       type: string
                     source:
                       description: |-
-                        source is what performed the check (e.g., "oc", "promql", "curl").
-                        Maximum 256 characters.
-                      maxLength: 256
+                        source is the command or query that was run for this check
+                        (e.g., "oc get pod -n production -o jsonpath='{.status.phase}'").
+                        Maximum 4096 characters.
+                      maxLength: 4096
                       minLength: 1
                       type: string
                     value:

--- a/controller/agenticrun/handlers_test.go
+++ b/controller/agenticrun/handlers_test.go
@@ -205,6 +205,56 @@ func TestReconcile_HappyPath_FullLifecycle(t *testing.T) {
 	assertResultConditions(t, verifyResult.Status.Conditions, "Succeeded")
 }
 
+func TestReconcile_VerificationWithLongSource_Succeeds(t *testing.T) {
+	agent := newTestAgentCaller()
+	// Source longer than the old 256-byte limit (OLS-3735).
+	longSource := "oc get pod -n payments-processing-system-production-us-east-1 -l app.kubernetes.io/name=payment-gateway-service,app.kubernetes.io/component=transaction-processor -o jsonpath='{.items[?(@.status.containerStatuses[0].state.waiting.reason==\"CrashLoopBackOff\")].metadata.name}'"
+	if len(longSource) <= 256 {
+		t.Fatalf("test source must exceed 256 bytes, got %d", len(longSource))
+	}
+	agent.verifyResult = &VerificationOutput{
+		Success: true,
+		Checks: []agenticv1alpha1.VerifyCheck{{
+			Name:   "pod-running",
+			Source: longSource,
+			Value:  "Running",
+			Result: agenticv1alpha1.CheckResultPassed,
+		}},
+		Summary: "All checks passed",
+	}
+
+	scheme := testScheme()
+	run := testAgenticRun()
+	objs := append([]client.Object{run}, defaultObjects()...)
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
+		WithStatusSubresource(run, &agenticv1alpha1.AnalysisResult{}, &agenticv1alpha1.ExecutionResult{}, &agenticv1alpha1.VerificationResult{}, &agenticv1alpha1.EscalationResult{}).Build()
+
+	r := &AgenticRunReconciler{Client: fc, Agent: agent, Namespace: "default"}
+
+	// Analysis → approve → execution → verification
+	reconcileOnce(r, "fix-crash")
+	approveAgenticRun(t, fc, "fix-crash")
+	reconcileOnce(r, "fix-crash")
+
+	_, err := reconcileOnce(r, "fix-crash")
+	if err != nil {
+		t.Fatalf("verification reconcile: %v", err)
+	}
+
+	p, _ := getAgenticRun(r, "fix-crash")
+	if agenticv1alpha1.DerivePhase(p.Status.Conditions) != agenticv1alpha1.AgenticRunPhaseCompleted {
+		t.Fatalf("expected Completed, got %s", agenticv1alpha1.DerivePhase(p.Status.Conditions))
+	}
+
+	var verifyResult agenticv1alpha1.VerificationResult
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: p.Status.Steps.Verification.Results[0].Name, Namespace: "default"}, &verifyResult); err != nil {
+		t.Fatalf("get VerificationResult: %v", err)
+	}
+	if verifyResult.Status.Checks[0].Source != longSource {
+		t.Fatalf("source was truncated: got %d bytes, want %d", len(verifyResult.Status.Checks[0].Source), len(longSource))
+	}
+}
+
 func TestReconcile_AnalysisSystemFailure_Terminal(t *testing.T) {
 	agent := newTestAgentCaller()
 	agent.analyzeErr = fmt.Errorf("LLM timeout")

--- a/controller/agenticrun/schemas.go
+++ b/controller/agenticrun/schemas.go
@@ -222,9 +222,9 @@ var VerificationOutputSchema = json.RawMessage(`{
       "items": {
         "type": "object",
         "properties": {
-          "name": { "type": "string", "description": "Check identifier matching the analysis verification plan (e.g., 'pod-running')" },
-          "source": { "type": "string", "description": "The full command that was run (e.g., 'oc get pod -n production -o jsonpath={.status.phase}', 'promql: rate(container_cpu_usage_seconds_total[5m])')" },
-          "value": { "type": "string", "description": "Actual observed value (e.g., 'Running', '3 replicas')" },
+          "name": { "type": "string", "maxLength": 253, "description": "Check identifier matching the analysis verification plan (e.g., 'pod-running')" },
+          "source": { "type": "string", "maxLength": 4096, "description": "The command or query that was run (e.g., 'oc get pod -n production -o jsonpath={.status.phase}', 'promql: rate(container_cpu_usage_seconds_total[5m])')" },
+          "value": { "type": "string", "maxLength": 4096, "description": "Actual observed value (e.g., 'Running', '3 replicas')" },
           "result": { "type": "string", "enum": ["Passed", "Failed"], "description": "Whether the observed value matches expectations" }
         },
         "required": ["name", "result", "source", "value"]


### PR DESCRIPTION
## Summary
- Bumps `VerifyCheck.Source` maxLength from 256 to 4096 to match `VerificationStep.Command` — same data, different lifecycle stage
- Adds `maxLength` constraints to the JSON schema sent to the LLM for `name`, `source`, and `value` fields
- Regenerates CRD via `make manifests`

## Test plan
- [x] `make test` — all unit tests pass
- [x] `make manifests` — CRD regenerated
- [x] `make api-lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)