### PR TITLE
Simplify execution and verification prompt templates with STE-lite rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -337,6 +337,23 @@ reviews:
         - Audit logging: who uploaded/downloaded/deleted what
         - Secure storage: encrypted at rest, access-controlled
 
+    # ── Agent prompt templates (STE) ──────────────────────────────
+    - path: "**/*.tmpl"
+      instructions: |
+        STE-lite review (structural rules from ASD-STE100, no predefined vocabulary):
+        - One instruction per sentence, max 20 words
+        - Descriptive sentences max 25 words
+        - Active voice; passive only when the actor is unknown
+        - Approved modals: can, will, must. Reject: should, would, may, might, could
+        - No contractions (it's → it is)
+        - No Latin abbreviations (e.g. → for example, i.e. → that is)
+        - Condition before command (If X, do Y — not Do Y if X)
+        - One word one meaning; do not rotate synonyms for the same concept
+        - Noun clusters max 3 words
+        - No phrasal verbs (walk through → check, set up → configure)
+        - Simple tenses only (no present perfect, no conditional)
+        - Domain terms (RBAC, replicaset, kubectl) are allowed
+
   # Security scanners (prodsec) + language-specific linters
   tools:
     gitleaks:

--- a/controller/agenticrun/templates/execution_query.tmpl
+++ b/controller/agenticrun/templates/execution_query.tmpl
@@ -1,18 +1,18 @@
-You are an execution agent. Your job is to execute the approved remediation option below — nothing more, nothing less. Do not re-analyze the problem or propose alternative solutions.
+You are an execution agent for OpenShift clusters. Execute the approved remediation option below. Do not re-analyze the problem. Do not propose alternative solutions.
 
 The approved option contains a concrete remediation script — an ordered list of exact bash commands. Follow these rules:
 
 1. **Execute commands in order.** Do not skip, reorder, or substitute commands. Run each command exactly as written.
 
-2. **Dry-run every mutation** before applying. For any command that modifies cluster state, first run it with `--dry-run=server`. If the command does not support `--dry-run`, skip it in dry-run execution.
+2. **Dry-run every mutation before you apply it.** If a command modifies the cluster state, first run it with `--dry-run=server`. If the command does not support `--dry-run`, skip the dry-run step.
 
-3. **Fix syntax errors, nothing else.** If any command fails due to a syntax error (malformed flag, missing `--namespace`, wrong argument order), fix the syntax and retry. Do not change the command's intent, target, or action.
+3. **Fix syntax errors only.** If a command fails because of a syntax error (malformed flag, missing `--namespace`, wrong argument order), fix the syntax and retry. Do not change the intent, target, or action of the command.
 
-4. **Skip non-blocking failures.** If a command fails but the error is clearly non-blocking (e.g., resource already exists, already patched to the desired state), treat it as succeeded and continue.
+4. **Skip non-blocking failures.** If a command fails but the error is not blocking (for example, the resource already exists or is already in the desired state), treat it as succeeded and continue.
 
-5. **Stop on blocking failure.** If a command fails for any other reason, **stop and report failure**.
+5. **Stop on a blocking failure.** If a command fails for any other reason, stop and report the failure.
 
-6. **Report each action** you take, its outcome (Succeeded/Failed), and any output or errors.
+6. **Report each action** you take, its outcome (Succeeded or Failed), and any output or errors.
 
 ## Approved Option
 

--- a/controller/agenticrun/templates/verification_query.tmpl
+++ b/controller/agenticrun/templates/verification_query.tmpl
@@ -1,4 +1,4 @@
-You are a verification agent. Your job is to verify that the executed remediation was applied correctly and the issue is resolved. Do not execute any additional changes — only verify.
+You are a verification agent for OpenShift clusters. Verify that the executed remediation was applied correctly. Verify that the issue is resolved. Do not execute any additional changes. Only verify.
 
 Run the verification checks from the approved option's verification plan. Compare the current cluster state against the expected outcomes. Report each check as Passed or Failed with evidence.
 


### PR DESCRIPTION
## Summary
- Apply STE-lite (structural rules from ASD-STE100, no predefined vocabulary) to `execution_query.tmpl` and `verification_query.tmpl`
- Explicit domain ("for OpenShift clusters"), one instruction per sentence, active voice, conditions before commands, `e.g.` → `for example`, no filler phrases
- Add CodeRabbit STE-lite review instruction for all `.tmpl` files
- Companion to #419 (analysis query template)

## Test plan
- [x] `make test` passes
- [x] No test assertion changes needed (substring checks for "execution agent" and "verification agent" still match)


🤖 Generated with [Claude Code](https://claude.com/claude-code)