### PR TITLE
OLS-3765 Add restricted securityContext to quickstart sandbox PodSpec

### DIFF
--- a/.tekton/integration-tests/scripts/install-operator.sh
+++ b/.tekton/integration-tests/scripts/install-operator.sh
@@ -89,8 +89,18 @@ data:
       "containers": [{
         "name": "agent",
         "image": "${SANDBOX_IMAGE}",
-        "ports": [{"containerPort": 8080}]
-      }]
+        "ports": [{"containerPort": 8080}],
+        "securityContext": {
+          "allowPrivilegeEscalation": false,
+          "runAsNonRoot": true,
+          "capabilities": {"drop": ["ALL"]},
+          "seccompProfile": {"type": "RuntimeDefault"}
+        }
+      }],
+      "securityContext": {
+        "runAsNonRoot": true,
+        "seccompProfile": {"type": "RuntimeDefault"}
+      }
     }
 EOF
 

--- a/hack/quickstart/deploy-configmap.sh
+++ b/hack/quickstart/deploy-configmap.sh
@@ -42,7 +42,7 @@ fail()  { echo "  ✗ $*" >&2; exit 1; }
 step "Creating ${CONFIGMAP_NAME} in ${NAMESPACE}"
 step "Sandbox image: ${SANDBOX_IMAGE}"
 
-POD_SPEC="{\"containers\":[{\"name\":\"agent\",\"image\":\"${SANDBOX_IMAGE}\",\"resources\":{\"requests\":{\"cpu\":\"100m\",\"memory\":\"256Mi\"},\"limits\":{\"cpu\":\"1\",\"memory\":\"1Gi\"}}}]}"
+POD_SPEC="{\"containers\":[{\"name\":\"agent\",\"image\":\"${SANDBOX_IMAGE}\",\"resources\":{\"requests\":{\"cpu\":\"100m\",\"memory\":\"256Mi\"},\"limits\":{\"cpu\":\"1\",\"memory\":\"1Gi\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"runAsNonRoot\":true,\"capabilities\":{\"drop\":[\"ALL\"]},\"seccompProfile\":{\"type\":\"RuntimeDefault\"}}}],\"securityContext\":{\"runAsNonRoot\":true,\"seccompProfile\":{\"type\":\"RuntimeDefault\"}}}"
 
 # Detect OTEL collector if deployed.
 OTEL_DATA=""


### PR DESCRIPTION
## Summary
- Add PSA `restricted:latest` compliant securityContext to sandbox PodSpec in **both** scripts:
  - `hack/quickstart/deploy-configmap.sh` — quickstart path
  - `.tekton/integration-tests/scripts/install-operator.sh` — CI/e2e path
- Matches the securityContext shape from `controller/sandbox/bootstrap.go`

Fixes #403

## Test plan
- [x] `make test` passes
- [ ] Deploy on restricted namespace, submit AgenticRun, verify pod starts without PSA violation

Jira: https://redhat.atlassian.net/browse/OLS-3765

🤖 Generated with [Claude Code](https://claude.ai/code)