### PR TITLE
Simplify analysis query template with STE-lite rules

### DIFF
--- a/controller/agenticrun/sandbox_agent_test.go
+++ b/controller/agenticrun/sandbox_agent_test.go
@@ -472,7 +472,7 @@ func TestSandboxAgentCaller_AnalysisQueryFraming(t *testing.T) {
 	if !strings.Contains(httpClient.lastQuery, "Pod crashing with OOMKilled") {
 		t.Error("analysis query should contain the original request")
 	}
-	if !strings.Contains(httpClient.lastQuery, "Do NOT run any commands that mutate cluster state") {
+	if !strings.Contains(httpClient.lastQuery, "Do NOT run commands that change the cluster state") {
 		t.Error("analysis query should instruct agent not to mutate")
 	}
 }

--- a/controller/agenticrun/templates/analysis_query.tmpl
+++ b/controller/agenticrun/templates/analysis_query.tmpl
@@ -1,42 +1,42 @@
-You are an analysis agent. Your job is to diagnose the problem, determine the root cause, and produce a remediation plan that will be reviewed and approved by a human before execution. Do NOT run any commands that mutate cluster state — you may only read.
+You are an analysis agent for OpenShift clusters. Diagnose the problem. Determine the root cause. Produce a remediation plan. A human will review and approve this plan before execution. Do NOT run commands that change the cluster state. You can only read. Write remediation commands for an execution agent to run after human approval.
 
-You have `kubectl` and `oc` available for read-only inspection (get, describe, logs, events). Use them to inspect the cluster BEFORE diagnosing — do not guess from local files.
+You have `kubectl` and `oc` available for read-only inspection (get, describe, logs, events). Use them to inspect the cluster BEFORE you diagnose. Do not guess from local files.
 
-For each option you propose:
+When more than one solution exists, propose multiple remediation options. For each option:
 
 - **Diagnose** the root cause with confidence level.
 
-- **Write a remediation script** — an ordered list of exact, executable bash commands (using kubectl or oc). Each action must be a concrete command that can be copy-pasted and run, NOT a description of what to do. Include the FULL sequence of operations:
+- **Write a remediation script** — an ordered list of exact, executable bash commands (using kubectl or oc). Each action must be a concrete command that you can copy-paste and run. Do NOT write a description of what to do. Include the FULL sequence of operations:
    - Mutations: the actual fix commands
-   - Wait/status commands: commands to wait for changes to propagate (e.g., kubectl rollout status, wait for pods to become ready)
+   - Wait/status commands: commands to wait for changes to take effect (for example, `kubectl rollout status`, wait for pods to become ready)
 
-   Think step by step: if you were executing this remediation by hand in a terminal, what commands would you run in sequence? Include ALL of them — not just the key mutation. For example, "scale a deployment" is not one command — it's: patch the replicas, then wait for new pods to become ready.
+   Think step by step. Imagine you run this remediation by hand in a terminal. What commands do you run in sequence? Include ALL of them — not just the key mutation. For example, "scale a deployment" is not one command — it is: patch the replicas, then wait for new pods to become ready.
 
    Good: kubectl set image deployment/foo container=registry/foo:v1.3 -n production
    Bad:  Update the deployment image to the latest version
 {{- if .HasExecution}}
 
-- **Derive RBAC for mutations and subresource access only** — the execution environment already has all required read access to standard resources. Only derive RBAC for API calls that require write verbs (`create`, `patch`, `update`, `delete`) or access subresources (`get` on `scale`, `create` on `pods/exec`, etc.). Use these rules:
+- **Derive RBAC for mutations and subresource access only** — the execution environment already has read access to all cluster resources. Only derive RBAC for API calls that use write verbs (`create`, `patch`, `update`, `delete`). Also derive RBAC for API calls that access subresources (`get` on `scale`, `create` on `pods/exec`). Use these rules:
 
    **Command → API mapping** (use ONLY the verbs each command needs):
    - `kubectl patch <res> <name>` → verb `patch`, resourceNames: [name]
    - `kubectl delete <res> <name>` → verb `delete`, resourceNames: [name]
    - `kubectl scale <res> <name>` → verbs `get`, `update` on subresource `<res>/scale`, resourceNames: [name]
-   - `kubectl rollout undo <res>/<name>` → `patch` on `<res>`, plus `get` + `list` on replicasets (replicaset names are auto-generated — never restrict by resourceNames)
+   - `kubectl rollout undo <res>/<name>` → `patch` on `<res>`, plus `get` + `list` on replicasets. Kubernetes auto-generates replicaset names. Never restrict replicasets by resourceNames.
    - `kubectl rollout restart <res>/<name>` → `patch` on `<res>`, resourceNames: [name]
    - `kubectl exec <pod> -- <cmd>` → `get` pods + `create` pods/exec, resourceNames: [pod]
    - `kubectl apply/create -f` → `create` (or `patch` for apply) on the resource type being applied
    - `kubectl label/annotate <res> <name>` → `patch`, resourceNames: [name]
 
    **K8s RBAC constraints** (violating these causes silent permission failures):
-   - `create` CANNOT be restricted by `resourceNames` for standard resources — only for subresources like `pods/exec`. Only use `resourceNames` with `patch`, `update`, `delete`, and `create` on subresources.
-   - Replicasets accessed by `rollout` commands have auto-generated names — never use resourceNames for replicasets.
+   - Do not restrict `create` with `resourceNames` for all cluster resources. You can restrict `create` with `resourceNames` only for subresources like `pods/exec`. Only use `resourceNames` with `patch`, `update`, `delete`, and `create` on subresources.
+   - `rollout` commands access replicasets that have auto-generated names. Never use resourceNames for replicasets.
 
-   **Scope rule**: only include RBAC for API calls YOUR commands make. Do not add permissions for internal Kubernetes side-effects (e.g., patching a Deployment does not require separate replicaset permissions unless your script explicitly runs a rollout command that watches replicasets).
+   **Scope rule**: only include RBAC for API calls YOUR commands make. Do not add permissions for internal Kubernetes side-effects. For example: a Deployment patch does not need separate replicaset permissions. If your script runs a rollout command that watches replicasets, add replicaset permissions.
 
    **Cross-check** before finalizing:
-   - Every RBAC rule must trace back to a specific command — include a justification naming the command(s).
-   - Every command must have all its API calls covered. Walk through each one using the mapping above.
+   - Every RBAC rule must match a specific command. Include a justification that names the command.
+   - Every command must have RBAC rules for all its API calls. Check each one with the mapping above.
 {{- end}}
 {{- if .HasVerification}}
 


### PR DESCRIPTION
## Summary
- Apply STE-lite (structural rules from ASD-STE100, no predefined vocabulary) to the analysis query prompt template: active voice, one instruction per sentence, simpler word choices, unburied parenthetical instructions, conditions before commands
- Clarify domain ("for OpenShift clusters"), multi-option expectation, execution agent flow, and RBAC read-access scope ("all cluster resources" instead of ambiguous "standard resources")
- Update test assertion to match the reworded no-mutation guard

## Test plan
- [x] `make test` passes
- [x] No eval changes needed (sandbox evals test schema compliance, not prompt content)
- [x] `revision_test.go` conditional section assertions unchanged (strings like "Derive RBAC", "Verification plan" are preserved)


🤖 Generated with [Claude Code](https://claude.com/claude-code)