### PR TITLE
OLS-3685 Rewrite quickstart: drop OLM bundle, deploy components directly

### DIFF
--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -1,128 +1,132 @@
 # Quickstart
 
-Deploy Agentic OLS onto an OpenShift cluster using pre-built Konflux images.
-Installs or updates Lightspeed Operator via OLM (`operator-sdk run bundle` /
-`bundle-upgrade`) when needed, then deploys the agentic operator. Pass
-`--ols-bundle-image` to choose the OLS bundle; otherwise the script resolves
-`lightspeed-operator-bundle` from git `related_images.json` and prompts
-(decline / option 3 stops). No building or cloning of this repo is required.
+Deploy Agentic OLS onto an OpenShift cluster. All components are deployed
+directly — no OLM bundle or `operator-sdk` required.
 
 ## Prerequisites
 
-- `oc` CLI on PATH
-- Logged into the target OpenShift cluster
+- A checkout of this repository (scripts reference each other via relative paths)
+- `oc` CLI on PATH, logged into an OpenShift 4.22+ cluster
 - cluster-admin privileges
-- `python3` on PATH only when `--ols-bundle-image` is omitted (related_images fallback)
+- `python3` and `curl` on PATH (for automatic image resolution from Quay)
+- `openssl` on PATH (for Postgres password generation, only with `--postgres`)
 
 ## Install
 
-Download the script, then run it (required for interactive Lightspeed Operator prompts):
+Run the all-in-one installer:
 
 ```bash
-curl -fsSL -o install-agentic.sh \
-  https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh
-bash install-agentic.sh
+bash hack/quickstart/install.sh
 ```
 
-Prefer an explicit OLS bundle (recommended when `related_images.json` may lag):
+Override any image:
 
 ```bash
-bash install-agentic.sh \
-  --ols-bundle-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-operator-bundle:main
+bash hack/quickstart/install.sh \
+  --operator-image=quay.io/.../lightspeed-agentic-operator:on-pr-<sha> \
+  --sandbox-image=quay.io/.../lightspeed-agentic-sandbox:main
 ```
 
-Do **not** use `curl … | bash` — stdin is the script, so `y`/`n` prompts cannot work.
+Deploy with Postgres backend for OTEL audit logs:
 
-The script:
+```bash
+bash hack/quickstart/install.sh --postgres
+```
 
-1. Detects whether Lightspeed Operator is installed (`OLSConfig` CRD).
-2. Installs or updates OLS via `operator-sdk run bundle` / `bundle-upgrade`:
-   - **`--ols-bundle-image` / `OLS_BUNDLE_IMAGE` set:** always install (if missing)
-     or update (if present) with that image — no confirmation.
-   - **No user image, OLS missing:** resolves
-     [`lightspeed-operator-bundle` from `related_images.json`](https://github.com/openshift/lightspeed-operator/blob/main/related_images.json)
-     (git ref `OLS_GIT_REF`, default `main`), shows the concrete image, and asks
-     to install it. Declining **stops** the script (re-run with
-     `--ols-bundle-image=…`).
-   - **No user image, OLS present:** three-way choice — (1) leave OLS as-is and
-     continue to agentic (still creates `OLSConfig` if the CR is missing),
-     (2) update to the related_images bundle, or (3) stop and re-run with
-     `--ols-bundle-image=…`.
-3. After a successful OLS install/update, or when leaving OLS as-is but
-   `OLSConfig` is missing: writes/exports an `OLSConfig` file
-   (`OLS_CONFIG_FILE`), lets you edit/apply in a loop, and waits until
-   `status.overallStatus=Ready` (dumps diagnostics on failure).
-4. Installs Agentic Operator CRDs, Deployment, ApprovalPolicy, and webhook.
+Or deploy components individually (run from the repo root — scripts
+call each other via `hack/quickstart/`):
 
-After completion it prints instructions for configuring an LLM provider and
-submitting a test run.
+```bash
+bash hack/quickstart/deploy-otel.sh
+bash hack/quickstart/deploy-alerts-adapter.sh
+bash hack/quickstart/deploy-configmap.sh
+bash hack/quickstart/deploy-operator.sh
+bash hack/quickstart/deploy-console.sh
+```
 
 ## Uninstall
 
-Download the script, then run it (required for interactive Lightspeed Operator prompts):
-
 ```bash
-curl -fsSL -o uninstall-agentic.sh \
-  https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh
-bash uninstall-agentic.sh
+bash hack/quickstart/uninstall.sh
 ```
 
-Do **not** use `curl … | bash` — stdin is the script, so `y`/`n` prompts cannot work.
+Skip the confirmation prompt:
 
-The script removes Agentic Operator resources and CRDs, and asks whether to also
-uninstall Lightspeed Operator via `operator-sdk cleanup`. Declining leaves OLS
-installed and keeps the namespace.
+```bash
+bash hack/quickstart/uninstall.sh --force
+```
 
-Skip the top-level confirmation with `QUICKSTART_FORCE=1`. For non-interactive
-OLS decisions, set `REMOVE_OLS=1` (uninstall OLS) or `REMOVE_OLS=0` (keep OLS).
+Or remove components individually (run from the repo root):
 
-## CLI options
+```bash
+bash hack/quickstart/undeploy-console.sh
+bash hack/quickstart/undeploy-operator.sh
+bash hack/quickstart/undeploy-configmap.sh
+bash hack/quickstart/undeploy-alerts-adapter.sh
+bash hack/quickstart/undeploy-otel.sh
+```
+
+## CLI flags
+
+### install.sh
 
 | Flag | Description |
-|---|---|
-| `--ols-bundle-image=IMAGE` | Lightspeed Operator OLM bundle for `operator-sdk run bundle` / `bundle-upgrade`. Required non-empty when set. If omitted, resolves `lightspeed-operator-bundle` from `related_images.json` and prompts (see Install flow above). |
-| `--sandbox-image=IMAGE` | Agentic sandbox container image (passed to the operator as `--agentic-sandbox-image`). Overrides `SANDBOX_IMAGE`. Defaults to the Konflux `:main` sandbox image. |
-| `-h`, `--help` | Show usage and exit |
+|------|-------------|
+| `--operator-image=IMAGE` | Agentic operator image (default: Konflux `:main`) |
+| `--sandbox-image=IMAGE` | Sandbox image for the ConfigMap PodSpec (default: Konflux `:main`) |
+| `--console-image=IMAGE` | Console plugin image (default: Konflux `:main`) |
+| `--alerts-adapter-image=IMAGE` | Alerts adapter image (default: resolved from Quay) |
+| `--otel-image=IMAGE` | OTEL collector image (default: resolved from Quay) |
+| `--postgres` | Deploy Postgres backend for OTEL audit logs |
 
-## Environment Variables
+### Individual scripts
 
-| Variable | Default | Description |
-|---|---|---|
-| `NAMESPACE` | `openshift-lightspeed` | Target namespace |
-| `OPERATOR_IMAGE` | Konflux `:main` | Agentic operator container image |
-| `SANDBOX_IMAGE` | Konflux `:main` | Agent sandbox container image; same as `--sandbox-image` (flag overrides) |
-| `SANDBOX_MODE` | `bare-pod` | Sandbox mode (`bare-pod` or `sandbox-claim`) |
-| `IMAGE_PULL_POLICY` | *(empty — Kubernetes default)* | Image pull policy for operator and sandbox pods (`Always`, `IfNotPresent`, `Never`) |
-| `OLS_BUNDLE_IMAGE` | *(empty)* | Same as `--ols-bundle-image`; the flag overrides this env var |
-| `OLS_GIT_REF` | `main` | Git ref for `openshift/lightspeed-operator` `related_images.json` (fallback only) |
-| `OLS_RELATED_IMAGES_URL` | raw GitHub URL for that ref | Override the related_images.json URL (fallback only) |
-| `BUNDLE_TIMEOUT` | `30m` | `operator-sdk run bundle` timeout |
-| `OLS_CONFIG_FILE` | `$TMPDIR/olsconfig-quickstart.yaml` | Path for the editable OLSConfig manifest |
-| `OLS_CONFIG_TIMEOUT_SEC` | `900` | Seconds to wait for `OLSConfig` `overallStatus=Ready` |
-| `AGENTIC_ROLLOUT_TIMEOUT` | `300s` | `oc rollout status` timeout for the agentic Deployment |
-| `REMOVE_OLS` | *(unset — prompt)* | Uninstall: `1` remove Lightspeed Operator, `0` keep it |
-| `CLEANUP_TIMEOUT` | `5m` | Uninstall: `operator-sdk cleanup` timeout |
+| Script | Flag | Default |
+|--------|------|---------|
+| `deploy-operator.sh` | `--image=IMAGE` | Konflux `:main` |
+| `deploy-console.sh` | `--image=IMAGE` | Konflux `:main` |
+| `deploy-alerts-adapter.sh` | `--image=IMAGE` | Resolved from Quay (newest git SHA tag) |
+| `deploy-otel.sh` | `--image=IMAGE` | Resolved from Quay (newest `on-pr-*` tag) |
+| `deploy-otel.sh` | `--postgres` | Deploy Postgres backend for audit logs |
+| `deploy-configmap.sh` | `--sandbox-image=IMAGE` | Konflux `:main` |
 
-Example with overrides:
+Images with a Konflux `:main` tag use it directly. Images without a `:main`
+tag (alerts adapter, OTEL collector) are resolved from Quay at runtime by
+finding the most recent build tag.
+
+## Image resolution
+
+The **operator**, **sandbox**, and **console** images are built by this repo's
+Konflux push pipeline and have a floating `:main` tag.
+
+The **alerts adapter** and **OTEL collector** are built by the same Konflux
+tenant (`crt-nshift-lightspeed-tenant`). They do not have `:main` tags, so the
+deploy scripts query the Quay API to find the latest build automatically.
+
+To use a specific PR build of the agentic operator:
 
 ```bash
-NAMESPACE=my-ns SANDBOX_MODE=sandbox-claim bash install-agentic.sh \
-  --ols-bundle-image=quay.io/example/lightspeed-operator-bundle:main \
-  --sandbox-image=quay.io/example/lightspeed-agentic-sandbox:main
+bash hack/quickstart/deploy-operator.sh \
+  --image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-operator:on-pr-<commit-sha>
 ```
 
-For dev environments with floating tags like `:main`, force fresh pulls:
+## Components
 
-```bash
-IMAGE_PULL_POLICY=Always bash install-agentic.sh
-```
+| Component | Script | What it deploys |
+|-----------|--------|-----------------|
+| OTEL collector | `deploy-otel.sh` | Collector accepting OTLP with TLS via service-ca; optionally `--postgres` for audit log storage |
+| Postgres | `deploy-postgres.sh` | Minimal Postgres instance (emptyDir), auto-deployed by `deploy-otel.sh --postgres` |
+| Alerts adapter | `deploy-alerts-adapter.sh` | Polls Alertmanager, creates AgenticRuns, RBAC for agenticruns + alertmanager |
+| Configuration | `deploy-configmap.sh` | `lightspeed-agentic-configuration` ConfigMap + OTEL CA secret |
+| Operator | `deploy-operator.sh` | CRDs, SA, cluster-admin, Deployment, agent RBAC, ApprovalPolicy, webhook |
+| Console | `deploy-console.sh` | Console plugin with nginx + TLS, registers with OpenShift Console |
 
 ## LLM Provider Examples
 
 The [`examples/`](examples/) directory contains LLMProvider + Agent templates:
 
 | File | Provider |
-|---|---|
+|------|----------|
 | [`openai.yaml`](examples/openai.yaml) | OpenAI (direct API) |
 | [`vertex-anthropic.yaml`](examples/vertex-anthropic.yaml) | Vertex AI with Claude |
 | [`vertex-google.yaml`](examples/vertex-google.yaml) | Vertex AI with Gemini |
@@ -132,40 +136,8 @@ The [`examples/`](examples/) directory contains LLMProvider + Agent templates:
 Install the `oc-agentic` CLI plugin to manage agenticruns from the command line
 ([install instructions](../../README.md#install)).
 
-Verify installation:
-
 ```bash
 oc agentic version
-```
-
-## Example AgenticRun
-
-[`deploy-test-workload.yaml`](examples/deploy-test-workload.yaml) submits a
-run that analyzes the target namespace and deploys a test workload
-(nginx Deployment + Service). Execution requires manual approval via
-`AgenticRunApproval`.
-
-### Using the CLI
-
-Instead of applying YAML, you can create and manage agenticruns with the CLI:
-
-```bash
-# Create a run
 oc agentic run create --request="Deploy a test nginx workload" --target-namespaces=default
-
-# Watch it progress
 oc agentic run list
-oc agentic run get <name>
-
-# Approve analysis, then execution
-oc agentic run approve <name> --stage=analysis
-oc agentic run approve <name> --stage=execution --option=0
-
-# Stream sandbox logs
-oc agentic run logs <name> -f
-
-# Check system status
-oc agentic status
 ```
-
-See the [CLI reference](../../README.md#cli-plugin-oc-agentic) for all commands and flags.

--- a/hack/quickstart/deploy-alerts-adapter.sh
+++ b/hack/quickstart/deploy-alerts-adapter.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# Deploy the agentic alerts adapter as a standalone workload.
+# Can be called from install.sh or run independently.
+#
+# The adapter polls Alertmanager for firing alerts and creates
+# AgenticRun CRs. It needs RBAC to create/list/get agenticruns
+# and read-only access to the Alertmanager API.
+#
+# Usage:
+#   bash hack/quickstart/deploy-alerts-adapter.sh
+#
+# Prerequisites:
+#   - oc CLI on PATH, logged into an OpenShift cluster
+#   - Namespace openshift-lightspeed exists
+#
+# Flags:
+#   --image=IMAGE   Alerts adapter image. If omitted, resolves the latest
+#                   build from Quay automatically.
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
+ALERTS_ADAPTER_IMAGE=""
+QUAY_REPO="redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --image=*) ALERTS_ADAPTER_IMAGE="${1#*=}"; shift ;;
+    --image)   [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; ALERTS_ADAPTER_IMAGE="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "${ALERTS_ADAPTER_IMAGE}" ]; then
+  echo "  Resolving latest alerts adapter image from Quay..."
+  TAG="$(curl -fsSL "https://quay.io/api/v1/repository/${QUAY_REPO}/tag/?limit=100&onlyActiveTags=true" \
+    | python3 -c "
+import json,sys,re
+tags = json.load(sys.stdin)['tags']
+pat = re.compile(r'^(on-pr-)?[0-9a-f]{40}$')
+tag = next((t['name'] for t in sorted(tags, key=lambda t: t['start_ts'], reverse=True) if pat.match(t['name'])), None)
+if not tag: sys.exit('No matching tag found in Quay repo')
+print(tag)
+")" || { echo "Failed to resolve image from Quay. Use --image=IMAGE." >&2; exit 1; }
+  ALERTS_ADAPTER_IMAGE="quay.io/${QUAY_REPO}:${TAG}"
+  echo "  Resolved: ${ALERTS_ADAPTER_IMAGE}"
+fi
+
+ADAPTER_NAME="lightspeed-agentic-alerts-adapter"
+ALERTMANAGER_URL="https://alertmanager-main.openshift-monitoring.svc:9094"
+
+info()  { echo "  ✓ $*"; }
+step()  { echo "[alerts-adapter] $*"; }
+
+step "Deploying alerts adapter to ${NAMESPACE}"
+step "Image: ${ALERTS_ADAPTER_IMAGE}"
+
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alerts-adapter-config
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${ADAPTER_NAME}
+    app.kubernetes.io/name: ${ADAPTER_NAME}
+    app.kubernetes.io/component: alerts-adapter
+data:
+  config.yaml: |
+    pollInterval: 30s
+    postRunDelay: 1h
+    filtering:
+      # Uncomment and configure at least one receiver to start automatic analysis.
+      # allowedReceivers:
+      #   - critical
+    deduplication:
+      ignoredLabels:
+        - pod
+        - instance
+        - endpoint
+        - uid
+    # agent:
+    #   default: "default"
+    tools:
+      skills:
+        - image: quay.io/openshiftanalytics/agentic-skills:latest
+          paths:
+            - /skills/cluster-troubleshoot/investigate-alert
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${ADAPTER_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${ADAPTER_NAME}
+    app.kubernetes.io/name: ${ADAPTER_NAME}
+    app.kubernetes.io/component: alerts-adapter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ${ADAPTER_NAME}-agenticruns
+  labels:
+    app: ${ADAPTER_NAME}
+    app.kubernetes.io/name: ${ADAPTER_NAME}
+    app.kubernetes.io/component: alerts-adapter
+rules:
+- apiGroups: ["agentic.openshift.io"]
+  resources: ["agenticruns"]
+  verbs: ["create", "list", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ${ADAPTER_NAME}-agenticruns
+  labels:
+    app: ${ADAPTER_NAME}
+    app.kubernetes.io/name: ${ADAPTER_NAME}
+    app.kubernetes.io/component: alerts-adapter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ${ADAPTER_NAME}-agenticruns
+subjects:
+- kind: ServiceAccount
+  name: ${ADAPTER_NAME}
+  namespace: ${NAMESPACE}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ${ADAPTER_NAME}-alertmanager
+  namespace: openshift-monitoring
+  labels:
+    app: ${ADAPTER_NAME}
+    app.kubernetes.io/name: ${ADAPTER_NAME}
+    app.kubernetes.io/component: alerts-adapter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: monitoring-alertmanager-view
+subjects:
+- kind: ServiceAccount
+  name: ${ADAPTER_NAME}
+  namespace: ${NAMESPACE}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${ADAPTER_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${ADAPTER_NAME}
+    app.kubernetes.io/name: ${ADAPTER_NAME}
+    app.kubernetes.io/component: alerts-adapter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${ADAPTER_NAME}
+  template:
+    metadata:
+      labels:
+        app: ${ADAPTER_NAME}
+        app.kubernetes.io/name: ${ADAPTER_NAME}
+        app.kubernetes.io/component: alerts-adapter
+    spec:
+      serviceAccountName: ${ADAPTER_NAME}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: adapter
+        image: ${ALERTS_ADAPTER_IMAGE}
+        imagePullPolicy: Always
+        env:
+        - name: ALERTMANAGER_URL
+          value: "${ALERTMANAGER_URL}"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        volumeMounts:
+        - name: config
+          mountPath: /etc/alerts-adapter
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: config
+        configMap:
+          name: alerts-adapter-config
+      - name: tmp
+        emptyDir: {}
+EOF
+
+info "Alerts adapter resources applied"
+
+step "Waiting for rollout..."
+oc rollout status deployment/${ADAPTER_NAME} -n "${NAMESPACE}" --timeout=120s
+
+info "Alerts adapter deployed successfully"

--- a/hack/quickstart/deploy-configmap.sh
+++ b/hack/quickstart/deploy-configmap.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Create the lightspeed-agentic-configuration ConfigMap.
+# Contains sandbox PodSpec and optionally OTEL collector settings.
+#
+# If the OTEL collector was deployed (deploy-otel.sh), the script
+# auto-detects its Service and wires otel-collector-endpoint,
+# otel-admin-endpoint, and otel-ca-secret into the ConfigMap.
+#
+# Usage:
+#   bash hack/quickstart/deploy-configmap.sh
+#   bash hack/quickstart/deploy-configmap.sh --sandbox-image=quay.io/my-org/my-sandbox:tag
+#
+# Prerequisites:
+#   - oc CLI on PATH, logged into an OpenShift cluster
+#   - Namespace openshift-lightspeed exists
+#
+# Flags:
+#   --sandbox-image=IMAGE   Sandbox image (default: Konflux :main)
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
+SANDBOX_IMAGE="quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-sandbox:main"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --sandbox-image=*) SANDBOX_IMAGE="${1#*=}"; shift ;;
+    --sandbox-image)   [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; SANDBOX_IMAGE="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+CONFIGMAP_NAME="lightspeed-agentic-configuration"
+COLLECTOR_NAME="lightspeed-otel-collector"
+COLLECTOR_CERT_SECRET="${COLLECTOR_NAME}-cert"
+
+info()  { echo "  ✓ $*"; }
+step()  { echo "[configmap] $*"; }
+fail()  { echo "  ✗ $*" >&2; exit 1; }
+
+step "Creating ${CONFIGMAP_NAME} in ${NAMESPACE}"
+step "Sandbox image: ${SANDBOX_IMAGE}"
+
+POD_SPEC="{\"containers\":[{\"name\":\"agent\",\"image\":\"${SANDBOX_IMAGE}\",\"resources\":{\"requests\":{\"cpu\":\"100m\",\"memory\":\"256Mi\"},\"limits\":{\"cpu\":\"1\",\"memory\":\"1Gi\"}}}]}"
+
+# Detect OTEL collector if deployed.
+OTEL_DATA=""
+OTEL_CA_SECRET_NAME="lightspeed-agentic-otel-ca"
+if oc get service "${COLLECTOR_NAME}" -n "${NAMESPACE}" >/dev/null 2>&1; then
+  OTEL_ENDPOINT="${COLLECTOR_NAME}.${NAMESPACE}.svc:4317"
+  OTEL_ADMIN="https://${COLLECTOR_NAME}.${NAMESPACE}.svc:8080"
+  step "OTEL collector detected: ${OTEL_ENDPOINT}"
+
+  # Create the CA secret from the service-ca bundle.
+  # The service-ca controller injects the CA into a well-known ConfigMap.
+  step "Creating OTEL CA secret from service-ca bundle..."
+  CA_BUNDLE="$(oc get configmap openshift-service-ca.crt -n "${NAMESPACE}" -o jsonpath='{.data.service-ca\.crt}' 2>/dev/null || true)"
+  if [ -n "${CA_BUNDLE}" ]; then
+    oc apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${OTEL_CA_SECRET_NAME}
+  namespace: ${NAMESPACE}
+type: Opaque
+stringData:
+  otel-ca.crt: |
+$(echo "${CA_BUNDLE}" | sed 's/^/    /')
+EOF
+    info "OTEL CA secret created"
+  else
+    fail "openshift-service-ca.crt ConfigMap not found in ${NAMESPACE}.
+  service-ca is required for OTEL TLS. Check that the service-ca operator is running."
+  fi
+
+  OTEL_DATA="  otel-collector-endpoint: \"${OTEL_ENDPOINT}\"
+  otel-ca-secret: \"${OTEL_CA_SECRET_NAME}\""
+
+  if oc get deployment lightspeed-postgres-server -n "${NAMESPACE}" >/dev/null 2>&1; then
+    OTEL_DATA="${OTEL_DATA}
+  otel-admin-endpoint: \"${OTEL_ADMIN}\""
+    info "Postgres detected — admin endpoint advertised"
+  fi
+else
+  step "No OTEL collector found — skipping OTEL config"
+fi
+
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${CONFIGMAP_NAME}
+  namespace: ${NAMESPACE}
+data:
+  sandbox-mode: "bare-pod"
+  sandbox-pod-spec: '${POD_SPEC}'
+${OTEL_DATA}
+EOF
+
+info "ConfigMap ${CONFIGMAP_NAME} created"

--- a/hack/quickstart/deploy-console.sh
+++ b/hack/quickstart/deploy-console.sh
@@ -5,19 +5,27 @@
 #
 # Usage:
 #   bash hack/quickstart/deploy-console.sh
+#   bash hack/quickstart/deploy-console.sh --image=quay.io/my-org/my-console:tag
 #
 # Prerequisites:
 #   - oc CLI on PATH, logged into an OpenShift 4.22+ cluster
-#   - Namespace exists (NAMESPACE env var, default: openshift-lightspeed)
+#   - Namespace openshift-lightspeed exists
 #
-# Environment variables:
-#   NAMESPACE      (default: openshift-lightspeed)
-#   CONSOLE_IMAGE  (default: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console:main)
+# Flags:
+#   --image=IMAGE   Console plugin image (default: Konflux :main)
 
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
-CONSOLE_IMAGE="${CONSOLE_IMAGE:-quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console:main}"
+CONSOLE_IMAGE="quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console:main"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --image=*) CONSOLE_IMAGE="${1#*=}"; shift ;;
+    --image)   [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; CONSOLE_IMAGE="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
 
 PLUGIN_NAME="lightspeed-agentic-console-plugin"
 PLUGIN_PORT=9443
@@ -28,11 +36,6 @@ step()  { echo "[console] $*"; }
 
 step "Deploying agentic console plugin to ${NAMESPACE}"
 step "Image: ${CONSOLE_IMAGE}"
-
-if [ -z "${CONSOLE_IMAGE}" ]; then
-  echo "  CONSOLE_IMAGE is empty — skipping console deployment"
-  exit 0
-fi
 
 oc apply -f - <<EOF
 apiVersion: v1
@@ -178,13 +181,11 @@ EOF
 
 info "Console plugin resources applied"
 
-# Activate the plugin on the OpenShift Console
 step "Activating console plugin"
 existing_plugins="$(oc get console.operator.openshift.io cluster -o jsonpath='{.spec.plugins[*]}' 2>/dev/null || echo "")"
 if echo " ${existing_plugins} " | grep -q " ${PLUGIN_NAME} "; then
   info "Plugin already registered — skipping"
 else
-  # Try appending to existing list; fall back to creating the list if spec.plugins is null
   if ! oc patch console.operator.openshift.io cluster --type=json \
     -p "[{\"op\": \"add\", \"path\": \"/spec/plugins/-\", \"value\": \"${PLUGIN_NAME}\"}]" 2>/dev/null; then
     oc patch console.operator.openshift.io cluster --type=json \
@@ -192,6 +193,9 @@ else
   fi
   info "Console plugin activated"
 fi
+
+step "Waiting for rollout..."
+oc rollout status deployment/${PLUGIN_NAME} -n "${NAMESPACE}" --timeout=120s
 
 info "Console plugin deployed successfully"
 info "Note: Console plugin requires OpenShift 4.22+"

--- a/hack/quickstart/deploy-operator.sh
+++ b/hack/quickstart/deploy-operator.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+#
+# Deploy the agentic operator as a standalone workload.
+# Installs CRDs, creates the operator Deployment, agent RBAC,
+# ApprovalPolicy, and webhook resources.
+#
+# Can be called from install.sh or run independently.
+#
+# Usage:
+#   bash hack/quickstart/deploy-operator.sh
+#   bash hack/quickstart/deploy-operator.sh --image=quay.io/my-org/my-operator:tag
+#
+# Prerequisites:
+#   - oc CLI on PATH, logged into an OpenShift cluster
+#   - Namespace openshift-lightspeed exists
+#
+# Flags:
+#   --image=IMAGE   Operator image (default: Konflux :main)
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
+OPERATOR_IMAGE="quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-operator:main"
+GITHUB_RAW="https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --image=*) OPERATOR_IMAGE="${1#*=}"; shift ;;
+    --image)   [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; OPERATOR_IMAGE="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+CRD_FILES=(
+  agentic.openshift.io_agenticolsconfigs.yaml
+  agentic.openshift.io_agents.yaml
+  agentic.openshift.io_analysisresults.yaml
+  agentic.openshift.io_approvalpolicies.yaml
+  agentic.openshift.io_escalationresults.yaml
+  agentic.openshift.io_executionresults.yaml
+  agentic.openshift.io_llmproviders.yaml
+  agentic.openshift.io_agenticrunapprovals.yaml
+  agentic.openshift.io_agenticruns.yaml
+  agentic.openshift.io_verificationresults.yaml
+)
+
+# Prefer local CRD files when running from a checkout; fall back to GitHub.
+REPO_ROOT=""
+if [ -n "${BASH_SOURCE[0]:-}" ]; then
+  _candidate="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  if [ -d "${_candidate}/config/crd/bases" ]; then
+    REPO_ROOT="${_candidate}"
+  fi
+fi
+
+info()  { echo "  ✓ $*"; }
+step()  { echo "[operator] $*"; }
+fail()  { echo "  ✗ $*" >&2; exit 1; }
+
+step "Deploying agentic operator to ${NAMESPACE}"
+step "Image: ${OPERATOR_IMAGE}"
+
+# --- CRDs --------------------------------------------------------------------
+
+step "Installing CRDs..."
+if [ -n "${REPO_ROOT}" ]; then
+  oc apply -f "${REPO_ROOT}/config/crd/bases/"
+  info "CRDs applied (from local checkout)"
+else
+  for crd in "${CRD_FILES[@]}"; do
+    oc apply -f "${GITHUB_RAW}/config/crd/bases/${crd}"
+  done
+  info "${#CRD_FILES[@]} CRDs applied (from GitHub)"
+fi
+
+# --- Webhook Service (must precede Deployment so service-ca generates certs) --
+
+step "Creating webhook Service..."
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentic-operator-webhook-service
+  namespace: ${NAMESPACE}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: agentic-operator-webhook-certs
+spec:
+  ports:
+    - port: 443
+      targetPort: 9443
+      protocol: TCP
+  selector:
+    app: lightspeed-agentic-operator
+EOF
+info "Webhook Service created (cert generation triggered)"
+
+# --- Operator Deployment -----------------------------------------------------
+
+step "Creating operator SA, RBAC, and Deployment..."
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lightspeed-agentic-operator
+  namespace: ${NAMESPACE}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lightspeed-agentic-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: lightspeed-agentic-operator
+  namespace: ${NAMESPACE}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lightspeed-agentic-operator
+  namespace: ${NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lightspeed-agentic-operator
+  template:
+    metadata:
+      labels:
+        app: lightspeed-agentic-operator
+    spec:
+      serviceAccountName: lightspeed-agentic-operator
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: manager
+        image: ${OPERATOR_IMAGE}
+        imagePullPolicy: Always
+        args:
+        - "--namespace=${NAMESPACE}"
+        ports:
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
+        - name: health
+          containerPort: 8081
+          protocol: TCP
+        - name: webhook
+          containerPort: 9443
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: agentic-operator-webhook-certs
+          optional: true
+EOF
+info "Operator deployment applied"
+
+# --- Agent read RBAC ---------------------------------------------------------
+
+step "Binding read permissions to lightspeed-agent SA..."
+oc apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lightspeed-agent-cluster-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+subjects:
+- kind: ServiceAccount
+  name: lightspeed-agent
+  namespace: ${NAMESPACE}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lightspeed-agent-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: lightspeed-agent
+  namespace: ${NAMESPACE}
+EOF
+info "Agent read RBAC applied (cluster-reader + cluster-monitoring-view)"
+
+# --- ApprovalPolicy ----------------------------------------------------------
+
+step "Creating ApprovalPolicy..."
+oc apply -f - <<'EOF'
+apiVersion: agentic.openshift.io/v1alpha1
+kind: ApprovalPolicy
+metadata:
+  name: cluster
+spec:
+  maxAttempts: 3
+  maxConcurrentRuns: 5
+  stages:
+  - name: Analysis
+    approval: Automatic
+  - name: Execution
+    approval: Manual
+  - name: Verification
+    approval: Automatic
+EOF
+info "ApprovalPolicy created"
+
+# --- Wait for operator --------------------------------------------------------
+
+step "Waiting for operator rollout..."
+if ! oc rollout status deployment/lightspeed-agentic-operator \
+    -n "${NAMESPACE}" --timeout=300s; then
+  fail "Agentic operator did not become ready.
+
+  Check:
+    oc logs deployment/lightspeed-agentic-operator -n ${NAMESPACE}
+    oc get configmap lightspeed-agentic-configuration -n ${NAMESPACE}"
+fi
+info "Agentic operator is running"
+
+# --- Webhook Configuration (after operator is ready) -------------------------
+
+step "Registering MutatingWebhookConfiguration..."
+oc apply -f - <<EOF
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: agentic-operator-mutating-webhook
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+webhooks:
+  - name: agenticrunapproval-mutator.agentic.openshift.io
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: ${NAMESPACE}
+    clientConfig:
+      service:
+        name: agentic-operator-webhook-service
+        namespace: ${NAMESPACE}
+        path: /mutate-agenticrunapproval
+    rules:
+      - operations: ["UPDATE"]
+        apiGroups: ["agentic.openshift.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["agenticrunapprovals"]
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+EOF
+info "MutatingWebhookConfiguration registered"
+
+info "Agentic operator deployed successfully"

--- a/hack/quickstart/deploy-otel.sh
+++ b/hack/quickstart/deploy-otel.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+#
+# Deploy the OTEL collector for quickstart.
+#
+# By default, accepts OTLP gRPC/HTTP and drops all data (nop exporter).
+# With --postgres, deploys a Postgres instance and routes agentic logs
+# to it for the console audit UI.
+#
+# The Service uses service-ca for TLS. The generated cert secret
+# (lightspeed-otel-collector-cert) is referenced in the agentic
+# configuration ConfigMap as otel-ca-secret.
+#
+# Usage:
+#   bash hack/quickstart/deploy-otel.sh
+#   bash hack/quickstart/deploy-otel.sh --postgres
+#   bash hack/quickstart/deploy-otel.sh --image=quay.io/my-org/my-collector:tag
+#
+# Prerequisites:
+#   - oc CLI on PATH, logged into an OpenShift cluster
+#   - Namespace openshift-lightspeed exists
+#
+# Flags:
+#   --image=IMAGE   OTEL collector image. If omitted, resolves the latest
+#                   build from Quay automatically.
+#   --postgres      Deploy Postgres and wire the collector to export logs to it.
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
+OTEL_IMAGE=""
+WITH_POSTGRES=0
+QUAY_REPO="redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector"
+
+COLLECTOR_NAME="lightspeed-otel-collector"
+CERT_SECRET="${COLLECTOR_NAME}-cert"
+PG_DSN_SECRET="lightspeed-otel-collector-postgres-dsn"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --image=*)   OTEL_IMAGE="${1#*=}"; shift ;;
+    --image)     [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; OTEL_IMAGE="$2"; shift 2 ;;
+    --postgres)  WITH_POSTGRES=1; shift ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "${OTEL_IMAGE}" ]; then
+  echo "  Resolving latest OTEL collector image from Quay..."
+  TAG="$(curl -fsSL "https://quay.io/api/v1/repository/${QUAY_REPO}/tag/?limit=100&onlyActiveTags=true" \
+    | python3 -c "
+import json,sys,re
+tags = json.load(sys.stdin)['tags']
+pat = re.compile(r'^(on-pr-)?[0-9a-f]{40}$')
+tag = next((t['name'] for t in sorted(tags, key=lambda t: t['start_ts'], reverse=True) if pat.match(t['name'])), None)
+if not tag: sys.exit('No matching tag found in Quay repo')
+print(tag)
+")" || { echo "Failed to resolve image from Quay. Use --image=IMAGE." >&2; exit 1; }
+  OTEL_IMAGE="quay.io/${QUAY_REPO}:${TAG}"
+  echo "  Resolved: ${OTEL_IMAGE}"
+fi
+
+info()  { echo "  ✓ $*"; }
+step()  { echo "[otel] $*"; }
+
+# --- Postgres (optional) -----------------------------------------------------
+
+if [ "${WITH_POSTGRES}" = "1" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  [ -f "${SCRIPT_DIR}/deploy-postgres.sh" ] || { echo "  ✗ Missing deploy-postgres.sh. Run from a repo checkout." >&2; exit 1; }
+  command -v openssl >/dev/null 2>&1 || { echo "  ✗ openssl not found. Required for Postgres password generation." >&2; exit 1; }
+  step "Deploying Postgres backend..."
+  bash "${SCRIPT_DIR}/deploy-postgres.sh"
+
+  step "Creating collector Postgres DSN secret..."
+  PG_PASSWORD="$(oc get secret lightspeed-postgres-secret -n "${NAMESPACE}" -o jsonpath='{.data.password}' | base64 -d)"
+  PG_PASSWORD_ENCODED="$(python3 -c "import urllib.parse; print(urllib.parse.quote('${PG_PASSWORD}', safe=''))")"
+  PG_HOST="lightspeed-postgres-server.${NAMESPACE}.svc"
+  PG_DSN="postgres://postgres:${PG_PASSWORD_ENCODED}@${PG_HOST}:5432/postgres?sslmode=require"
+
+  oc apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${PG_DSN_SECRET}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${COLLECTOR_NAME}
+    app.kubernetes.io/name: ${COLLECTOR_NAME}
+    app.kubernetes.io/component: otel-collector
+type: Opaque
+stringData:
+  connection_string: "${PG_DSN}"
+EOF
+  info "DSN secret created"
+fi
+
+# --- Collector config ---------------------------------------------------------
+
+step "Deploying OTEL collector to ${NAMESPACE}"
+step "Image: ${OTEL_IMAGE}"
+
+if [ "${WITH_POSTGRES}" = "1" ]; then
+COLLECTOR_CONFIG='
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+            tls:
+              cert_file: /etc/otel-certs/tls.crt
+              key_file: /etc/otel-certs/tls.key
+          http:
+            endpoint: "0.0.0.0:4318"
+            tls:
+              cert_file: /etc/otel-certs/tls.crt
+              key_file: /etc/otel-certs/tls.key
+    processors:
+      batch:
+        timeout: 1s
+        send_batch_size: 100
+    exporters:
+      nop: {}
+      postgres:
+        connection_string: ${env:POSTGRES_CONNECTION_STRING}
+        schema: templogs
+        logs_table: logs
+        retry_on_failure:
+          enabled: true
+        sending_queue:
+          enabled: true
+          num_consumers: 4
+          queue_size: 1000
+          storage: file_storage
+    connectors:
+      routing/logs:
+        default_pipelines: [logs/unmatched]
+        table:
+        - condition: "attributes[\"service.name\"] == \"lightspeed-agentic\""
+          pipelines: [logs/postgres]
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:13133"
+      file_storage:
+        directory: /var/lib/otelcol/file-storage
+        create_directory: true
+        compaction:
+          on_start: true
+          directory: /var/lib/otelcol/file-storage/compaction
+      postgres_admin:
+        endpoint: "0.0.0.0:8080"
+        connection_string: ${env:POSTGRES_CONNECTION_STRING}
+        schema: templogs
+        logs_table: logs
+        tls_cert_file: /etc/otel-certs/tls.crt
+        tls_key_file: /etc/otel-certs/tls.key
+    service:
+      extensions: [health_check, file_storage, postgres_admin]
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [routing/logs]
+        logs/postgres:
+          receivers: [routing/logs]
+          exporters: [postgres]
+        logs/unmatched:
+          receivers: [routing/logs]
+          exporters: [nop]
+        traces:
+          receivers: [otlp]
+          exporters: [nop]
+      telemetry:
+        logs:
+          level: info'
+else
+COLLECTOR_CONFIG='
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+            tls:
+              cert_file: /etc/otel-certs/tls.crt
+              key_file: /etc/otel-certs/tls.key
+          http:
+            endpoint: "0.0.0.0:4318"
+            tls:
+              cert_file: /etc/otel-certs/tls.crt
+              key_file: /etc/otel-certs/tls.key
+    processors:
+      batch:
+        timeout: 1s
+        send_batch_size: 100
+    exporters:
+      nop: {}
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:13133"
+    service:
+      extensions: [health_check]
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [nop]
+        traces:
+          receivers: [otlp]
+          exporters: [nop]
+      telemetry:
+        logs:
+          level: info'
+fi
+
+# --- Deployment env/volumes (conditional on Postgres) -------------------------
+
+if [ "${WITH_POSTGRES}" = "1" ]; then
+EXTRA_ENV="
+        - name: POSTGRES_CONNECTION_STRING
+          valueFrom:
+            secretKeyRef:
+              name: ${PG_DSN_SECRET}
+              key: connection_string"
+EXTRA_VOLUME_MOUNTS="
+        - name: file-storage
+          mountPath: /var/lib/otelcol/file-storage"
+EXTRA_VOLUMES="
+      - name: file-storage
+        emptyDir:
+          sizeLimit: 500Mi"
+else
+EXTRA_ENV=""
+EXTRA_VOLUME_MOUNTS=""
+EXTRA_VOLUMES=""
+fi
+
+# --- Apply resources ----------------------------------------------------------
+
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${COLLECTOR_NAME}-config
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${COLLECTOR_NAME}
+    app.kubernetes.io/name: ${COLLECTOR_NAME}
+    app.kubernetes.io/component: otel-collector
+data:
+  config.yaml: |${COLLECTOR_CONFIG}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${COLLECTOR_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${COLLECTOR_NAME}
+    app.kubernetes.io/name: ${COLLECTOR_NAME}
+    app.kubernetes.io/component: otel-collector
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${COLLECTOR_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${COLLECTOR_NAME}
+    app.kubernetes.io/name: ${COLLECTOR_NAME}
+    app.kubernetes.io/component: otel-collector
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ${CERT_SECRET}
+spec:
+  selector:
+    app: ${COLLECTOR_NAME}
+  ports:
+  - name: otlp-grpc
+    port: 4317
+    targetPort: 4317
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: 4318
+    protocol: TCP
+  - name: admin
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${COLLECTOR_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${COLLECTOR_NAME}
+    app.kubernetes.io/name: ${COLLECTOR_NAME}
+    app.kubernetes.io/component: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${COLLECTOR_NAME}
+  template:
+    metadata:
+      labels:
+        app: ${COLLECTOR_NAME}
+        app.kubernetes.io/name: ${COLLECTOR_NAME}
+        app.kubernetes.io/component: otel-collector
+    spec:
+      serviceAccountName: ${COLLECTOR_NAME}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: collector
+        image: ${OTEL_IMAGE}
+        imagePullPolicy: Always
+        args: ["--config=/etc/otelcol/config.yaml"]
+        ports:
+        - name: otlp-grpc
+          containerPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: admin
+          containerPort: 8080
+          protocol: TCP
+        - name: health
+          containerPort: 13133
+          protocol: TCP
+        env:${EXTRA_ENV}
+        - name: OTEL_PLACEHOLDER
+          value: "true"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - name: config
+          mountPath: /etc/otelcol
+          readOnly: true
+        - name: certs
+          mountPath: /etc/otel-certs
+          readOnly: true${EXTRA_VOLUME_MOUNTS}
+      volumes:
+      - name: config
+        configMap:
+          name: ${COLLECTOR_NAME}-config
+      - name: certs
+        secret:
+          secretName: ${CERT_SECRET}${EXTRA_VOLUMES}
+EOF
+
+info "OTEL collector resources applied"
+info "Cert secret: ${CERT_SECRET} (use as otel-ca-secret in agentic ConfigMap)"
+
+step "Waiting for rollout..."
+oc rollout status deployment/${COLLECTOR_NAME} -n "${NAMESPACE}" --timeout=120s
+
+info "OTEL collector deployed successfully"
+if [ "${WITH_POSTGRES}" = "1" ]; then
+  info "Postgres backend: enabled (logs routed to lightspeed-postgres-server)"
+else
+  info "Postgres backend: disabled (logs dropped via nop exporter)"
+fi

--- a/hack/quickstart/deploy-postgres.sh
+++ b/hack/quickstart/deploy-postgres.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+#
+# Deploy a minimal Postgres instance for the OTEL collector audit backend.
+# Uses emptyDir for data — sufficient for dev/test, not for production.
+#
+# Usage:
+#   bash hack/quickstart/deploy-postgres.sh
+#
+# Prerequisites:
+#   - oc CLI on PATH, logged into an OpenShift cluster
+#   - Namespace openshift-lightspeed exists
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
+POSTGRES_IMAGE="registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b"
+
+PG_NAME="lightspeed-postgres-server"
+PG_SECRET="lightspeed-postgres-secret"
+PG_BOOTSTRAP_SECRET="lightspeed-postgres-bootstrap"
+PG_CONFIGMAP="lightspeed-postgres-conf"
+PG_CERTS_SECRET="lightspeed-postgres-certs"
+PG_DATA_DIR="/var/lib/pgsql/data/userdata"
+
+info()  { echo "  ✓ $*"; }
+step()  { echo "[postgres] $*"; }
+
+step "Deploying Postgres to ${NAMESPACE}"
+
+# --- Generate random password ------------------------------------------------
+
+PG_PASSWORD="$(openssl rand -base64 16)"
+
+# --- Apply all resources ------------------------------------------------------
+
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${PG_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${PG_NAME}
+    app.kubernetes.io/name: ${PG_NAME}
+    app.kubernetes.io/component: postgres
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${PG_SECRET}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${PG_NAME}
+    app.kubernetes.io/name: ${PG_NAME}
+    app.kubernetes.io/component: postgres
+type: Opaque
+stringData:
+  password: "${PG_PASSWORD}"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${PG_BOOTSTRAP_SECRET}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${PG_NAME}
+    app.kubernetes.io/name: ${PG_NAME}
+    app.kubernetes.io/component: postgres
+type: Opaque
+stringData:
+  create-extensions.sh: |
+    #!/bin/bash
+    cat /var/lib/pgsql/data/userdata/postgresql.conf
+    echo "attempting to create extensions and schemas if they do not exist"
+    _psql () { psql --set ON_ERROR_STOP=1 "\$@" ; }
+    echo "CREATE EXTENSION IF NOT EXISTS pg_trgm;" | _psql -d \$POSTGRESQL_DATABASE
+    echo "CREATE SCHEMA IF NOT EXISTS quota;" | _psql -d \$POSTGRESQL_DATABASE
+    echo "CREATE SCHEMA IF NOT EXISTS conversation_cache;" | _psql -d \$POSTGRESQL_DATABASE
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${PG_CONFIGMAP}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${PG_NAME}
+    app.kubernetes.io/name: ${PG_NAME}
+    app.kubernetes.io/component: postgres
+data:
+  postgresql.conf.sample: |
+    huge_pages = off
+    ssl = on
+    ssl_cert_file = '/etc/certs/tls.crt'
+    ssl_key_file = '/etc/certs/tls.key'
+    ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${PG_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${PG_NAME}
+    app.kubernetes.io/name: ${PG_NAME}
+    app.kubernetes.io/component: postgres
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ${PG_CERTS_SECRET}
+spec:
+  selector:
+    app: ${PG_NAME}
+  type: ClusterIP
+  ports:
+  - name: server
+    port: 5432
+    targetPort: server
+    protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${PG_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${PG_NAME}
+    app.kubernetes.io/name: ${PG_NAME}
+    app.kubernetes.io/component: postgres
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ${PG_NAME}
+  template:
+    metadata:
+      labels:
+        app: ${PG_NAME}
+        app.kubernetes.io/name: ${PG_NAME}
+        app.kubernetes.io/component: postgres
+    spec:
+      serviceAccountName: ${PG_NAME}
+      terminationGracePeriodSeconds: 60
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: ${PG_NAME}
+        image: ${POSTGRES_IMAGE}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: server
+          containerPort: 5432
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        env:
+        - name: POSTGRESQL_USER
+          value: postgres
+        - name: POSTGRESQL_DATABASE
+          value: postgres
+        - name: POSTGRESQL_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ${PG_SECRET}
+              key: password
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ${PG_SECRET}
+              key: password
+        - name: POSTGRESQL_SHARED_BUFFERS
+          value: "256MB"
+        - name: POSTGRESQL_MAX_CONNECTIONS
+          value: "2000"
+        resources:
+          requests:
+            cpu: 30m
+            memory: 300Mi
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - "if [ -f ${PG_DATA_DIR}/PG_VERSION ]; then pg_ctl stop -D ${PG_DATA_DIR} -m fast -w -t 55; fi"
+        volumeMounts:
+        - name: tls-certs
+          mountPath: /etc/certs
+          readOnly: true
+        - name: bootstrap
+          mountPath: /opt/app-root/src/postgresql-start/create-extensions.sh
+          subPath: create-extensions.sh
+          readOnly: true
+        - name: config
+          mountPath: /usr/share/pgsql/postgresql.conf.sample
+          subPath: postgresql.conf.sample
+        - name: data
+          mountPath: /var/lib/pgsql/data
+        - name: run
+          mountPath: /var/run/postgresql
+        - name: tmp
+          mountPath: /tmp
+        - name: postgres-ca
+          mountPath: /etc/certs/cm-olspostgresca
+          readOnly: true
+      volumes:
+      - name: tls-certs
+        secret:
+          secretName: ${PG_CERTS_SECRET}
+          defaultMode: 0640
+      - name: bootstrap
+        secret:
+          secretName: ${PG_BOOTSTRAP_SECRET}
+          defaultMode: 0640
+      - name: config
+        configMap:
+          name: ${PG_CONFIGMAP}
+          defaultMode: 0644
+      - name: data
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+      - name: postgres-ca
+        configMap:
+          name: openshift-service-ca.crt
+          defaultMode: 0644
+EOF
+
+info "Postgres resources applied"
+
+step "Waiting for rollout..."
+oc rollout status deployment/${PG_NAME} -n "${NAMESPACE}" --timeout=120s
+
+info "Postgres deployed successfully"
+info "Service: ${PG_NAME}.${NAMESPACE}.svc:5432"
+info "Password stored in secret: ${PG_SECRET}"

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -1,488 +1,92 @@
 #!/usr/bin/env bash
 #
 # Quickstart installer for Agentic OLS.
-# Installs or updates Lightspeed Operator via OLM (operator-sdk run bundle /
-# bundle-upgrade) when needed, then deploys the agentic operator from pre-built
-# Konflux images. Pass --ols-bundle-image=IMAGE to choose the OLS bundle;
-# otherwise the script resolves lightspeed-operator-bundle from
-# related_images.json and prompts (decline / option 3 stops). No building or
-# cloning of this repo is required; operator-sdk is downloaded on demand if
-# missing from PATH.
+# Deploys all required components directly — no OLM bundle needed.
 #
-# Usage (download then run — required for interactive OLS prompts):
-#   curl -fsSL -o install-agentic.sh \
-#     https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/install.sh
-#   bash install-agentic.sh
-#   bash install-agentic.sh --ols-bundle-image=quay.io/.../lightspeed-operator-bundle:tag
-#   bash install-agentic.sh --sandbox-image=quay.io/.../lightspeed-agentic-sandbox:tag
-#
-# Do not use: curl … | bash  (stdin is the script; prompts cannot read y/n)
+# Usage:
+#   bash hack/quickstart/install.sh
+#   bash hack/quickstart/install.sh --operator-image=quay.io/... --sandbox-image=quay.io/...
 #
 # Prerequisites:
-#   - oc CLI on PATH
-#   - python3 on PATH only when --ols-bundle-image is omitted (related_images.json fallback)
-#   - Logged into the target OpenShift cluster
+#   - oc CLI on PATH, logged into an OpenShift 4.22+ cluster
 #   - cluster-admin privileges
-#   - Interactive terminal (TTY) for Lightspeed Operator install/update prompts
 #
-# Note: The console plugin requires OpenShift 4.22+.
-#       Set CONSOLE_IMAGE="" to skip console deployment on older clusters.
-#       The console is deployed as a standalone workload (not operator-managed).
+# Flags:
+#   --operator-image=IMAGE          Agentic operator image
+#   --sandbox-image=IMAGE           Sandbox image for the ConfigMap PodSpec
+#   --console-image=IMAGE           Console plugin image
+#   --alerts-adapter-image=IMAGE    Alerts adapter image
+#   --otel-image=IMAGE              OTEL collector image
+#   --postgres                      Deploy Postgres backend for OTEL audit logs
+#   -h, --help                      Show this help and exit
 
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
-OPERATOR_IMAGE="${OPERATOR_IMAGE:-quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-operator:main}"
-SANDBOX_IMAGE="${SANDBOX_IMAGE:-quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-sandbox:main}"
-CONSOLE_IMAGE="${CONSOLE_IMAGE:-quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console:main}"
-SANDBOX_MODE="${SANDBOX_MODE:-bare-pod}"
-IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-}"
 
-GITHUB_RAW="${GITHUB_RAW:-https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main}"
-# Preferred OLS bundle image. Flag --ols-bundle-image overrides; env OLS_BUNDLE_IMAGE is a fallback.
-# When neither is set, install/update resolves the bundle from related_images.json.
-OLS_BUNDLE_IMAGE="${OLS_BUNDLE_IMAGE:-}"
-# Git ref for openshift/lightspeed-operator related_images.json (used only when OLS_BUNDLE_IMAGE is empty).
-OLS_GIT_REF="${OLS_GIT_REF:-main}"
-OLS_RELATED_IMAGES_URL="${OLS_RELATED_IMAGES_URL:-https://raw.githubusercontent.com/openshift/lightspeed-operator/${OLS_GIT_REF}/related_images.json}"
-OPERATOR_SDK_VERSION="${OPERATOR_SDK_VERSION:-1.36.1}"
-BUNDLE_TIMEOUT="${BUNDLE_TIMEOUT:-30m}"
-OLS_CONFIG_FILE="${OLS_CONFIG_FILE:-${TMPDIR:-/tmp}/olsconfig-quickstart.yaml}"
-# How long to wait for OLSConfig status.overallStatus=Ready after each apply.
-OLS_CONFIG_TIMEOUT_SEC="${OLS_CONFIG_TIMEOUT_SEC:-900}"
-
-info()  { echo "  ✓ $*"; }
-step()  { echo "[${1}] ${2}"; }
-fail()  { echo "  ✗ $*" >&2; exit 1; }
-warn()  { echo "  ⚠ $*" >&2; }
+OPERATOR_IMAGE=""
+SANDBOX_IMAGE=""
+CONSOLE_IMAGE=""
+ALERTS_ADAPTER_IMAGE=""
+OTEL_IMAGE=""
+WITH_POSTGRES=0
 
 usage() {
-  cat <<EOF
-Usage: bash install-agentic.sh [options]
+  cat <<'EOF'
+Usage: bash install.sh [options]
 
 Options:
-  --ols-bundle-image=IMAGE   Lightspeed Operator OLM bundle image for
-                             operator-sdk run bundle / bundle-upgrade.
-                             Always install/update when set (no prompt).
-                             If omitted, resolves lightspeed-operator-bundle
-                             from related_images.json (${OLS_RELATED_IMAGES_URL})
-                             and prompts (decline / option 3 stops the script).
-  --sandbox-image=IMAGE      Agentic sandbox container image passed to the
-                             operator as --agentic-sandbox-image.
-                             Overrides SANDBOX_IMAGE. Default:
-                             ${SANDBOX_IMAGE}
-  -h, --help                 Show this help and exit
-
-Environment variables (OPERATOR_IMAGE, SANDBOX_IMAGE, NAMESPACE, …) are
-documented in hack/quickstart/README.md.
+  --operator-image=IMAGE          Agentic operator image (default: Konflux :main)
+  --sandbox-image=IMAGE           Sandbox image (default: Konflux :main)
+  --console-image=IMAGE           Console plugin image (default: Konflux :main)
+  --alerts-adapter-image=IMAGE    Alerts adapter image (default: resolved from Quay)
+  --otel-image=IMAGE              OTEL collector image (default: resolved from Quay)
+  --postgres                      Deploy Postgres backend for OTEL audit logs
+  -h, --help                      Show this help and exit
 EOF
 }
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --ols-bundle-image=*)
-      OLS_BUNDLE_IMAGE="${1#*=}"
-      [ -n "${OLS_BUNDLE_IMAGE}" ] || fail "--ols-bundle-image requires a non-empty image"
-      shift
-      ;;
-    --ols-bundle-image)
-      [ $# -ge 2 ] || fail "--ols-bundle-image requires an image argument"
-      OLS_BUNDLE_IMAGE="$2"
-      [ -n "${OLS_BUNDLE_IMAGE}" ] || fail "--ols-bundle-image requires a non-empty image"
-      shift 2
-      ;;
-    --sandbox-image=*)
-      SANDBOX_IMAGE="${1#*=}"
-      [ -n "${SANDBOX_IMAGE}" ] || fail "--sandbox-image requires a non-empty image"
-      shift
-      ;;
-    --sandbox-image)
-      [ $# -ge 2 ] || fail "--sandbox-image requires an image argument"
-      SANDBOX_IMAGE="$2"
-      [ -n "${SANDBOX_IMAGE}" ] || fail "--sandbox-image requires a non-empty image"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      fail "unknown argument: $1 (try --help)"
-      ;;
+    --operator-image=*)        OPERATOR_IMAGE="${1#*=}"; shift ;;
+    --operator-image)          [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; OPERATOR_IMAGE="$2"; shift 2 ;;
+    --sandbox-image=*)         SANDBOX_IMAGE="${1#*=}"; shift ;;
+    --sandbox-image)           [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; SANDBOX_IMAGE="$2"; shift 2 ;;
+    --console-image=*)         CONSOLE_IMAGE="${1#*=}"; shift ;;
+    --console-image)           [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; CONSOLE_IMAGE="$2"; shift 2 ;;
+    --alerts-adapter-image=*)  ALERTS_ADAPTER_IMAGE="${1#*=}"; shift ;;
+    --alerts-adapter-image)    [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; ALERTS_ADAPTER_IMAGE="$2"; shift 2 ;;
+    --otel-image=*)            OTEL_IMAGE="${1#*=}"; shift ;;
+    --otel-image)              [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; OTEL_IMAGE="$2"; shift 2 ;;
+    --postgres)                WITH_POSTGRES=1; shift ;;
+    -h|--help)                 usage; exit 0 ;;
+    *)                         echo "Unknown flag: $1 (try --help)" >&2; exit 1 ;;
   esac
 done
 
-# Trim leading/trailing whitespace from flag or env. Whitespace-only → empty → error
-# if the user provided a blank value; truly unset/empty stays on the related_images path.
-_ols_bundle_raw="${OLS_BUNDLE_IMAGE}"
-OLS_BUNDLE_IMAGE="${OLS_BUNDLE_IMAGE#"${OLS_BUNDLE_IMAGE%%[![:space:]]*}"}"
-OLS_BUNDLE_IMAGE="${OLS_BUNDLE_IMAGE%"${OLS_BUNDLE_IMAGE##*[![:space:]]}"}"
-if [ -n "${_ols_bundle_raw}" ] && [ -z "${OLS_BUNDLE_IMAGE}" ]; then
-  fail "--ols-bundle-image / OLS_BUNDLE_IMAGE must be non-empty"
-fi
-unset _ols_bundle_raw
+info()  { echo "  ✓ $*"; }
+step()  { echo ""; echo "=== $* ==="; }
+fail()  { echo "  ✗ $*" >&2; exit 1; }
 
-_sandbox_raw="${SANDBOX_IMAGE}"
-SANDBOX_IMAGE="${SANDBOX_IMAGE#"${SANDBOX_IMAGE%%[![:space:]]*}"}"
-SANDBOX_IMAGE="${SANDBOX_IMAGE%"${SANDBOX_IMAGE##*[![:space:]]}"}"
-if [ -z "${SANDBOX_IMAGE}" ]; then
-  fail "--sandbox-image / SANDBOX_IMAGE must be non-empty"
-fi
-unset _sandbox_raw
+# Locate the script directory (for calling sibling scripts).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if [ -n "${OLS_BUNDLE_IMAGE}" ] && [[ "${OLS_BUNDLE_IMAGE}" != *[:/]* ]]; then
-  fail "OLS_BUNDLE_IMAGE looks invalid: ${OLS_BUNDLE_IMAGE}"
-fi
-if [[ "${SANDBOX_IMAGE}" != *[:/]* ]]; then
-  fail "SANDBOX_IMAGE looks invalid: ${SANDBOX_IMAGE}"
-fi
-# Set when a related_images.json bundle is resolved (for logging / summary).
-OLS_RELATED_BUNDLE_IMAGE=""
-# install | update | left-as-is | none — what happened to OLS in this run.
-OLS_ACTION="none"
+# --- Prerequisites -----------------------------------------------------------
 
-CRD_FILES=(
-  agentic.openshift.io_agenticolsconfigs.yaml
-  agentic.openshift.io_agents.yaml
-  agentic.openshift.io_analysisresults.yaml
-  agentic.openshift.io_approvalpolicies.yaml
-  agentic.openshift.io_escalationresults.yaml
-  agentic.openshift.io_executionresults.yaml
-  agentic.openshift.io_llmproviders.yaml
-  agentic.openshift.io_agenticrunapprovals.yaml
-  agentic.openshift.io_agenticruns.yaml
-  agentic.openshift.io_verificationresults.yaml
-)
-
-# Prefer local CRD files when running from a checkout; fall back to GitHub.
-REPO_ROOT=""
-if [ -n "${BASH_SOURCE[0]:-}" ]; then
-  _candidate="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-  if [ -d "${_candidate}/config/crd/bases" ]; then
-    REPO_ROOT="${_candidate}"
-  fi
-fi
-
-ols_crd_installed() {
-  oc get crd olsconfigs.ols.openshift.io >/dev/null 2>&1
-}
-
-olsconfig_exists() {
-  oc get olsconfig cluster >/dev/null 2>&1
-}
-
-require_tty_for_prompts() {
-  if [[ ! -t 0 ]]; then
-    fail "Interactive prompts require a terminal.
-
-  Do not pipe the script into bash (curl … | bash).
-  Download it, then run it:
-
-    curl -fsSL -o install-agentic.sh \\
-      ${GITHUB_RAW}/hack/quickstart/install.sh
-    bash install-agentic.sh"
-  fi
-}
-
-prompt_yes_no() {
-  # $1 = prompt text. Returns 0 for yes, 1 for no.
-  require_tty_for_prompts
-  local reply
-  while true; do
-    printf '%s [y/n]: ' "$1"
-    read -r reply
-    case "${reply}" in
-      [yY]|[yY][eE][sS]) return 0 ;;
-      [nN]|[nN][oO]) return 1 ;;
-      *) echo "  Unexpected input: '${reply}'. Please answer y or n." >&2 ;;
-    esac
-  done
-}
-
-ensure_operator_sdk() {
-  if command -v operator-sdk >/dev/null 2>&1; then
-    OPERATOR_SDK_BIN="$(command -v operator-sdk)"
-    return 0
-  fi
-  command -v curl >/dev/null 2>&1 || fail "curl is required to download operator-sdk"
-  local os arch dest url
-  case "$(uname -s)" in
-    Linux) os=linux ;;
-    Darwin) os=darwin ;;
-    *) fail "unsupported OS for operator-sdk download: $(uname -s)" ;;
-  esac
-  case "$(uname -m)" in
-    x86_64|amd64) arch=amd64 ;;
-    aarch64|arm64) arch=arm64 ;;
-    *) fail "unsupported arch for operator-sdk download: $(uname -m)" ;;
-  esac
-  dest="${TMPDIR:-/tmp}/operator-sdk-${OPERATOR_SDK_VERSION}"
-  url="https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_${os}_${arch}"
-  echo "  Downloading operator-sdk v${OPERATOR_SDK_VERSION}..."
-  curl -fsSL -o "${dest}" "${url}"
-  chmod +x "${dest}"
-  OPERATOR_SDK_BIN="${dest}"
-  info "operator-sdk ready (${OPERATOR_SDK_BIN})"
-}
-
-ols_bundle_image_from_git() {
-  command -v python3 >/dev/null 2>&1 \
-    || fail "python3 not found (needed to read related_images.json when --ols-bundle-image is omitted)"
-  python3 - "${OLS_RELATED_IMAGES_URL}" <<'PY'
-import json, sys, urllib.error, urllib.request
-url = sys.argv[1]
-try:
-    with urllib.request.urlopen(url, timeout=30) as resp:
-        data = json.load(resp)
-except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
-    sys.stderr.write(f"error: fetch related_images.json: {e}\n")
-    sys.exit(1)
-for entry in data:
-    if entry.get("name") == "lightspeed-operator-bundle" and entry.get("image"):
-        print(entry["image"])
-        sys.exit(0)
-sys.stderr.write("error: lightspeed-operator-bundle not found in related_images.json\n")
-sys.exit(1)
-PY
-}
-
-fetch_related_images_bundle() {
-  info "OLS bundle source: related_images.json (git)"
-  echo "  Fetching related_images.json from ${OLS_RELATED_IMAGES_URL}"
-  OLS_RELATED_BUNDLE_IMAGE="$(ols_bundle_image_from_git)"
-  info "Resolved OLS bundle image: ${OLS_RELATED_BUNDLE_IMAGE}"
-}
-
-stop_for_custom_ols_bundle() {
-  local resolved="${1:-}"
-  local msg
-  msg="Stopping. Re-run with your preferred OLS bundle image, for example:
-
-  bash install-agentic.sh --ols-bundle-image=quay.io/<org>/lightspeed-operator-bundle:<tag>
-
-  Related_images URL:
-    ${OLS_RELATED_IMAGES_URL}"
-  if [ -n "${resolved}" ]; then
-    msg="${msg}
-  Resolved related_images bundle (not used):
-    ${resolved}"
-  fi
-  fail "${msg}"
-}
-
-ols_bundle_source_desc() {
-  if [ -n "${OLS_BUNDLE_IMAGE}" ]; then
-    echo "user-provided ${OLS_BUNDLE_IMAGE}"
-  elif [ -n "${OLS_RELATED_BUNDLE_IMAGE}" ]; then
-    echo "related_images.json ${OLS_RELATED_BUNDLE_IMAGE}"
-  else
-    echo "related_images.json ${OLS_RELATED_IMAGES_URL}"
-  fi
-}
-
-install_or_update_ols() {
-  # $1 = install | update
-  # $2 = bundle image
-  local mode="$1"
-  local bundle_image="$2"
-  ensure_operator_sdk
-  info "OLS bundle image: ${bundle_image}"
-
-  if [ "${mode}" = "update" ]; then
-    echo "  Updating Lightspeed Operator via operator-sdk run bundle-upgrade..."
-    if ! "${OPERATOR_SDK_BIN}" run bundle-upgrade --security-context-config=restricted --timeout="${BUNDLE_TIMEOUT}" --namespace "${NAMESPACE}" "${bundle_image}"; then
-      fail "Lightspeed Operator bundle-upgrade failed.
-
-  Refusing to fall back to a fresh 'run bundle' (that can leave a conflicting OLM install).
-  Fix or reinstall OLS manually, then re-run this script.
-  Bundle image: ${bundle_image}
-  Bundle source: $(ols_bundle_source_desc)"
-    fi
-    info "Lightspeed Operator updated"
-    OLS_ACTION="update"
-    return 0
-  fi
-
-  echo "  Installing Lightspeed Operator via operator-sdk run bundle..."
-  "${OPERATOR_SDK_BIN}" run bundle --security-context-config=restricted --timeout="${BUNDLE_TIMEOUT}" --namespace "${NAMESPACE}" "${bundle_image}" \
-    || fail "Lightspeed Operator bundle install failed"
-  info "Lightspeed Operator installed"
-  OLS_ACTION="install"
-}
-
-prompt_ols_already_installed() {
-  # $1 = related_images bundle. Prints leave | update | stop on stdout.
-  local bundle_image="$1"
-  require_tty_for_prompts
-  cat <<EOF >&2
-
-  Lightspeed Operator is already installed (OLSConfig CRD present).
-  related_images.json resolved to:
-    ${bundle_image}
-
-  Choose:
-    1) Leave current OLS as-is
-    2) Update OLS to the related_images bundle above
-    3) Stop and re-run with --ols-bundle-image=<your-image>
-
-EOF
-  local reply
-  while true; do
-    printf 'Choice [1/2/3]: ' >&2
-    read -r reply
-    case "${reply}" in
-      1) echo leave; return 0 ;;
-      2) echo update; return 0 ;;
-      3) echo stop; return 0 ;;
-      *) echo "  Unexpected input: '${reply}'. Please answer 1, 2, or 3." >&2 ;;
-    esac
-  done
-}
-
-write_olsconfig_template() {
-  cat >"${OLS_CONFIG_FILE}" <<EOF
-# Quickstart OLSConfig — edit provider/secret/model as needed, then apply from the installer prompt.
-#
-# Create the LLM credentials Secret in ${NAMESPACE} first, for example (OpenAI):
-#   oc create secret generic llm-creds -n ${NAMESPACE} --from-literal=apitoken=sk-...
-#
-# credentialsSecretRef.name below must match that Secret.
-apiVersion: ols.openshift.io/v1alpha1
-kind: OLSConfig
-metadata:
-  name: cluster
-spec:
-  llm:
-    providers:
-      - name: openai
-        type: openai
-        credentialsSecretRef:
-          name: llm-creds
-        url: https://api.openai.com/v1
-        models:
-          - name: gpt-4o-mini
-  ols:
-    defaultProvider: openai
-    defaultModel: gpt-4o-mini
-EOF
-}
-
-seed_olsconfig_file() {
-  if oc get olsconfig cluster >/dev/null 2>&1; then
-    oc get olsconfig cluster -o yaml >"${OLS_CONFIG_FILE}"
-    info "Exported existing OLSConfig cluster to ${OLS_CONFIG_FILE}"
-  else
-    write_olsconfig_template
-    info "Wrote starter OLSConfig to ${OLS_CONFIG_FILE}"
-  fi
-}
-
-dump_ols_diagnostics() {
-  echo ""
-  warn "OLS diagnostics (${NAMESPACE}):"
-  echo "---- oc get olsconfig cluster -o yaml ----"
-  oc get olsconfig cluster -o yaml 2>&1 || true
-  echo "---- oc get pods -n ${NAMESPACE} ----"
-  oc get pods -n "${NAMESPACE}" -o wide 2>&1 || true
-  echo "---- recent events -n ${NAMESPACE} ----"
-  oc get events -n "${NAMESPACE}" --sort-by=.metadata.creationTimestamp 2>&1 | tail -40 || true
-  echo ""
-}
-
-wait_olsconfig_ready() {
-  local elapsed=0
-  local status=""
-  echo "  Waiting up to ${OLS_CONFIG_TIMEOUT_SEC}s for OLSConfig status.overallStatus=Ready..."
-  while (( elapsed < OLS_CONFIG_TIMEOUT_SEC )); do
-    status="$(oc get olsconfig cluster -o jsonpath='{.status.overallStatus}' 2>/dev/null || true)"
-    if [[ "${status}" == "Ready" ]]; then
-      info "OLS is ready (overallStatus=Ready)"
-      return 0
-    fi
-    sleep 10
-    elapsed=$((elapsed + 10))
-    if (( elapsed % 60 == 0 )); then
-      echo "  … still waiting (overallStatus=${status:-unset}, ${elapsed}s/${OLS_CONFIG_TIMEOUT_SEC}s)"
-    fi
-  done
-  warn "OLS failed to become Ready within ${OLS_CONFIG_TIMEOUT_SEC}s (last overallStatus=${status:-unset})"
-  dump_ols_diagnostics
-  return 1
-}
-
-# Interactive loop: edit OLSConfig file, apply, wait for overallStatus=Ready.
-configure_olsconfig_interactive() {
-  require_tty_for_prompts
-  seed_olsconfig_file
-
-  while true; do
-    cat <<EOF
-
-  OLSConfig file: ${OLS_CONFIG_FILE}
-
-  Before applying, you must:
-    1. Create a Secret in ${NAMESPACE} with your LLM API key, for example (OpenAI):
-         oc create secret generic llm-creds -n ${NAMESPACE} \\
-           --from-literal=apitoken=sk-...
-    2. Edit ${OLS_CONFIG_FILE} and set provider information to match:
-         - spec.llm.providers[].type / name / url / models
-         - spec.llm.providers[].credentialsSecretRef.name (must match the Secret)
-         - spec.ols.defaultProvider and spec.ols.defaultModel
-
-  Open the file in another terminal to accept the starter values or customize them.
-  OLS will stay NotReady until the Secret and provider config are correct.
-
-EOF
-    local reply
-    while true; do
-      printf 'Apply OLSConfig from this file now? [y=apply / e=edit first / a=abort]: '
-      read -r reply
-      case "${reply}" in
-        [yY]|[yY][eE][sS]) break ;;
-        [eE]|[eE][dD][iI][tT])
-          echo "  Create the LLM Secret and edit provider fields in ${OLS_CONFIG_FILE}, then choose y to apply."
-          continue 2
-          ;;
-        [aA]|[aA][bB][oO][rR][tT])
-          fail "Aborted OLSConfig setup. Re-run the installer when ready."
-          ;;
-        *) echo "  Unexpected input: '${reply}'. Please answer y, e, or a." >&2 ;;
-      esac
-    done
-
-    echo "  Applying ${OLS_CONFIG_FILE}..."
-    if ! oc apply -f "${OLS_CONFIG_FILE}"; then
-      warn "oc apply failed — fix the file and try again"
-      continue
-    fi
-    info "OLSConfig applied"
-
-    if wait_olsconfig_ready; then
-      return 0
-    fi
-
-    warn "OLS is not Ready. Fix the OLSConfig (and Secrets), then apply again."
-    if ! prompt_yes_no "Return to the OLSConfig edit/apply loop?"; then
-      fail "OLSConfig did not become Ready. Fix OLS, then re-run this script."
-    fi
-  done
-}
-
-# --- Step 1: Prerequisites ---------------------------------------------------
-
-step "1/9" "Checking prerequisites..."
+step "1/7 Checking prerequisites"
 
 command -v oc >/dev/null 2>&1 || fail "oc CLI not found. Install it first."
-info "oc CLI found"
-
-if [ -z "${OLS_BUNDLE_IMAGE}" ]; then
-  command -v python3 >/dev/null 2>&1 \
-    || fail "python3 not found (needed to read related_images.json when --ols-bundle-image is omitted)"
-  info "python3 found (related_images.json fallback)"
-else
-  info "OLS bundle image override: ${OLS_BUNDLE_IMAGE}"
+command -v curl >/dev/null 2>&1 || fail "curl not found. Required for image resolution from Quay."
+command -v python3 >/dev/null 2>&1 || fail "python3 not found. Required for image resolution from Quay."
+if [ "${WITH_POSTGRES}" = "1" ]; then
+  command -v openssl >/dev/null 2>&1 || fail "openssl not found. Required for Postgres password generation."
 fi
-info "Sandbox image: ${SANDBOX_IMAGE}"
+info "Required CLI tools found"
+
+for script in deploy-otel.sh deploy-alerts-adapter.sh deploy-configmap.sh deploy-operator.sh deploy-console.sh; do
+  [ -f "${SCRIPT_DIR}/${script}" ] || fail "Missing script: ${SCRIPT_DIR}/${script}. Run from a repo checkout."
+done
+info "All deploy scripts present"
 
 oc whoami >/dev/null 2>&1 || fail "Not logged into a cluster. Run: oc login ..."
 info "Logged in as $(oc whoami)"
@@ -492,361 +96,79 @@ if ! oc auth can-i create clusterrolebindings >/dev/null 2>&1; then
 fi
 info "cluster-admin privileges confirmed"
 
-# --- Step 2: Namespace --------------------------------------------------------
+# --- Namespace ---------------------------------------------------------------
 
-step "2/9" "Ensuring namespace ${NAMESPACE}..."
+step "2/7 Ensuring namespace ${NAMESPACE}"
 
-if oc create namespace "${NAMESPACE}" 2>/dev/null; then
-  info "Namespace created"
-elif oc get namespace "${NAMESPACE}" >/dev/null 2>&1; then
+if oc get namespace "${NAMESPACE}" >/dev/null 2>&1; then
   info "Namespace already exists"
 else
-  fail "Failed to create namespace ${NAMESPACE}"
+  oc create namespace "${NAMESPACE}"
+  info "Namespace created"
 fi
 
-# --- Step 3: Lightspeed Operator ----------------------------------------------
+# --- OTEL collector ----------------------------------------------------------
 
-step "3/9" "Lightspeed Operator..."
+step "3/7 Deploying OTEL collector"
 
-CONFIGURE_OLSCONFIG=0
+OTEL_ARGS=""
+if [ -n "${OTEL_IMAGE}" ]; then
+  OTEL_ARGS="--image=${OTEL_IMAGE}"
+fi
+if [ "${WITH_POSTGRES}" = "1" ]; then
+  OTEL_ARGS="${OTEL_ARGS} --postgres"
+fi
+bash "${SCRIPT_DIR}/deploy-otel.sh" ${OTEL_ARGS}
 
-if [ -n "${OLS_BUNDLE_IMAGE}" ]; then
-  # User supplied an image — always install or update; they know what they are doing.
-  info "OLS bundle source: user-provided (--ols-bundle-image / OLS_BUNDLE_IMAGE)"
-  if ols_crd_installed; then
-    info "OLSConfig CRD present — updating Lightspeed Operator"
-    install_or_update_ols update "${OLS_BUNDLE_IMAGE}"
-  else
-    info "OLSConfig CRD not found — installing Lightspeed Operator"
-    install_or_update_ols install "${OLS_BUNDLE_IMAGE}"
-  fi
-  CONFIGURE_OLSCONFIG=1
+# --- Configuration ConfigMap -------------------------------------------------
+
+step "4/7 Creating agentic configuration"
+
+if [ -n "${SANDBOX_IMAGE}" ]; then
+  bash "${SCRIPT_DIR}/deploy-configmap.sh" --sandbox-image="${SANDBOX_IMAGE}"
 else
-  # related_images.json path — resolve concrete image before any install/update decision.
-  fetch_related_images_bundle
-
-  if ols_crd_installed; then
-    info "OLSConfig CRD present"
-    case "$(prompt_ols_already_installed "${OLS_RELATED_BUNDLE_IMAGE}")" in
-      leave)
-        warn "Leaving current Lightspeed Operator as-is"
-        OLS_ACTION="left-as-is"
-        # CRD present does not imply OLSConfig exists — create one if missing.
-        if olsconfig_exists; then
-          info "OLSConfig cluster already present — skipping OLSConfig setup"
-        else
-          warn "OLSConfig cluster not found — will create one before agentic install"
-          CONFIGURE_OLSCONFIG=1
-        fi
-        ;;
-      update)
-        install_or_update_ols update "${OLS_RELATED_BUNDLE_IMAGE}"
-        CONFIGURE_OLSCONFIG=1
-        ;;
-      stop)
-        stop_for_custom_ols_bundle "${OLS_RELATED_BUNDLE_IMAGE}"
-        ;;
-    esac
-  else
-    info "OLSConfig CRD not found"
-    cat <<EOF
-
-  Lightspeed Operator is not installed.
-  Installing from related_images.json would use:
-    ${OLS_RELATED_BUNDLE_IMAGE}
-
-  Declining stops this script — re-run with --ols-bundle-image=<your-image>
-  if you want a different bundle.
-
-EOF
-    if prompt_yes_no "Install Lightspeed Operator using ${OLS_RELATED_BUNDLE_IMAGE}?"; then
-      install_or_update_ols install "${OLS_RELATED_BUNDLE_IMAGE}"
-      CONFIGURE_OLSCONFIG=1
-    else
-      stop_for_custom_ols_bundle "${OLS_RELATED_BUNDLE_IMAGE}"
-    fi
-  fi
+  bash "${SCRIPT_DIR}/deploy-configmap.sh"
 fi
 
-if [ "${CONFIGURE_OLSCONFIG}" = "1" ]; then
-  configure_olsconfig_interactive
-fi
+# --- Agentic operator (installs CRDs — must precede alerts adapter) ----------
 
-# --- Step 4: Agentic Operator CRDs --------------------------------------------
+step "5/7 Deploying agentic operator"
 
-step "4/9" "Installing Agentic Operator CRDs..."
-
-for crd in "${CRD_FILES[@]}"; do
-  if [ -n "${REPO_ROOT}" ]; then
-    oc apply -f "${REPO_ROOT}/config/crd/bases/${crd}"
-  else
-    oc apply -f "${GITHUB_RAW}/config/crd/bases/${crd}"
-  fi
-done
-if [ -n "${REPO_ROOT}" ]; then
-  info "${#CRD_FILES[@]} CRDs applied (from local checkout)"
+if [ -n "${OPERATOR_IMAGE}" ]; then
+  bash "${SCRIPT_DIR}/deploy-operator.sh" --image="${OPERATOR_IMAGE}"
 else
-  info "${#CRD_FILES[@]} CRDs applied (from GitHub)"
+  bash "${SCRIPT_DIR}/deploy-operator.sh"
 fi
 
-# --- Step 5: Agentic operator deployment --------------------------------------
+# --- Alerts adapter ----------------------------------------------------------
 
-step "5/9" "Deploying agentic operator to ${NAMESPACE} (sandbox-mode=${SANDBOX_MODE})..."
+step "6/7 Deploying alerts adapter"
 
-oc apply -f - <<EOF
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: lightspeed-agentic-operator
-  namespace: ${NAMESPACE}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: lightspeed-agentic-operator
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-- kind: ServiceAccount
-  name: lightspeed-agentic-operator
-  namespace: ${NAMESPACE}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lightspeed-agentic-operator
-  namespace: ${NAMESPACE}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: lightspeed-agentic-operator
-  template:
-    metadata:
-      labels:
-        app: lightspeed-agentic-operator
-    spec:
-      serviceAccountName: lightspeed-agentic-operator
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
-      containers:
-      - name: manager
-        image: ${OPERATOR_IMAGE}
-$([ -n "${IMAGE_PULL_POLICY}" ] && echo "        imagePullPolicy: ${IMAGE_PULL_POLICY}")
-        args:
-        - "--namespace=${NAMESPACE}"
-        ports:
-        - name: metrics
-          containerPort: 8080
-          protocol: TCP
-        - name: health
-          containerPort: 8081
-          protocol: TCP
-        - name: webhook
-          containerPort: 9443
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - name: webhook-certs
-          mountPath: /tmp/k8s-webhook-server/serving-certs
-          readOnly: true
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-      volumes:
-      - name: webhook-certs
-        secret:
-          secretName: agentic-operator-webhook-certs
-          optional: true
-EOF
-info "Operator deployment applied"
-
-# --- Step 5b: Agent read RBAC -------------------------------------------------
-
-info "Binding read permissions to lightspeed-agent SA..."
-
-oc apply -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: lightspeed-agent-cluster-reader
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-reader
-subjects:
-- kind: ServiceAccount
-  name: lightspeed-agent
-  namespace: ${NAMESPACE}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: lightspeed-agent-monitoring-view
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-monitoring-view
-subjects:
-- kind: ServiceAccount
-  name: lightspeed-agent
-  namespace: ${NAMESPACE}
-EOF
-info "Agent read RBAC applied (cluster-reader + cluster-monitoring-view)"
-
-# --- Step 6: ApprovalPolicy ---------------------------------------------------
-
-step "6/9" "Creating ApprovalPolicy..."
-
-oc apply -f - <<'EOF'
-apiVersion: agentic.openshift.io/v1alpha1
-kind: ApprovalPolicy
-metadata:
-  name: cluster
-spec:
-  maxAttempts: 3
-  maxConcurrentRuns: 5
-  stages:
-  - name: Analysis
-    approval: Automatic
-  - name: Execution
-    approval: Manual
-  - name: Verification
-    approval: Automatic
-EOF
-info "ApprovalPolicy created"
-
-# --- Step 7: Webhook Service --------------------------------------------------
-
-step "7/9" "Creating webhook Service..."
-
-oc apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: agentic-operator-webhook-service
-  namespace: ${NAMESPACE}
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: agentic-operator-webhook-certs
-spec:
-  ports:
-    - port: 443
-      targetPort: 9443
-      protocol: TCP
-  selector:
-    app: lightspeed-agentic-operator
-EOF
-info "Webhook Service created"
-
-# --- Step 8: Wait for operator ------------------------------------------------
-
-step "8/9" "Waiting for agentic operator to become ready..."
-
-AGENTIC_ROLLOUT_TIMEOUT="${AGENTIC_ROLLOUT_TIMEOUT:-300s}"
-if ! oc rollout status deployment/lightspeed-agentic-operator \
-    -n "${NAMESPACE}" --timeout="${AGENTIC_ROLLOUT_TIMEOUT}" >/dev/null 2>&1; then
-  fail "Agentic operator did not become ready within ${AGENTIC_ROLLOUT_TIMEOUT}.
-
-  Check:
-    oc logs deployment/lightspeed-agentic-operator -n ${NAMESPACE}
-    oc get configmap lightspeed-agentic-configuration -n ${NAMESPACE}"
+if [ -n "${ALERTS_ADAPTER_IMAGE}" ]; then
+  bash "${SCRIPT_DIR}/deploy-alerts-adapter.sh" --image="${ALERTS_ADAPTER_IMAGE}"
+else
+  bash "${SCRIPT_DIR}/deploy-alerts-adapter.sh"
 fi
-info "Agentic operator is running"
 
-# --- Step 9: Webhook Configuration (after operator is ready) ------------------
+# --- Console plugin ----------------------------------------------------------
 
-step "9/9" "Registering fail-closed MutatingWebhookConfiguration..."
-
-oc apply -f - <<EOF
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: agentic-operator-mutating-webhook
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
-webhooks:
-  - name: agenticrunapproval-mutator.agentic.openshift.io
-    namespaceSelector:
-      matchLabels:
-        kubernetes.io/metadata.name: ${NAMESPACE}
-    clientConfig:
-      service:
-        name: agentic-operator-webhook-service
-        namespace: ${NAMESPACE}
-        path: /mutate-agenticrunapproval
-    rules:
-      - operations: ["UPDATE"]
-        apiGroups: ["agentic.openshift.io"]
-        apiVersions: ["v1alpha1"]
-        resources: ["agenticrunapprovals"]
-    failurePolicy: Fail
-    sideEffects: None
-    admissionReviewVersions: ["v1"]
-EOF
-info "MutatingWebhookConfiguration registered"
-
-# --- Step: Deploy console plugin (standalone) --------------------------------
+step "7/7 Deploying console plugin"
 
 if [ -n "${CONSOLE_IMAGE}" ]; then
-  SCRIPT_DIR=""
-  if [ -n "${BASH_SOURCE[0]:-}" ]; then
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  fi
-  if [ -n "${SCRIPT_DIR}" ] && [ -f "${SCRIPT_DIR}/deploy-console.sh" ]; then
-    NAMESPACE="${NAMESPACE}" CONSOLE_IMAGE="${CONSOLE_IMAGE}" bash "${SCRIPT_DIR}/deploy-console.sh"
-  else
-    curl -fsL "${GITHUB_RAW}/hack/quickstart/deploy-console.sh" \
-      | NAMESPACE="${NAMESPACE}" CONSOLE_IMAGE="${CONSOLE_IMAGE}" bash
-  fi
+  bash "${SCRIPT_DIR}/deploy-console.sh" --image="${CONSOLE_IMAGE}"
 else
-  echo "  CONSOLE_IMAGE is empty — skipping console deployment"
+  bash "${SCRIPT_DIR}/deploy-console.sh"
 fi
 
-# --- Done ---------------------------------------------------------------------
+# --- Done --------------------------------------------------------------------
 
-if [ -n "${REPO_ROOT}" ] && [ -d "${REPO_ROOT}/hack/quickstart/examples" ]; then
-  EXAMPLES_BASE="${REPO_ROOT}/hack/quickstart/examples"
+GITHUB_RAW="https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main"
+
+# Prefer local examples when running from a checkout.
+if [ -d "${SCRIPT_DIR}/../../hack/quickstart/examples" ]; then
+  EXAMPLES_BASE="$(cd "${SCRIPT_DIR}/../.." && pwd)/hack/quickstart/examples"
 else
   EXAMPLES_BASE="${GITHUB_RAW}/hack/quickstart/examples"
-fi
-
-if [ "${OLS_ACTION}" = "left-as-is" ]; then
-  OLS_SUMMARY_BUNDLE="(not changed)"
-  OLS_SUMMARY_SUGGESTED="
-  related_images suggested: ${OLS_RELATED_BUNDLE_IMAGE}"
-else
-  OLS_SUMMARY_BUNDLE="$(ols_bundle_source_desc)"
-  OLS_SUMMARY_SUGGESTED=""
 fi
 
 cat <<DONE
@@ -854,21 +176,7 @@ cat <<DONE
 ════════════════════════════════════════════════════════════════
   Agentic OLS installed successfully!
 
-  Namespace     : ${NAMESPACE}
-  Sandbox mode  : ${SANDBOX_MODE}
-  Operator image: ${OPERATOR_IMAGE}
-  Sandbox image : ${SANDBOX_IMAGE}
-  Console image : ${CONSOLE_IMAGE}
-  OLS bundle    : ${OLS_SUMMARY_BUNDLE}${OLS_SUMMARY_SUGGESTED}
-  OLS action    : ${OLS_ACTION}
-  OLSConfig file: ${OLS_CONFIG_FILE}
-
-  > Console works only on OpenShift 4.22+
-════════════════════════════════════════════════════════════════
-
-  OLS status (if Lightspeed Operator was installed/updated):
-    oc get olsconfig cluster -o jsonpath='{.status.overallStatus}{"\\n"}'
-    oc get olsconfig cluster -o yaml
+  Namespace: ${NAMESPACE}
 
   NEXT: Configure your agentic LLM provider. Pick one:
 
@@ -876,14 +184,12 @@ cat <<DONE
   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service-account-key.json
   oc create secret generic llm-creds-vertex -n ${NAMESPACE} \\
     --from-file=GOOGLE_APPLICATION_CREDENTIALS="\$GOOGLE_APPLICATION_CREDENTIALS"
-  # Edit vertex-anthropic.yaml — set your GCP project ID and region
   oc apply -f ${EXAMPLES_BASE}/vertex-anthropic.yaml
 
   ── Vertex AI / Gemini ─────────────────────────────────────
   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service-account-key.json
   oc create secret generic llm-creds-vertex -n ${NAMESPACE} \\
     --from-file=GOOGLE_APPLICATION_CREDENTIALS="\$GOOGLE_APPLICATION_CREDENTIALS"
-  # Edit vertex-google.yaml — set your GCP project ID and region
   oc apply -f ${EXAMPLES_BASE}/vertex-google.yaml
 
   ── OpenAI ─────────────────────────────────────────────────
@@ -892,39 +198,11 @@ cat <<DONE
   oc apply -f ${EXAMPLES_BASE}/openai.yaml
 
   ── Then submit an example run ────────────────────────
-
-  # Investigate namespace workloads, remediate if issues found:
   oc apply -f ${EXAMPLES_BASE}/namespace-inventory.yaml
-
-  # Deploy a test workload (analysis + execution):
-  oc apply -f ${EXAMPLES_BASE}/deploy-test-workload.yaml
-
-  # Watch until analysis completes (Analyzed=True):
   oc get agenticruns -n ${NAMESPACE} -w
-
-  # Check the analysis result:
-  oc get analysisresult -n ${NAMESPACE} -o json
-
-  # Approve execution (option 0 = first option) via oc CLI or in console UI:
-  oc patch agenticrunapproval namespace-inventory -n ${NAMESPACE} \\
-    --type=json \\
-    -p '[{"op":"add","path":"/spec/stages/-","value":{"type":"Execution","execution":{"option":0}}}]'
-
-  # Watch execution progress:
-  oc get agenticruns -n ${NAMESPACE} -w
-
-  ── Enable audit tracing ───────────────────────────────────
-  # Deploy Jaeger first (if you don't have a collector):
-  bash <(curl -sL ${GITHUB_RAW}/hack/deploy-jaeger.sh)
-
-  # Then enable audit tracing + OTEL export:
-  OTEL_ENDPOINT=jaeger-otlp-grpc.observability.svc:4317 \\
-    bash <(curl -sL ${GITHUB_RAW}/hack/quickstart/setup-audit.sh)
-
-  # Audit tracing only (stdout JSON, no remote collector):
-  bash <(curl -sL ${GITHUB_RAW}/hack/quickstart/setup-audit.sh)
 
   ── To uninstall ───────────────────────────────────────────
-  bash <(curl -sL ${GITHUB_RAW}/hack/quickstart/uninstall.sh)
+  bash hack/quickstart/uninstall.sh
 
+════════════════════════════════════════════════════════════════
 DONE

--- a/hack/quickstart/undeploy-alerts-adapter.sh
+++ b/hack/quickstart/undeploy-alerts-adapter.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Remove the agentic alerts adapter standalone workload.
+# Can be called from uninstall.sh or run independently.
+#
+# Usage:
+#   bash hack/quickstart/undeploy-alerts-adapter.sh
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
+ADAPTER_NAME="lightspeed-agentic-alerts-adapter"
+
+info()  { echo "  ✓ $*"; }
+step()  { echo "[alerts-adapter] $*"; }
+
+step "Deleting alerts adapter resources"
+
+oc delete deployment "${ADAPTER_NAME}" -n "${NAMESPACE}" --ignore-not-found
+oc delete configmap alerts-adapter-config -n "${NAMESPACE}" --ignore-not-found
+oc delete sa "${ADAPTER_NAME}" -n "${NAMESPACE}" --ignore-not-found
+oc delete clusterrolebinding "${ADAPTER_NAME}-agenticruns" --ignore-not-found ||
+  echo "  ! Warning: could not delete ClusterRoleBinding (managed cluster?)"
+oc delete clusterrole "${ADAPTER_NAME}-agenticruns" --ignore-not-found ||
+  echo "  ! Warning: could not delete ClusterRole (managed cluster?)"
+oc delete rolebinding "${ADAPTER_NAME}-alertmanager" -n openshift-monitoring --ignore-not-found ||
+  echo "  ! Warning: could not delete RoleBinding in openshift-monitoring (managed cluster?)"
+
+info "Alerts adapter resources deleted"

--- a/hack/quickstart/undeploy-configmap.sh
+++ b/hack/quickstart/undeploy-configmap.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Remove the agentic configuration ConfigMap and OTEL CA secret.
+# Can be called from uninstall.sh or run independently.
+#
+# Usage:
+#   bash hack/quickstart/undeploy-configmap.sh
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
+
+info()  { echo "  ✓ $*"; }
+step()  { echo "[configmap] $*"; }
+
+step "Deleting agentic configuration resources"
+
+oc delete configmap lightspeed-agentic-configuration -n "${NAMESPACE}" --ignore-not-found
+oc delete secret lightspeed-agentic-otel-ca -n "${NAMESPACE}" --ignore-not-found
+
+info "Configuration resources deleted"

--- a/hack/quickstart/undeploy-console.sh
+++ b/hack/quickstart/undeploy-console.sh
@@ -5,10 +5,6 @@
 #
 # Usage:
 #   bash hack/quickstart/undeploy-console.sh
-#
-# Environment variables:
-#   NAMESPACE  (default: openshift-lightspeed)
-
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-openshift-lightspeed}"

--- a/hack/quickstart/undeploy-operator.sh
+++ b/hack/quickstart/undeploy-operator.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Remove the agentic operator quickstart deployment.
+# Can be called from uninstall.sh or run independently.
+#
+# Usage:
+#   bash hack/quickstart/undeploy-operator.sh
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
+
+info()  { echo "  ✓ $*"; }
+step()  { echo "[operator] $*"; }
+
+# Delete webhook first so the fail-closed webhook doesn't block API calls.
+step "Deleting webhook resources"
+oc delete mutatingwebhookconfiguration agentic-operator-mutating-webhook --ignore-not-found ||
+  step "Warning: could not delete MutatingWebhookConfiguration (managed cluster?)"
+oc delete service agentic-operator-webhook-service -n "${NAMESPACE}" --ignore-not-found
+oc delete secret agentic-operator-webhook-certs -n "${NAMESPACE}" --ignore-not-found
+info "Webhook resources deleted"
+
+step "Deleting ApprovalPolicy"
+oc delete approvalpolicy cluster --ignore-not-found
+info "ApprovalPolicy deleted"
+
+step "Deleting custom resources (operator still running to process finalizers)"
+CR_TYPES=(
+  agenticruns.agentic.openshift.io
+  agenticrunapprovals.agentic.openshift.io
+  analysisresults.agentic.openshift.io
+  executionresults.agentic.openshift.io
+  escalationresults.agentic.openshift.io
+  verificationresults.agentic.openshift.io
+)
+for cr in "${CR_TYPES[@]}"; do
+  oc delete "${cr}" --all -n "${NAMESPACE}" --ignore-not-found --timeout=60s >/dev/null 2>&1 || true
+done
+
+step "Waiting for custom resources to be fully removed..."
+STUCK=""
+for cr in "${CR_TYPES[@]}"; do
+  remaining="$(oc get "${cr}" -n "${NAMESPACE}" --no-headers 2>/dev/null | wc -l || echo 0)"
+  if [ "${remaining}" -gt 0 ]; then
+    STUCK="${STUCK} ${cr}"
+  fi
+done
+if [ -n "${STUCK}" ]; then
+  step "Warning: resources still exist (stuck finalizers?):${STUCK}"
+  step "Stripping finalizers to unblock deletion..."
+  for cr in ${STUCK}; do
+    for name in $(oc get "${cr}" -n "${NAMESPACE}" --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null); do
+      oc patch "${cr}" "${name}" -n "${NAMESPACE}" --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+    done
+  done
+  sleep 2
+fi
+info "Custom resources removed"
+
+step "Deleting operator deployment"
+oc delete deployment lightspeed-agentic-operator -n "${NAMESPACE}" --ignore-not-found
+oc delete sa lightspeed-agentic-operator -n "${NAMESPACE}" --ignore-not-found
+oc delete clusterrolebinding lightspeed-agentic-operator --ignore-not-found ||
+  step "Warning: could not delete ClusterRoleBinding lightspeed-agentic-operator (managed cluster?)"
+oc delete clusterrolebinding lightspeed-agent-cluster-reader --ignore-not-found ||
+  step "Warning: could not delete ClusterRoleBinding lightspeed-agent-cluster-reader (managed cluster?)"
+oc delete clusterrolebinding lightspeed-agent-monitoring-view --ignore-not-found ||
+  step "Warning: could not delete ClusterRoleBinding lightspeed-agent-monitoring-view (managed cluster?)"
+info "Operator resources deleted"
+
+step "Deleting CRDs"
+for crd in \
+  agenticolsconfigs.agentic.openshift.io \
+  agents.agentic.openshift.io \
+  analysisresults.agentic.openshift.io \
+  approvalpolicies.agentic.openshift.io \
+  escalationresults.agentic.openshift.io \
+  executionresults.agentic.openshift.io \
+  llmproviders.agentic.openshift.io \
+  agenticrunapprovals.agentic.openshift.io \
+  agenticruns.agentic.openshift.io \
+  verificationresults.agentic.openshift.io; do
+  oc delete crd "${crd}" --ignore-not-found --timeout=30s
+done
+info "CRDs deleted"
+
+info "Agentic operator removed"

--- a/hack/quickstart/undeploy-otel.sh
+++ b/hack/quickstart/undeploy-otel.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Remove the quickstart OTEL collector.
+# Can be called from uninstall.sh or run independently.
+#
+# Usage:
+#   bash hack/quickstart/undeploy-otel.sh
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
+COLLECTOR_NAME="lightspeed-otel-collector"
+
+info()  { echo "  ✓ $*"; }
+step()  { echo "[otel] $*"; }
+
+step "Deleting OTEL collector resources"
+
+oc delete deployment "${COLLECTOR_NAME}" -n "${NAMESPACE}" --ignore-not-found
+oc delete service "${COLLECTOR_NAME}" -n "${NAMESPACE}" --ignore-not-found
+oc delete configmap "${COLLECTOR_NAME}-config" -n "${NAMESPACE}" --ignore-not-found
+oc delete sa "${COLLECTOR_NAME}" -n "${NAMESPACE}" --ignore-not-found
+oc delete secret "${COLLECTOR_NAME}-cert" -n "${NAMESPACE}" --ignore-not-found
+oc delete secret "${COLLECTOR_NAME}-postgres-dsn" -n "${NAMESPACE}" --ignore-not-found
+
+info "OTEL collector resources deleted"
+
+if oc get deployment lightspeed-postgres-server -n "${NAMESPACE}" >/dev/null 2>&1; then
+  step "Removing Postgres backend..."
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  bash "${SCRIPT_DIR}/undeploy-postgres.sh"
+fi

--- a/hack/quickstart/undeploy-postgres.sh
+++ b/hack/quickstart/undeploy-postgres.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Remove the Postgres instance deployed by deploy-postgres.sh.
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
+
+echo "[postgres] Removing Postgres from ${NAMESPACE}..."
+
+oc delete deployment lightspeed-postgres-server -n "${NAMESPACE}" --ignore-not-found
+oc delete service lightspeed-postgres-server -n "${NAMESPACE}" --ignore-not-found
+oc delete configmap lightspeed-postgres-conf -n "${NAMESPACE}" --ignore-not-found
+oc delete secret lightspeed-postgres-bootstrap -n "${NAMESPACE}" --ignore-not-found
+oc delete secret lightspeed-postgres-secret -n "${NAMESPACE}" --ignore-not-found
+oc delete secret lightspeed-postgres-certs -n "${NAMESPACE}" --ignore-not-found
+oc delete sa lightspeed-postgres-server -n "${NAMESPACE}" --ignore-not-found
+
+echo "  ✓ Postgres removed"

--- a/hack/quickstart/uninstall.sh
+++ b/hack/quickstart/uninstall.sh
@@ -1,109 +1,39 @@
 #!/usr/bin/env bash
 #
 # Uninstall Agentic OLS quickstart deployment.
-# Optionally uninstalls Lightspeed Operator if it was installed via OLM
-# (operator-sdk run bundle), matching hack/quickstart/install.sh.
+# Removes all components in reverse order.
 #
-# Usage (download then run — required for interactive OLS prompts):
-#   curl -fsSL -o uninstall-agentic.sh \
-#     https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh
-#   bash uninstall-agentic.sh
+# Usage:
+#   bash hack/quickstart/uninstall.sh
 #
-# Do not use: curl … | bash  (stdin is the script; prompts cannot read y/n)
-#
-# Env:
-#   NAMESPACE       (default: openshift-lightspeed)
-#   QUICKSTART_FORCE=1  skip the top-level confirmation
-#   REMOVE_OLS=1|0      non-interactive OLS uninstall decision (skips the y/n prompt)
-#   OPERATOR_SDK_VERSION, CLEANUP_TIMEOUT
+# Flags:
+#   --force   Skip confirmation prompt
 
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
-OPERATOR_SDK_VERSION="${OPERATOR_SDK_VERSION:-1.36.1}"
-CLEANUP_TIMEOUT="${CLEANUP_TIMEOUT:-5m}"
-# OLM package name used by operator-sdk run bundle for Lightspeed Operator.
-OLS_PACKAGE_NAME="${OLS_PACKAGE_NAME:-lightspeed-operator}"
+FORCE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force) FORCE=1; shift ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
 
 info()  { echo "  ✓ $*"; }
-warn()  { echo "  ⚠ $*" >&2; }
-step()  { echo "[${1}] ${2}"; }
+step()  { echo ""; echo "=== $* ==="; }
 fail()  { echo "  ✗ $*" >&2; exit 1; }
 
-require_tty_for_prompts() {
-  if [[ ! -t 0 ]]; then
-    fail "Interactive prompts require a terminal.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  Do not pipe the script into bash (curl … | bash).
-  Download it, then run it:
+for script in undeploy-console.sh undeploy-operator.sh undeploy-configmap.sh undeploy-alerts-adapter.sh undeploy-otel.sh; do
+  [ -f "${SCRIPT_DIR}/${script}" ] || fail "Missing script: ${SCRIPT_DIR}/${script}. Run from a repo checkout."
+done
 
-    curl -fsSL -o uninstall-agentic.sh \\
-      https://raw.githubusercontent.com/openshift/lightspeed-agentic-operator/main/hack/quickstart/uninstall.sh
-    bash uninstall-agentic.sh
-
-  Or set REMOVE_OLS=0|1 for a non-interactive OLS decision."
-  fi
-}
-
-prompt_yes_no() {
-  # $1 = prompt text. Returns 0 for yes, 1 for no.
-  require_tty_for_prompts
-  local reply
-  while true; do
-    printf '%s [y/n]: ' "$1"
-    read -r reply
-    case "${reply}" in
-      [yY]|[yY][eE][sS]) return 0 ;;
-      [nN]|[nN][oO]) return 1 ;;
-      *) echo "  Please answer y or n." ;;
-    esac
-  done
-}
-
-ensure_operator_sdk() {
-  if command -v operator-sdk >/dev/null 2>&1; then
-    OPERATOR_SDK_BIN="$(command -v operator-sdk)"
-    return 0
-  fi
-  command -v curl >/dev/null 2>&1 || fail "curl is required to download operator-sdk"
-  local os arch dest url
-  case "$(uname -s)" in
-    Linux) os=linux ;;
-    Darwin) os=darwin ;;
-    *) fail "unsupported OS for operator-sdk download: $(uname -s)" ;;
-  esac
-  case "$(uname -m)" in
-    x86_64|amd64) arch=amd64 ;;
-    aarch64|arm64) arch=arm64 ;;
-    *) fail "unsupported arch for operator-sdk download: $(uname -m)" ;;
-  esac
-  dest="${TMPDIR:-/tmp}/operator-sdk-${OPERATOR_SDK_VERSION}"
-  url="https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_${os}_${arch}"
-  echo "  Downloading operator-sdk v${OPERATOR_SDK_VERSION}..."
-  curl -fsSL -o "${dest}" "${url}"
-  chmod +x "${dest}"
-  OPERATOR_SDK_BIN="${dest}"
-  info "operator-sdk ready (${OPERATOR_SDK_BIN})"
-}
-
-uninstall_ols() {
-  ensure_operator_sdk
-  echo "  Deleting OLSConfig (if present)..."
-  oc delete olsconfig cluster --ignore-not-found 2>/dev/null || true
-  echo "  Running: operator-sdk cleanup ${OLS_PACKAGE_NAME} -n ${NAMESPACE}..."
-  "${OPERATOR_SDK_BIN}" cleanup "${OLS_PACKAGE_NAME}" \
-    --namespace "${NAMESPACE}" \
-    --timeout="${CLEANUP_TIMEOUT}" \
-    || fail "operator-sdk cleanup failed for ${OLS_PACKAGE_NAME}.
-  Fix OLM leftovers manually, then re-run this script (or set REMOVE_OLS=0 to skip OLS)."
-  info "Lightspeed Operator uninstalled"
-}
-
-if [ "${QUICKSTART_FORCE:-}" != "1" ]; then
-  require_tty_for_prompts
-  echo "This will delete ALL Agentic OLS resources in namespace ${NAMESPACE},"
-  echo "remove the console plugin, and operator CRDs cluster-wide."
-  echo "You will be asked separately whether to also uninstall Lightspeed Operator."
+if [ "${FORCE}" != "1" ]; then
+  echo "This will delete all supporting deployments (OTEL collector, alerts adapter,"
+  echo "console plugin, Postgres), the operator, CRDs, and the ${NAMESPACE} namespace."
   echo ""
   read -rp "Continue? [y/N] " confirm
   case "${confirm}" in
@@ -112,132 +42,62 @@ if [ "${QUICKSTART_FORCE:-}" != "1" ]; then
   esac
 fi
 
-REMOVE_OLS_OPERATOR=0
+# --- Delete Agentic CRs ------------------------------------------------------
 
-# Ask the user (unless REMOVE_OLS is set for non-interactive runs).
-# No cluster probes — the answer alone decides whether OLS is cleaned up.
-case "${REMOVE_OLS:-}" in
-  1|true|yes|YES)
-    REMOVE_OLS_OPERATOR=1
-    ;;
-  0|false|no|NO)
-    REMOVE_OLS_OPERATOR=0
-    ;;
-  "")
-    cat <<EOF
-
-  Quickstart may also have installed Lightspeed Operator (OLS) via OLM.
-  Answer n to leave OLS installed (namespace ${NAMESPACE} will be kept).
-
-EOF
-    if prompt_yes_no "Uninstall Lightspeed Operator as well?"; then
-      REMOVE_OLS_OPERATOR=1
-    else
-      REMOVE_OLS_OPERATOR=0
-    fi
-    ;;
-  *)
-    fail "REMOVE_OLS must be 0 or 1 (got: ${REMOVE_OLS})"
-    ;;
-esac
-
-if [ "${REMOVE_OLS_OPERATOR}" = "0" ]; then
-  warn "Lightspeed Operator will be left installed; namespace ${NAMESPACE} will be kept"
-fi
-
-# --- Step 1: Delete Agentic CRs ----------------------------------------------
-
-step "1/8" "Deleting Agentic custom resources..."
+step "1/8 Deleting Agentic custom resources"
 
 for kind in agenticruns agenticrunapprovals analysisresults executionresults verificationresults escalationresults; do
-  oc delete "${kind}" --all -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
+  oc delete "${kind}" --all -n "${NAMESPACE}" --ignore-not-found >/dev/null 2>&1 || true
 done
 info "AgenticRun resources deleted"
 
-oc delete agents --all --ignore-not-found 2>/dev/null || true
-oc delete llmproviders --all --ignore-not-found 2>/dev/null || true
-oc delete approvalpolicy cluster --ignore-not-found 2>/dev/null || true
-oc delete agenticolsconfig cluster --ignore-not-found 2>/dev/null || true
-info "Agents, LLMProviders, ApprovalPolicy, AgenticOLSConfig deleted"
+oc delete agents --all --ignore-not-found >/dev/null 2>&1 || true
+oc delete llmproviders --all --ignore-not-found >/dev/null 2>&1 || true
+oc delete agenticolsconfig cluster --ignore-not-found >/dev/null 2>&1 || true
+info "Agents, LLMProviders, AgenticOLSConfig deleted"
 
-# --- Step 2: Optional Lightspeed Operator ------------------------------------
+# --- Delete secrets -----------------------------------------------------------
 
-step "2/8" "Optional Lightspeed Operator uninstall..."
-
-if [ "${REMOVE_OLS_OPERATOR}" = "1" ]; then
-  uninstall_ols
-else
-  info "Skipped Lightspeed Operator uninstall"
-fi
-
-# --- Step 3: Delete secrets ---------------------------------------------------
-
-step "3/8" "Deleting credential secrets..."
+step "2/8 Deleting credential secrets"
 
 for secret in llm-creds-vertex llm-creds-openai llm-creds-azure llm-creds-bedrock llm-creds-anthropic; do
-  oc delete secret "${secret}" -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
+  oc delete secret "${secret}" -n "${NAMESPACE}" --ignore-not-found >/dev/null 2>&1 || true
 done
 info "Credential secrets deleted"
 
-# --- Step 4: Remove console plugin --------------------------------------------
+# --- Console plugin -----------------------------------------------------------
 
-step "4/8" "Removing console plugin..."
+step "3/8 Removing console plugin"
+bash "${SCRIPT_DIR}/undeploy-console.sh"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "${SCRIPT_DIR}/undeploy-console.sh" ]; then
-  NAMESPACE="${NAMESPACE}" bash "${SCRIPT_DIR}/undeploy-console.sh"
+# --- Operator -----------------------------------------------------------------
+
+step "4/8 Removing agentic operator"
+bash "${SCRIPT_DIR}/undeploy-operator.sh"
+
+# --- Configuration ConfigMap --------------------------------------------------
+
+step "5/8 Removing configuration"
+bash "${SCRIPT_DIR}/undeploy-configmap.sh"
+
+# --- Alerts adapter -----------------------------------------------------------
+
+step "6/8 Removing alerts adapter"
+bash "${SCRIPT_DIR}/undeploy-alerts-adapter.sh"
+
+# --- OTEL collector -----------------------------------------------------------
+
+step "7/8 Removing OTEL collector"
+bash "${SCRIPT_DIR}/undeploy-otel.sh"
+
+# --- Namespace ----------------------------------------------------------------
+
+step "8/8 Namespace ${NAMESPACE}"
+oc delete namespace "${NAMESPACE}" --ignore-not-found --timeout=60s || true
+if oc get namespace "${NAMESPACE}" >/dev/null 2>&1; then
+  echo "  ! Namespace ${NAMESPACE} is still terminating — check for stuck finalizers" >&2
+  echo "  ! A reinstall may fail until the namespace is fully gone" >&2
 else
-  info "undeploy-console.sh not found — skipping console cleanup"
-fi
-
-# --- Step 5: Delete webhook resources -----------------------------------------
-# Delete the MutatingWebhookConfiguration BEFORE the operator so the fail-closed
-# webhook doesn't block API calls while its backend is gone.
-
-step "5/8" "Deleting webhook resources..."
-oc delete mutatingwebhookconfiguration agentic-operator-mutating-webhook --ignore-not-found 2>/dev/null || true
-oc delete service agentic-operator-webhook-service -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
-oc delete secret agentic-operator-webhook-certs -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
-info "Webhook resources deleted"
-
-# --- Step 6: Delete operator --------------------------------------------------
-
-step "6/8" "Deleting agentic operator deployment..."
-
-oc delete deployment lightspeed-agentic-operator -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
-oc delete sa lightspeed-agentic-operator -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || true
-oc delete clusterrolebinding lightspeed-agentic-operator --ignore-not-found 2>/dev/null || true
-oc delete clusterrolebinding lightspeed-agent-cluster-reader --ignore-not-found 2>/dev/null || true
-oc delete clusterrolebinding lightspeed-agent-monitoring-view --ignore-not-found 2>/dev/null || true
-info "Agentic operator removed"
-
-# --- Step 7: Delete CRDs -----------------------------------------------------
-
-step "7/8" "Deleting Agentic Operator CRDs..."
-
-for crd in \
-  agenticolsconfigs.agentic.openshift.io \
-  agents.agentic.openshift.io \
-  analysisresults.agentic.openshift.io \
-  approvalpolicies.agentic.openshift.io \
-  escalationresults.agentic.openshift.io \
-  executionresults.agentic.openshift.io \
-  llmproviders.agentic.openshift.io \
-  agenticrunapprovals.agentic.openshift.io \
-  agenticruns.agentic.openshift.io \
-  verificationresults.agentic.openshift.io; do
-  oc delete crd "${crd}" --ignore-not-found --timeout=30s 2>/dev/null || true
-done
-info "Agentic CRDs deleted"
-
-# --- Step 8: Delete namespace -------------------------------------------------
-
-step "8/8" "Namespace ${NAMESPACE}..."
-
-if [ "${REMOVE_OLS_OPERATOR}" = "0" ]; then
-  warn "Keeping namespace ${NAMESPACE} (Lightspeed Operator left installed)"
-else
-  oc delete namespace "${NAMESPACE}" --ignore-not-found --timeout=60s 2>/dev/null || true
   info "Namespace deleted"
 fi
 
@@ -245,10 +105,3 @@ cat <<DONE
 
   Agentic OLS has been uninstalled.
 DONE
-
-if [ "${REMOVE_OLS_OPERATOR}" = "1" ]; then
-  echo "  Lightspeed Operator was also uninstalled."
-else
-  echo "  Lightspeed Operator was left installed in ${NAMESPACE}."
-fi
-echo ""


### PR DESCRIPTION

 **Summary**
- Rewrites the quickstart installer to deploy all components directly — no OLM
  bundle, no `operator-sdk`, no interactive prompts.
- Splits installation into standalone scripts that can be run individually or
  composed via `install.sh`:
  - `deploy-otel.sh` — minimal OTEL collector (no Postgres, nop exporter)
  - `deploy-alerts-adapter.sh` — AlertManager adapter with RBAC
  - `deploy-configmap.sh` — `lightspeed-agentic-configuration` ConfigMap with
    auto-detected OTEL wiring
  - `deploy-operator.sh` — CRDs, SA, RBAC, Deployment, webhook
  - `deploy-console.sh` — console plugin (updated to match new pattern)
- Each deploy script has a matching undeploy script.
- All images are overridable via `--image` flags.
- Images with Konflux `:main` tags use them directly; images without (alerts
  adapter, OTEL collector) are resolved from Quay at runtime.
- Updates `uninstall.sh` and `README.md` to match.
