### PR TITLE
OLS-3515: Use Konflux :main tag for Otel and adapter, and fix OTEL config

### DIFF
--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -8,8 +8,7 @@ directly — no OLM bundle or `operator-sdk` required.
 - A checkout of this repository (scripts reference each other via relative paths)
 - `oc` CLI on PATH, logged into an OpenShift 4.22+ cluster
 - cluster-admin privileges
-- `python3` and `curl` on PATH (for automatic image resolution from Quay)
-- `openssl` on PATH (for Postgres password generation, only with `--postgres`)
+- `python3` and `openssl` on PATH
 
 ## Install
 
@@ -75,8 +74,8 @@ bash hack/quickstart/undeploy-otel.sh
 | `--operator-image=IMAGE` | Agentic operator image (default: Konflux `:main`) |
 | `--sandbox-image=IMAGE` | Sandbox image for the ConfigMap PodSpec (default: Konflux `:main`) |
 | `--console-image=IMAGE` | Console plugin image (default: Konflux `:main`) |
-| `--alerts-adapter-image=IMAGE` | Alerts adapter image (default: resolved from Quay) |
-| `--otel-image=IMAGE` | OTEL collector image (default: resolved from Quay) |
+| `--alerts-adapter-image=IMAGE` | Alerts adapter image (default: Konflux `:main`) |
+| `--otel-image=IMAGE` | OTEL collector image (default: Konflux `:main`) |
 | `--postgres` | Deploy Postgres backend for OTEL audit logs |
 
 ### Individual scripts
@@ -85,23 +84,17 @@ bash hack/quickstart/undeploy-otel.sh
 |--------|------|---------|
 | `deploy-operator.sh` | `--image=IMAGE` | Konflux `:main` |
 | `deploy-console.sh` | `--image=IMAGE` | Konflux `:main` |
-| `deploy-alerts-adapter.sh` | `--image=IMAGE` | Resolved from Quay (newest git SHA tag) |
-| `deploy-otel.sh` | `--image=IMAGE` | Resolved from Quay (newest `on-pr-*` tag) |
+| `deploy-alerts-adapter.sh` | `--image=IMAGE` | Konflux `:main` |
+| `deploy-otel.sh` | `--image=IMAGE` | Konflux `:main` |
 | `deploy-otel.sh` | `--postgres` | Deploy Postgres backend for audit logs |
 | `deploy-configmap.sh` | `--sandbox-image=IMAGE` | Konflux `:main` |
 
-Images with a Konflux `:main` tag use it directly. Images without a `:main`
-tag (alerts adapter, OTEL collector) are resolved from Quay at runtime by
-finding the most recent build tag.
+All images use the Konflux floating `:main` tag by default.
 
 ## Image resolution
 
-The **operator**, **sandbox**, and **console** images are built by this repo's
-Konflux push pipeline and have a floating `:main` tag.
-
-The **alerts adapter** and **OTEL collector** are built by the same Konflux
-tenant (`crt-nshift-lightspeed-tenant`). They do not have `:main` tags, so the
-deploy scripts query the Quay API to find the latest build automatically.
+All quickstart images are built by the Konflux push pipeline under the same
+tenant (`crt-nshift-lightspeed-tenant`) and have a floating `:main` tag.
 
 To use a specific PR build of the agentic operator:
 

--- a/hack/quickstart/deploy-alerts-adapter.sh
+++ b/hack/quickstart/deploy-alerts-adapter.sh
@@ -15,14 +15,12 @@
 #   - Namespace openshift-lightspeed exists
 #
 # Flags:
-#   --image=IMAGE   Alerts adapter image. If omitted, resolves the latest
-#                   build from Quay automatically.
+#   --image=IMAGE   Alerts adapter image (default: Konflux :main).
 
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
-ALERTS_ADAPTER_IMAGE=""
-QUAY_REPO="redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter"
+ALERTS_ADAPTER_IMAGE="quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter:main"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -32,20 +30,6 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ -z "${ALERTS_ADAPTER_IMAGE}" ]; then
-  echo "  Resolving latest alerts adapter image from Quay..."
-  TAG="$(curl -fsSL "https://quay.io/api/v1/repository/${QUAY_REPO}/tag/?limit=100&onlyActiveTags=true" \
-    | python3 -c "
-import json,sys,re
-tags = json.load(sys.stdin)['tags']
-pat = re.compile(r'^(on-pr-)?[0-9a-f]{40}$')
-tag = next((t['name'] for t in sorted(tags, key=lambda t: t['start_ts'], reverse=True) if pat.match(t['name'])), None)
-if not tag: sys.exit('No matching tag found in Quay repo')
-print(tag)
-")" || { echo "Failed to resolve image from Quay. Use --image=IMAGE." >&2; exit 1; }
-  ALERTS_ADAPTER_IMAGE="quay.io/${QUAY_REPO}:${TAG}"
-  echo "  Resolved: ${ALERTS_ADAPTER_IMAGE}"
-fi
 
 ADAPTER_NAME="lightspeed-agentic-alerts-adapter"
 ALERTMANAGER_URL="https://alertmanager-main.openshift-monitoring.svc:9094"

--- a/hack/quickstart/deploy-otel.sh
+++ b/hack/quickstart/deploy-otel.sh
@@ -20,16 +20,14 @@
 #   - Namespace openshift-lightspeed exists
 #
 # Flags:
-#   --image=IMAGE   OTEL collector image. If omitted, resolves the latest
-#                   build from Quay automatically.
+#   --image=IMAGE   OTEL collector image (default: Konflux :main).
 #   --postgres      Deploy Postgres and wire the collector to export logs to it.
 
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
-OTEL_IMAGE=""
+OTEL_IMAGE="quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector:main"
 WITH_POSTGRES=0
-QUAY_REPO="redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector"
 
 COLLECTOR_NAME="lightspeed-otel-collector"
 CERT_SECRET="${COLLECTOR_NAME}-cert"
@@ -44,20 +42,6 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ -z "${OTEL_IMAGE}" ]; then
-  echo "  Resolving latest OTEL collector image from Quay..."
-  TAG="$(curl -fsSL "https://quay.io/api/v1/repository/${QUAY_REPO}/tag/?limit=100&onlyActiveTags=true" \
-    | python3 -c "
-import json,sys,re
-tags = json.load(sys.stdin)['tags']
-pat = re.compile(r'^(on-pr-)?[0-9a-f]{40}$')
-tag = next((t['name'] for t in sorted(tags, key=lambda t: t['start_ts'], reverse=True) if pat.match(t['name'])), None)
-if not tag: sys.exit('No matching tag found in Quay repo')
-print(tag)
-")" || { echo "Failed to resolve image from Quay. Use --image=IMAGE." >&2; exit 1; }
-  OTEL_IMAGE="quay.io/${QUAY_REPO}:${TAG}"
-  echo "  Resolved: ${OTEL_IMAGE}"
-fi
 
 info()  { echo "  ✓ $*"; }
 step()  { echo "[otel] $*"; }
@@ -135,7 +119,7 @@ COLLECTOR_CONFIG='
       routing/logs:
         default_pipelines: [logs/unmatched]
         table:
-        - condition: "attributes[\"service.name\"] == \"lightspeed-agentic\""
+        - condition: "resource.attributes[\"service.name\"] == \"lightspeed-agentic-sandbox\""
           pipelines: [logs/postgres]
     extensions:
       health_check:

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -39,8 +39,8 @@ Options:
   --operator-image=IMAGE          Agentic operator image (default: Konflux :main)
   --sandbox-image=IMAGE           Sandbox image (default: Konflux :main)
   --console-image=IMAGE           Console plugin image (default: Konflux :main)
-  --alerts-adapter-image=IMAGE    Alerts adapter image (default: resolved from Quay)
-  --otel-image=IMAGE              OTEL collector image (default: resolved from Quay)
+  --alerts-adapter-image=IMAGE    Alerts adapter image (default: Konflux :main)
+  --otel-image=IMAGE              OTEL collector image (default: Konflux :main)
   --postgres                      Deploy Postgres backend for OTEL audit logs
   -h, --help                      Show this help and exit
 EOF
@@ -76,11 +76,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 step "1/7 Checking prerequisites"
 
 command -v oc >/dev/null 2>&1 || fail "oc CLI not found. Install it first."
-command -v curl >/dev/null 2>&1 || fail "curl not found. Required for image resolution from Quay."
-command -v python3 >/dev/null 2>&1 || fail "python3 not found. Required for image resolution from Quay."
-if [ "${WITH_POSTGRES}" = "1" ]; then
-  command -v openssl >/dev/null 2>&1 || fail "openssl not found. Required for Postgres password generation."
-fi
+command -v python3 >/dev/null 2>&1 || fail "python3 not found. Required by deploy scripts."
+command -v openssl >/dev/null 2>&1 || fail "openssl not found. Required by deploy scripts."
 info "Required CLI tools found"
 
 for script in deploy-otel.sh deploy-alerts-adapter.sh deploy-configmap.sh deploy-operator.sh deploy-console.sh; do


### PR DESCRIPTION
- Switch deploy-otel.sh and deploy-alerts-adapter.sh from runtime Quay API resolution to Konflux :main defaults, matching the other quickstart images.
- Fix OTEL routing condition in deploy-otel.sh: attributes["service.name"] == "lightspeed-agentic" → resource.attributes["service.name"] == "lightspeed-agentic-sandbox" (service.name is a resource attribute, not a log record attribute).
- Update install.sh help text and README.md accordingly.