### PR TITLE
OLS-3811 Make confidence/risk optional and remove from LLM schemas

### DIFF
--- a/api/v1alpha1/agenticrun_analysis_types.go
+++ b/api/v1alpha1/agenticrun_analysis_types.go
@@ -69,7 +69,7 @@ type DiagnosisResult struct {
 	// confidence is the agent's self-assessed confidence in its diagnosis.
 	// Higher confidence generally correlates with clearer symptoms and
 	// more deterministic root causes.
-	// +required
+	// +optional
 	Confidence ConfidenceLevel `json:"confidence,omitempty"`
 	// rootCause is a concise Markdown-formatted description of the identified
 	// root cause (e.g., "OOMKilled due to memory limit of 256Mi").
@@ -139,7 +139,7 @@ type RemediationPlan struct {
 	Actions []ProposedAction `json:"actions,omitempty"`
 	// risk is the agent's assessment of how risky the remediation is.
 	// Critical-risk remediations typically require explicit human review.
-	// +required
+	// +optional
 	Risk RiskLevel `json:"risk,omitempty"`
 	// reversible indicates whether the remediation can be rolled back
 	// if something goes wrong. See rollbackPlan for details.

--- a/config/crd/bases/agentic.openshift.io_analysisresults.yaml
+++ b/config/crd/bases/agentic.openshift.io_analysisresults.yaml
@@ -171,7 +171,6 @@ spec:
                     minLength: 1
                     type: string
                 required:
-                - confidence
                 - rootCause
                 - summary
                 type: object
@@ -237,7 +236,6 @@ spec:
                           minLength: 1
                           type: string
                       required:
-                      - confidence
                       - rootCause
                       - summary
                       type: object
@@ -543,7 +541,6 @@ spec:
                       required:
                       - actions
                       - description
-                      - risk
                       type: object
                     summary:
                       description: |-

--- a/controller/agenticrun/agent.go
+++ b/controller/agenticrun/agent.go
@@ -73,14 +73,12 @@ func (s *StubAgentCaller) Analyze(_ context.Context, _ *agenticv1alpha1.AgenticR
 		Options: []agenticv1alpha1.RemediationOption{{
 			Title: "Stub remediation",
 			Diagnosis: agenticv1alpha1.DiagnosisResult{
-				Summary:    "Stub diagnosis",
-				Confidence: "Medium",
-				RootCause:  "Stub root cause",
+				Summary:   "Stub diagnosis",
+				RootCause: "Stub root cause",
 			},
 			RemediationPlan: agenticv1alpha1.RemediationPlan{
 				Description: "Stub remediation plan",
 				Actions:     []agenticv1alpha1.ProposedAction{{Command: "kubectl get pods -n default", Type: "pre-check", Description: "Stub action"}},
-				Risk:        "Low",
 				Reversible:  agenticv1alpha1.ReversibilityReversible,
 			},
 		}},

--- a/controller/agenticrun/audit.go
+++ b/controller/agenticrun/audit.go
@@ -365,7 +365,6 @@ func (l *ProductionAuditLogger) EmitAnalysisCompleted(ctx context.Context, run *
 		prefix := fmt.Sprintf("option.%d.", i)
 		attrs = append(attrs,
 			attribute.String(prefix+"title", opt.Title),
-			attribute.String(prefix+"risk", string(opt.RemediationPlan.Risk)),
 		)
 	}
 	attrs = append(attrs, attribute.String("agenticrun.cr", serializeCRJSON(result)))

--- a/controller/agenticrun/audit_test.go
+++ b/controller/agenticrun/audit_test.go
@@ -431,8 +431,8 @@ func TestEmitAnalysisCompleted_EventAttributes(t *testing.T) {
 		},
 		Status: agenticv1alpha1.AnalysisResultStatus{
 			Options: []agenticv1alpha1.RemediationOption{
-				{Title: "Increase memory", RemediationPlan: agenticv1alpha1.RemediationPlan{Risk: agenticv1alpha1.RiskLevelLow}},
-				{Title: "Restart pod", RemediationPlan: agenticv1alpha1.RemediationPlan{Risk: agenticv1alpha1.RiskLevelMedium}},
+				{Title: "Increase memory"},
+				{Title: "Restart pod"},
 			},
 		},
 	}
@@ -474,15 +474,18 @@ func TestEmitAnalysisCompleted_EventAttributes(t *testing.T) {
 		"result.name":     "test-analysis",
 		"options.count":   "2",
 		"option.0.title":  "Increase memory",
-		"option.0.risk":   "Low",
 		"option.1.title":  "Restart pod",
-		"option.1.risk":   "Medium",
 	}
 	for key, want := range checks {
 		if got, ok := attrMap[key]; !ok {
 			t.Errorf("missing attribute %q", key)
 		} else if got != want {
 			t.Errorf("attribute %q = %q, want %q", key, got, want)
+		}
+	}
+	for _, key := range []string{"option.0.risk", "option.1.risk"} {
+		if _, ok := attrMap[key]; ok {
+			t.Errorf("unexpected attribute %q", key)
 		}
 	}
 }

--- a/controller/agenticrun/handlers_test.go
+++ b/controller/agenticrun/handlers_test.go
@@ -844,12 +844,11 @@ func TestReconcile_ExecutionRBACCreatedOnApproval(t *testing.T) {
 		Options: []agenticv1alpha1.RemediationOption{{
 			Title: "Increase memory",
 			Diagnosis: agenticv1alpha1.DiagnosisResult{
-				Summary: "OOM", Confidence: "High", RootCause: "Low limit",
+				Summary: "OOM", RootCause: "Low limit",
 			},
 			RemediationPlan: agenticv1alpha1.RemediationPlan{
 				Description: "Increase to 512Mi",
 				Actions:     []agenticv1alpha1.ProposedAction{{Command: "kubectl patch deployment/web -n production -p '{}'", Type: "mutation", Description: "Patch deploy"}},
-				Risk:        "Low",
 				Reversible:  agenticv1alpha1.ReversibilityReversible,
 			},
 			RBAC: agenticv1alpha1.RBACResult{
@@ -930,12 +929,11 @@ func TestReconcile_ExecutionRBACCleanedOnFailure(t *testing.T) {
 		Options: []agenticv1alpha1.RemediationOption{{
 			Title: "Fix it",
 			Diagnosis: agenticv1alpha1.DiagnosisResult{
-				Summary: "Broken", Confidence: "High", RootCause: "Bug",
+				Summary: "Broken", RootCause: "Bug",
 			},
 			RemediationPlan: agenticv1alpha1.RemediationPlan{
 				Description: "Apply fix",
 				Actions:     []agenticv1alpha1.ProposedAction{{Command: "kubectl patch deployment/web -n production -p '{}'", Type: "mutation", Description: "Patch"}},
-				Risk:        "Low",
 				Reversible:  agenticv1alpha1.ReversibilityReversible,
 			},
 			RBAC: agenticv1alpha1.RBACResult{
@@ -988,14 +986,12 @@ func TestFullLifecycle_WithSandboxAgent(t *testing.T) {
 		Options: []agenticv1alpha1.RemediationOption{{
 			Title: "Increase memory limit",
 			Diagnosis: agenticv1alpha1.DiagnosisResult{
-				Summary:    "Pod OOMKilled due to 256Mi memory limit",
-				Confidence: "High",
-				RootCause:  "Memory limit too low for workload",
+				Summary:   "Pod OOMKilled due to 256Mi memory limit",
+				RootCause: "Memory limit too low for workload",
 			},
 			RemediationPlan: agenticv1alpha1.RemediationPlan{
 				Description: "Increase deployment memory limit to 512Mi",
 				Actions:     []agenticv1alpha1.ProposedAction{{Command: "kubectl set resources deployment/web -n production --limits=memory=512Mi", Type: "mutation", Description: "Patch deployment memory limit"}},
-				Risk:        "Low",
 				Reversible:  agenticv1alpha1.ReversibilityReversible,
 			},
 		}},
@@ -1056,9 +1052,6 @@ func TestFullLifecycle_WithSandboxAgent(t *testing.T) {
 	}
 	if ar.Status.Options[0].Title != "Increase memory limit" {
 		t.Errorf("option title = %q", ar.Status.Options[0].Title)
-	}
-	if ar.Status.Options[0].Diagnosis.Confidence != "High" {
-		t.Errorf("confidence = %q", ar.Status.Options[0].Diagnosis.Confidence)
 	}
 
 	// Approve

--- a/controller/agenticrun/results.go
+++ b/controller/agenticrun/results.go
@@ -112,7 +112,7 @@ func (r *AgenticRunReconciler) createAnalysisResult(
 	if result != nil {
 		cr.Status.Options = result.Options
 		cr.Status.ActionRequired = agenticv1alpha1.ActionRequiredFromBool(result.IsActionRequired())
-		if result.Diagnosis != nil && result.Diagnosis.Summary != "" && result.Diagnosis.RootCause != "" && result.Diagnosis.Confidence != "" {
+		if result.Diagnosis != nil && result.Diagnosis.Summary != "" && result.Diagnosis.RootCause != "" {
 			cr.Status.Diagnosis = *result.Diagnosis
 		}
 	}

--- a/controller/agenticrun/results_test.go
+++ b/controller/agenticrun/results_test.go
@@ -199,10 +199,9 @@ func TestCreateAnalysisResult_EmptyTopLevelDiagnosis(t *testing.T) {
 		name      string
 		diagnosis *agenticv1alpha1.DiagnosisResult
 	}{
-		{"both empty", &agenticv1alpha1.DiagnosisResult{Confidence: agenticv1alpha1.ConfidenceLevelLow, RootCause: "", Summary: ""}},
-		{"summary only empty", &agenticv1alpha1.DiagnosisResult{Confidence: agenticv1alpha1.ConfidenceLevelLow, RootCause: "some cause", Summary: ""}},
-		{"rootCause only empty", &agenticv1alpha1.DiagnosisResult{Confidence: agenticv1alpha1.ConfidenceLevelLow, RootCause: "", Summary: "some summary"}},
-		{"confidence empty", &agenticv1alpha1.DiagnosisResult{Confidence: "", RootCause: "some cause", Summary: "some summary"}},
+		{"both empty", &agenticv1alpha1.DiagnosisResult{RootCause: "", Summary: ""}},
+		{"summary only empty", &agenticv1alpha1.DiagnosisResult{RootCause: "some cause", Summary: ""}},
+		{"rootCause only empty", &agenticv1alpha1.DiagnosisResult{RootCause: "", Summary: "some summary"}},
 	}
 
 	for _, tc := range cases {
@@ -222,14 +221,12 @@ func TestCreateAnalysisResult_EmptyTopLevelDiagnosis(t *testing.T) {
 				Options: []agenticv1alpha1.RemediationOption{{
 					Title: "Increase connection pool limits",
 					Diagnosis: agenticv1alpha1.DiagnosisResult{
-						Confidence: agenticv1alpha1.ConfidenceLevelHigh,
-						RootCause:  "reporting-service v1.0.2 opens a new PostgreSQL transaction every 10s",
-						Summary:    "PostgresqlTooManyConnections is firing in payments",
+						RootCause: "reporting-service v1.0.2 opens a new PostgreSQL transaction every 10s",
+						Summary:   "PostgresqlTooManyConnections is firing in payments",
 					},
 					RemediationPlan: agenticv1alpha1.RemediationPlan{
 						Description: "Increase max_connections",
 						Actions:     []agenticv1alpha1.ProposedAction{{Command: "kubectl patch", Type: "patch", Description: "Patch configmap"}},
-						Risk:        agenticv1alpha1.RiskLevelLow,
 					},
 				}},
 			}
@@ -246,9 +243,8 @@ func TestCreateAnalysisResult_EmptyTopLevelDiagnosis(t *testing.T) {
 				t.Fatalf("createAnalysisResult: %v", err)
 			}
 
-			if snapshot.Status.Diagnosis.Summary != "" || snapshot.Status.Diagnosis.RootCause != "" || snapshot.Status.Diagnosis.Confidence != "" {
-				t.Errorf("expected zero-value diagnosis in status, got confidence=%q summary=%q rootCause=%q",
-					snapshot.Status.Diagnosis.Confidence,
+			if snapshot.Status.Diagnosis.Summary != "" || snapshot.Status.Diagnosis.RootCause != "" {
+				t.Errorf("expected zero-value diagnosis in status, got summary=%q rootCause=%q",
 					snapshot.Status.Diagnosis.Summary,
 					snapshot.Status.Diagnosis.RootCause)
 			}

--- a/controller/agenticrun/sandbox_agent.go
+++ b/controller/agenticrun/sandbox_agent.go
@@ -93,7 +93,7 @@ func (s *SandboxAgentCaller) Analyze(ctx context.Context, run *agenticv1alpha1.A
 		}
 	}
 
-	if resp.Diagnosis != nil && (resp.Diagnosis.Summary == "" || resp.Diagnosis.RootCause == "" || resp.Diagnosis.Confidence == "") {
+	if resp.Diagnosis != nil && (resp.Diagnosis.Summary == "" || resp.Diagnosis.RootCause == "") {
 		log.Info("ignoring empty top-level diagnosis (per-option diagnoses used instead)", "run", run.Name)
 		resp.Diagnosis = nil
 	}

--- a/controller/agenticrun/sandbox_agent_test.go
+++ b/controller/agenticrun/sandbox_agent_test.go
@@ -101,7 +101,7 @@ func TestSandboxAgentCaller_Analyze_HappyPath(t *testing.T) {
 	sandbox := &mockSandboxProvider{claimName: "ls-analysis-fix-crash", endpoint: "http://sandbox:8080"}
 	httpClient := &mockHTTPClient{
 		response: &agentRunResponse{
-			Response: json.RawMessage(`{"success": true, "options": [{"title": "Increase memory", "diagnosis": {"summary": "OOM", "confidence": "High", "rootCause": "memory limit"}, "run": {"description": "Bump memory", "actions": [{"type": "patch", "description": "patch deploy"}], "risk": "Low"}}]}`),
+			Response: json.RawMessage(`{"success": true, "options": [{"title": "Increase memory", "diagnosis": {"summary": "OOM", "rootCause": "memory limit"}, "run": {"description": "Bump memory", "actions": [{"type": "patch", "description": "patch deploy"}]}}]}`),
 		},
 	}
 
@@ -115,9 +115,6 @@ func TestSandboxAgentCaller_Analyze_HappyPath(t *testing.T) {
 	}
 	if result.Options[0].Title != "Increase memory" {
 		t.Errorf("title = %q", result.Options[0].Title)
-	}
-	if result.Options[0].Diagnosis.Confidence != "High" {
-		t.Errorf("confidence = %q", result.Options[0].Diagnosis.Confidence)
 	}
 }
 
@@ -411,10 +408,9 @@ func TestSandboxAgentCaller_Analyze_EmptyTopLevelDiagnosis(t *testing.T) {
 		name      string
 		diagnosis string
 	}{
-		{"both empty", `{"confidence": "Low", "rootCause": "", "summary": ""}`},
-		{"summary only empty", `{"confidence": "Low", "rootCause": "some cause", "summary": ""}`},
-		{"rootCause only empty", `{"confidence": "Low", "rootCause": "", "summary": "some summary"}`},
-		{"confidence empty", `{"confidence": "", "rootCause": "some cause", "summary": "some summary"}`},
+		{"both empty", `{"rootCause": "", "summary": ""}`},
+		{"summary only empty", `{"rootCause": "some cause", "summary": ""}`},
+		{"rootCause only empty", `{"rootCause": "", "summary": "some summary"}`},
 	}
 
 	for _, tc := range cases {
@@ -428,8 +424,8 @@ func TestSandboxAgentCaller_Analyze_EmptyTopLevelDiagnosis(t *testing.T) {
 						"diagnosis": %s,
 						"options": [{
 							"title": "Increase connection pool limits",
-							"diagnosis": {"confidence": "High", "rootCause": "reporting-service opens too many connections", "summary": "PostgresqlTooManyConnections firing"},
-							"remediationPlan": {"description": "Increase limits", "actions": [{"command": "kubectl patch", "type": "patch", "description": "patch configmap"}], "risk": "Low"}
+							"diagnosis": {"rootCause": "reporting-service opens too many connections", "summary": "PostgresqlTooManyConnections firing"},
+							"remediationPlan": {"description": "Increase limits", "actions": [{"command": "kubectl patch", "type": "patch", "description": "patch configmap"}]}
 						}]
 					}`, tc.diagnosis)),
 				},
@@ -489,7 +485,6 @@ func TestSandboxAgentCaller_ExecutionQueryFraming(t *testing.T) {
 		RemediationPlan: agenticv1alpha1.RemediationPlan{
 			Description: "Patch deployment memory",
 			Actions:     []agenticv1alpha1.ProposedAction{{Command: "kubectl set resources deployment/web -n production --limits=memory=512Mi", Type: "mutation", Description: "Set memory to 512Mi"}},
-			Risk:        "Low",
 		},
 	}
 	run := testSandboxAgenticRun()
@@ -565,7 +560,7 @@ func TestSandboxAgentCaller_Analyze_PatchesSandboxInfo(t *testing.T) {
 	sandbox := &mockSandboxProvider{claimName: "ls-analysis-fix-crash", endpoint: "http://sandbox:8080"}
 	httpClient := &mockHTTPClient{
 		response: &agentRunResponse{
-			Response: json.RawMessage(`{"success": true, "options": [{"title": "Fix it", "diagnosis": {"summary": "broken", "confidence": "High", "rootCause": "bug"}, "run": {"description": "fix", "actions": [{"type": "patch", "description": "patch"}], "risk": "Low"}}]}`),
+			Response: json.RawMessage(`{"success": true, "options": [{"title": "Fix it", "diagnosis": {"summary": "broken", "rootCause": "bug"}, "run": {"description": "fix", "actions": [{"type": "patch", "description": "patch"}]}}]}`),
 		},
 	}
 

--- a/controller/agenticrun/schemas.go
+++ b/controller/agenticrun/schemas.go
@@ -23,10 +23,9 @@ var AnalysisOutputSchema = json.RawMessage(`{
       "description": "Top-level root cause analysis. Required when actionRequired is false. When actionRequired is true, diagnosis is provided per-option instead.",
       "properties": {
         "summary": { "type": "string", "description": "Markdown-formatted diagnosis summary explaining the problem, symptoms, and findings" },
-        "confidence": { "type": "string", "enum": ["Low", "Medium", "High"], "description": "Your confidence in this diagnosis" },
         "rootCause": { "type": "string", "description": "Concise one-line root cause" }
       },
-      "required": ["summary", "confidence", "rootCause"]
+      "required": ["summary", "rootCause"]
     },
     "options": {
       "type": "array",
@@ -41,10 +40,9 @@ var AnalysisOutputSchema = json.RawMessage(`{
             "type": "object",
             "properties": {
               "summary": { "type": "string", "description": "Markdown-formatted root cause analysis explaining the problem, symptoms, and findings" },
-              "confidence": { "type": "string", "enum": ["Low", "Medium", "High"], "description": "Your confidence in this diagnosis. Low: ambiguous symptoms. Medium: likely cause identified. High: clear, deterministic root cause" },
               "rootCause": { "type": "string", "description": "Concise one-line root cause (e.g., 'OOMKilled due to memory limit of 256Mi')" }
             },
-            "required": ["summary", "confidence", "rootCause"]
+            "required": ["summary", "rootCause"]
           },
           "remediationPlan": {
             "type": "object",
@@ -63,7 +61,6 @@ var AnalysisOutputSchema = json.RawMessage(`{
                   "required": ["command", "type", "description"]
                 }
               },
-              "risk": { "type": "string", "enum": ["Low", "Medium", "High", "Critical"], "description": "Risk assessment. Low: safe to apply. Medium: review recommended. High: careful review required. Critical: manual approval strongly recommended" },
               "reversible": { "type": "string", "enum": ["Reversible", "Irreversible", "Partial"], "description": "Whether this remediation can be rolled back. Reversible: fully undoable. Irreversible: cannot undo. Partial: some actions undoable" },
               "rollbackPlan": {
                 "type": "object",
@@ -75,7 +72,7 @@ var AnalysisOutputSchema = json.RawMessage(`{
                 "required": ["description", "command"]
               }
             },
-            "required": ["description", "actions", "risk", "reversible"]
+            "required": ["description", "actions", "reversible"]
           },
           "verification": {
             "type": "object",
@@ -159,10 +156,9 @@ var MinimalAnalysisOutputSchema = json.RawMessage(`{
       "description": "Top-level root cause analysis. Required when actionRequired is false.",
       "properties": {
         "summary": { "type": "string", "description": "Markdown-formatted diagnosis summary" },
-        "confidence": { "type": "string", "enum": ["Low", "Medium", "High"], "description": "Your confidence in this diagnosis" },
         "rootCause": { "type": "string", "description": "Concise one-line root cause" }
       },
-      "required": ["summary", "confidence", "rootCause"]
+      "required": ["summary", "rootCause"]
     },
     "options": {
       "type": "array",

--- a/controller/agenticrun/schemas_test.go
+++ b/controller/agenticrun/schemas_test.go
@@ -391,7 +391,7 @@ func TestAnalysisOutputSchema_ActionRequiredAndDiagnosis(t *testing.T) {
 		t.Fatal("schema missing diagnosis property")
 	}
 	diagProps := diag.(map[string]any)["properties"].(map[string]any)
-	for _, key := range []string{"summary", "confidence", "rootCause"} {
+	for _, key := range []string{"summary", "rootCause"} {
 		if _, ok := diagProps[key]; !ok {
 			t.Errorf("diagnosis missing property %q", key)
 		}

--- a/controller/agenticrun/state_machine_test.go
+++ b/controller/agenticrun/state_machine_test.go
@@ -1072,9 +1072,8 @@ func TestNoActionRequired_TerminalWithoutExecution(t *testing.T) {
 		Success:        true,
 		ActionRequired: ptr.To(false),
 		Diagnosis: &agenticv1alpha1.DiagnosisResult{
-			Summary:    "Alert is a false alarm — pod restarted once due to a transient OOM but has been stable since",
-			Confidence: "High",
-			RootCause:  "Transient OOM, already self-healed",
+			Summary:   "Alert is a false alarm — pod restarted once due to a transient OOM but has been stable since",
+			RootCause: "Transient OOM, already self-healed",
 		},
 	}
 	r, fc := newReconcilerWithPolicy(t, run, agent, testAutoApprovePolicy())
@@ -1097,10 +1096,6 @@ func TestNoActionRequired_TerminalWithoutExecution(t *testing.T) {
 	if ar.Status.Diagnosis.Summary == "" {
 		t.Fatal("expected Diagnosis to be set")
 	}
-	if ar.Status.Diagnosis.Confidence != "High" {
-		t.Errorf("Diagnosis.Confidence = %q, want High", ar.Status.Diagnosis.Confidence)
-	}
-
 	// Execution and verification should never have run
 	if len(p.Status.Steps.Execution.Results) != 0 {
 		t.Error("execution should not have run")
@@ -1122,9 +1117,8 @@ func TestNoActionRequired_RevisionTriggersReanalysis(t *testing.T) {
 		Success:        true,
 		ActionRequired: ptr.To(false),
 		Diagnosis: &agenticv1alpha1.DiagnosisResult{
-			Summary:    "False alarm",
-			Confidence: "Medium",
-			RootCause:  "Transient issue",
+			Summary:   "False alarm",
+			RootCause: "Transient issue",
 		},
 	}
 	r, fc := newReconcilerWithPolicy(t, run, agent, testAutoApprovePolicy())
@@ -1141,12 +1135,11 @@ func TestNoActionRequired_RevisionTriggersReanalysis(t *testing.T) {
 		Options: []agenticv1alpha1.RemediationOption{{
 			Title: "Increase memory",
 			Diagnosis: agenticv1alpha1.DiagnosisResult{
-				Summary: "OOM", Confidence: "High", RootCause: "Low limit",
+				Summary: "OOM", RootCause: "Low limit",
 			},
 			RemediationPlan: agenticv1alpha1.RemediationPlan{
 				Description: "Increase to 512Mi",
 				Actions:     []agenticv1alpha1.ProposedAction{{Command: "kubectl patch deploy/web -n production -p '{}'", Type: "mutation", Description: "Patch"}},
-				Risk:        "Low",
 				Reversible:  agenticv1alpha1.ReversibilityReversible,
 			},
 		}},
@@ -1173,12 +1166,11 @@ func TestNoActionRequired_NilActionRequiredDefaultsToTrue(t *testing.T) {
 		Options: []agenticv1alpha1.RemediationOption{{
 			Title: "Increase memory",
 			Diagnosis: agenticv1alpha1.DiagnosisResult{
-				Summary: "OOM", Confidence: "High", RootCause: "Low limit",
+				Summary: "OOM", RootCause: "Low limit",
 			},
 			RemediationPlan: agenticv1alpha1.RemediationPlan{
 				Description: "Increase to 512Mi",
 				Actions:     []agenticv1alpha1.ProposedAction{{Command: "kubectl patch deploy/web -n production -p '{}'", Type: "mutation", Description: "Patch"}},
-				Risk:        "Low",
 				Reversible:  agenticv1alpha1.ReversibilityReversible,
 			},
 		}},

--- a/controller/agenticrun/templates/analysis_query.tmpl
+++ b/controller/agenticrun/templates/analysis_query.tmpl
@@ -4,7 +4,7 @@ You have `kubectl` and `oc` available for read-only inspection (get, describe, l
 
 When more than one solution exists, propose multiple remediation options. For each option:
 
-- **Diagnose** the root cause with confidence level.
+- **Diagnose** the root cause.
 
 - **Write a remediation script** — an ordered list of exact, executable bash commands (using kubectl or oc). Each action must be a concrete command that you can copy-paste and run. Do NOT write a description of what to do. Include the FULL sequence of operations:
    - Mutations: the actual fix commands
@@ -43,7 +43,7 @@ When more than one solution exists, propose multiple remediation options. For ea
 - **Verification plan** — checks to confirm the fix worked.
 {{- end}}
 
-- **Risk assessment** and reversibility.
+- **Reversibility** assessment.
 
 ## Request
 

--- a/controller/agenticrun/templates/revision_context.tmpl
+++ b/controller/agenticrun/templates/revision_context.tmpl
@@ -8,5 +8,5 @@ This is a revised analysis for agentic run "{{.AgenticRunName}}" in namespace "{
 
 Review the current analysis options and the user's feedback, then produce updated remediation
 options that address the user's request.
-If you disagree with the user's suggestion, return multiple options: one following their request
-and one with your recommendation, with clear explanations and appropriate risk/confidence levels.
+If you disagree with the user's suggestion, return multiple options.
+Include one option that follows their request and one with your recommendation.

--- a/test/agent/main.go
+++ b/test/agent/main.go
@@ -246,7 +246,6 @@ func cannedResponse(phase, targetNS string) []byte {
       "summary": "mock option summary",
       "diagnosis": {
         "summary": "mock diagnosis",
-        "confidence": "High",
         "rootCause": "mock root cause"
       },
       "remediationPlan": {
@@ -256,7 +255,6 @@ func cannedResponse(phase, targetNS string) []byte {
           { "command": "kubectl patch configmap mock-cm -n %s -p '{\"data\":{\"key\":\"value\"}}'", "type": "mutation", "description": "Patch configmap with fix" },
           { "command": "kubectl get configmap mock-cm -n %s -o jsonpath='{.data.key}'", "type": "post-check", "description": "Verify configmap was patched" }
         ],
-        "risk": "Low",
         "reversible": "Reversible"
       },
       "verification": {


### PR DESCRIPTION
## Summary

- Make `DiagnosisResult.Confidence` and `RemediationPlan.Risk` CRD fields optional (remove `+required` markers)
- Remove confidence/risk from LLM output schemas so the agent no longer produces these values
- Remove confidence/risk from prompt templates (`analysis_query.tmpl`, `revision_context.tmpl`)
- Update validation, stub agent, mock agent, and all test fixtures
- Type definitions (`ConfidenceLevel`, `RiskLevel`) kept for backward compatibility

Legal requirement: AIA TG-03 prohibits displaying LLM-self-assessed confidence/risk scores to users.

## Test plan

- [x] `make manifests` — CRD regenerated, confidence/risk no longer required
- [x] `make test` — all unit tests pass
- [x] `make api-lint` — passes
- [x] `make fmt` / `make vet` — clean
- [x] Deployed to cluster, verified AnalysisResult CRs no longer contain confidence/risk

## Jira

https://redhat.atlassian.net/browse/OLS-3811

🤖 Generated with [Claude Code](https://claude.com/claude-code)