### PR TITLE
OLS-3781: Give verification agent retry autonomy for convergence-dependent checks

### DIFF
--- a/controller/agenticrun/client.go
+++ b/controller/agenticrun/client.go
@@ -70,7 +70,7 @@ type agentRunResponse struct {
 
 // AgentHTTPClientInterface abstracts HTTP calls to the agent service for testability.
 type AgentHTTPClientInterface interface {
-	Run(ctx context.Context, systemPrompt, query string, outputSchema json.RawMessage, agentCtx *agentContext, extraHeaders http.Header) (*agentRunResponse, error)
+	Run(ctx context.Context, systemPrompt, query string, outputSchema json.RawMessage, agentCtx *agentContext, extraHeaders http.Header, timeout time.Duration) (*agentRunResponse, error)
 }
 
 // AgentHTTPClient communicates with the agentic-sandbox REST API.
@@ -79,10 +79,10 @@ type AgentHTTPClient struct {
 	endpoint   string
 }
 
-func NewAgentHTTPClient(endpoint string) AgentHTTPClientInterface {
+func NewAgentHTTPClient(endpoint string, timeout time.Duration) AgentHTTPClientInterface {
 	return &AgentHTTPClient{
 		httpClient: &http.Client{
-			Timeout: 5 * time.Minute,
+			Timeout: timeout,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // internal cluster traffic
 			},
@@ -91,12 +91,18 @@ func NewAgentHTTPClient(endpoint string) AgentHTTPClientInterface {
 	}
 }
 
-func (c *AgentHTTPClient) Run(ctx context.Context, systemPrompt, query string, outputSchema json.RawMessage, agentCtx *agentContext, extraHeaders http.Header) (*agentRunResponse, error) {
+func (c *AgentHTTPClient) Run(ctx context.Context, systemPrompt, query string, outputSchema json.RawMessage, agentCtx *agentContext, extraHeaders http.Header, timeout time.Duration) (*agentRunResponse, error) {
+	var timeoutMs *int64
+	if timeout > 0 {
+		ms := timeout.Milliseconds()
+		timeoutMs = &ms
+	}
 	req := agentRunRequest{
 		Query:        query,
 		SystemPrompt: systemPrompt,
 		OutputSchema: outputSchema,
 		Context:      agentCtx,
+		TimeoutMs:    timeoutMs,
 	}
 
 	body, err := json.Marshal(req)

--- a/controller/agenticrun/client_test.go
+++ b/controller/agenticrun/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
@@ -29,14 +30,20 @@ func TestAgentHTTPClient_RunSuccess(t *testing.T) {
 		if req.SystemPrompt != "You are an SRE agent" {
 			t.Errorf("expected systemPrompt='You are an SRE agent', got %q", req.SystemPrompt)
 		}
+		if req.TimeoutMs == nil {
+			t.Fatal("expected timeout_ms to be set")
+		}
+		if *req.TimeoutMs != int64(5*time.Minute/time.Millisecond) {
+			t.Errorf("expected timeout_ms=%d, got %d", int64(5*time.Minute/time.Millisecond), *req.TimeoutMs)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"options": [{"title": "Fix it"}]}`))
 	}))
 	defer server.Close()
 
-	client := NewAgentHTTPClient(server.URL)
-	resp, err := client.Run(context.Background(), "You are an SRE agent", "check health", nil, nil, nil)
+	client := NewAgentHTTPClient(server.URL, 5*time.Minute)
+	resp, err := client.Run(context.Background(), "You are an SRE agent", "check health", nil, nil, nil, 5*time.Minute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -52,16 +59,16 @@ func TestAgentHTTPClient_RunHTTPError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAgentHTTPClient(server.URL)
-	_, err := client.Run(context.Background(), "", "test", nil, nil, nil)
+	client := NewAgentHTTPClient(server.URL, 5*time.Minute)
+	_, err := client.Run(context.Background(), "", "test", nil, nil, nil, 5*time.Minute)
 	if err == nil {
 		t.Fatal("expected error for HTTP 500")
 	}
 }
 
 func TestAgentHTTPClient_RunConnectionError(t *testing.T) {
-	client := NewAgentHTTPClient("http://127.0.0.1:1")
-	_, err := client.Run(context.Background(), "", "test", nil, nil, nil)
+	client := NewAgentHTTPClient("http://127.0.0.1:1", 5*time.Minute)
+	_, err := client.Run(context.Background(), "", "test", nil, nil, nil, 5*time.Minute)
 	if err == nil {
 		t.Fatal("expected error for connection failure")
 	}
@@ -100,7 +107,7 @@ func TestAgentHTTPClient_RunWithExecutionResult(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAgentHTTPClient(server.URL)
+	client := NewAgentHTTPClient(server.URL, 5*time.Minute)
 	agentCtx := &agentContext{
 		TargetNamespaces: []string{"production"},
 		ExecutionResult: &agentExecutionResult{
@@ -114,7 +121,7 @@ func TestAgentHTTPClient_RunWithExecutionResult(t *testing.T) {
 			},
 		},
 	}
-	_, err := client.Run(context.Background(), "", "test", nil, agentCtx, nil)
+	_, err := client.Run(context.Background(), "", "test", nil, agentCtx, nil, 5*time.Minute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -135,11 +142,11 @@ func TestAgentHTTPClient_RunWithoutExecutionResult(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAgentHTTPClient(server.URL)
+	client := NewAgentHTTPClient(server.URL, 5*time.Minute)
 	agentCtx := &agentContext{
 		TargetNamespaces: []string{"production"},
 	}
-	_, err := client.Run(context.Background(), "", "test", nil, agentCtx, nil)
+	_, err := client.Run(context.Background(), "", "test", nil, agentCtx, nil, 5*time.Minute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -169,12 +176,12 @@ func TestAgentHTTPClient_RunWithContext(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewAgentHTTPClient(server.URL)
+	client := NewAgentHTTPClient(server.URL, 5*time.Minute)
 	agentCtx := &agentContext{
 		TargetNamespaces: []string{"production"},
 		PreviousAttempts: []agentPreviousAttempt{{Attempt: 1, FailureReason: "timeout"}},
 	}
-	_, err := client.Run(context.Background(), "", "test", nil, agentCtx, nil)
+	_, err := client.Run(context.Background(), "", "test", nil, agentCtx, nil, 5*time.Minute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/controller/agenticrun/reconciler_test.go
+++ b/controller/agenticrun/reconciler_test.go
@@ -262,14 +262,13 @@ func newMockSandboxAgent(analysisJSON, executionJSON, verificationJSON string) (
 	caller := &SandboxAgentCaller{
 		Sandbox:   sandbox,
 		K8sClient: fc,
-		ClientFactory: func(_ string) AgentHTTPClientInterface {
+		ClientFactory: func(_ string, _ time.Duration) AgentHTTPClientInterface {
 			resp := responses[callCount%len(responses)]
 			callCount++
 			httpClient.response = &agentRunResponse{Response: json.RawMessage(resp)}
 			return httpClient
 		},
 		Namespace: "test-ns",
-		Timeout:   5 * time.Minute,
 	}
 	return caller, sandbox
 }

--- a/controller/agenticrun/revision_test.go
+++ b/controller/agenticrun/revision_test.go
@@ -92,6 +92,12 @@ func TestBuildAnalysisQuery_FullAgenticRun(t *testing.T) {
 	if !strings.Contains(result, "Verification plan") {
 		t.Error("full run should mention verification plan")
 	}
+	if !strings.Contains(result, "read-only cluster access") {
+		t.Error("full run should constrain verification to read-only commands")
+	}
+	if !strings.Contains(result, "Expected must be an exact observable value") {
+		t.Error("full run should require exact verification Expected values")
+	}
 	if !strings.Contains(result, "Fix the crash") {
 		t.Error("should contain the request text")
 	}

--- a/controller/agenticrun/sandbox_agent.go
+++ b/controller/agenticrun/sandbox_agent.go
@@ -17,6 +17,10 @@ import (
 const (
 	defaultSandboxTimeout = 5 * time.Minute
 
+	analysisStepTimeout     = 10 * time.Minute
+	executionStepTimeout    = 10 * time.Minute
+	verificationStepTimeout = 30 * time.Minute
+
 	ErrAnalysisAgentCall         = "analysis agent call"
 	ErrParseAnalysisResponse     = "parse analysis response"
 	ErrExecutionAgentCall        = "execution agent call"
@@ -52,7 +56,7 @@ type verificationResponse struct {
 
 // SandboxLifecycle is the interface for sandbox create/wait/release.
 type SandboxLifecycle interface {
-	Create(ctx context.Context, run *agenticv1alpha1.AgenticRun, step string, agent *agenticv1alpha1.Agent, llm *agenticv1alpha1.LLMProvider, tools *agenticv1alpha1.ToolsSpec, serviceAccount string) (string, error)
+	Create(ctx context.Context, run *agenticv1alpha1.AgenticRun, step string, agent *agenticv1alpha1.Agent, llm *agenticv1alpha1.LLMProvider, tools *agenticv1alpha1.ToolsSpec, serviceAccount string, deadline time.Duration) (string, error)
 	WaitReady(ctx context.Context, name string, timeout time.Duration) (endpoint string, err error)
 	Release(ctx context.Context, name string) error
 }
@@ -62,9 +66,8 @@ type SandboxLifecycle interface {
 type SandboxAgentCaller struct {
 	Sandbox       SandboxLifecycle
 	K8sClient     client.Client
-	ClientFactory func(endpoint string) AgentHTTPClientInterface
+	ClientFactory func(endpoint string, timeout time.Duration) AgentHTTPClientInterface
 	Namespace     string
-	Timeout       time.Duration
 	Audit         AuditLogger
 }
 
@@ -188,6 +191,19 @@ func (s *SandboxAgentCaller) Escalate(ctx context.Context, run *agenticv1alpha1.
 	}, nil
 }
 
+func stepTimeout(step string) time.Duration {
+	switch step {
+	case "analysis", "escalation":
+		return analysisStepTimeout
+	case "execution":
+		return executionStepTimeout
+	case "verification":
+		return verificationStepTimeout
+	default:
+		return analysisStepTimeout
+	}
+}
+
 func (s *SandboxAgentCaller) callWithSandbox(
 	ctx context.Context,
 	run *agenticv1alpha1.AgenticRun,
@@ -197,19 +213,17 @@ func (s *SandboxAgentCaller) callWithSandbox(
 	agentCtx *agentContext,
 	serviceAccount string,
 ) (json.RawMessage, error) {
-	name, err := s.Sandbox.Create(ctx, run, stepName, step.Agent, step.LLM, step.Tools, serviceAccount)
+	agentTimeout := stepTimeout(stepName)
+	podDeadline := agentTimeout + defaultSandboxTimeout
+
+	name, err := s.Sandbox.Create(ctx, run, stepName, step.Agent, step.LLM, step.Tools, serviceAccount, podDeadline)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", ErrClaimSandbox, err)
 	}
 
 	s.patchSandboxInfo(ctx, run, stepName, name)
 
-	timeout := s.Timeout
-	if timeout == 0 {
-		timeout = defaultSandboxTimeout
-	}
-
-	endpoint, err := s.Sandbox.WaitReady(ctx, name, timeout)
+	endpoint, err := s.Sandbox.WaitReady(ctx, name, defaultSandboxTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", ErrWaitForSandbox, err)
 	}
@@ -227,8 +241,8 @@ func (s *SandboxAgentCaller) callWithSandbox(
 		s.Audit.InjectTraceContext(ctx, run, headers)
 	}
 
-	client := s.ClientFactory(agentURL)
-	resp, err := client.Run(ctx, "", query, schema, agentCtx, headers)
+	client := s.ClientFactory(agentURL, podDeadline)
+	resp, err := client.Run(ctx, "", query, schema, agentCtx, headers, agentTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/agenticrun/sandbox_agent_test.go
+++ b/controller/agenticrun/sandbox_agent_test.go
@@ -28,7 +28,7 @@ type mockSandboxProvider struct {
 	releaseCalls int
 }
 
-func (m *mockSandboxProvider) Create(_ context.Context, _ *agenticv1alpha1.AgenticRun, _ string, _ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec, _ string) (string, error) {
+func (m *mockSandboxProvider) Create(_ context.Context, _ *agenticv1alpha1.AgenticRun, _ string, _ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec, _ string, _ time.Duration) (string, error) {
 	m.claimCalls++
 	return m.claimName, m.claimErr
 }
@@ -48,7 +48,7 @@ type mockHTTPClient struct {
 	lastCtx    *agentContext
 }
 
-func (m *mockHTTPClient) Run(_ context.Context, systemPrompt, query string, _ json.RawMessage, agentCtx *agentContext, _ http.Header) (*agentRunResponse, error) {
+func (m *mockHTTPClient) Run(_ context.Context, systemPrompt, query string, _ json.RawMessage, agentCtx *agentContext, _ http.Header, _ time.Duration) (*agentRunResponse, error) {
 	m.lastQuery = query
 	m.lastPrompt = systemPrompt
 	m.lastCtx = agentCtx
@@ -61,9 +61,8 @@ func newTestSandboxAgentCaller(sandbox *mockSandboxProvider, httpClient *mockHTT
 	return &SandboxAgentCaller{
 		Sandbox:       sandbox,
 		K8sClient:     fc,
-		ClientFactory: func(_ string) AgentHTTPClientInterface { return httpClient },
+		ClientFactory: func(_ string, _ time.Duration) AgentHTTPClientInterface { return httpClient },
 		Namespace:     "test-ns",
-		Timeout:       5 * time.Minute,
 	}
 }
 
@@ -76,9 +75,8 @@ func newTestSandboxAgentCallerWithAgenticRun(sandbox *mockSandboxProvider, httpC
 	return &SandboxAgentCaller{
 		Sandbox:       sandbox,
 		K8sClient:     fc,
-		ClientFactory: func(_ string) AgentHTTPClientInterface { return httpClient },
+		ClientFactory: func(_ string, _ time.Duration) AgentHTTPClientInterface { return httpClient },
 		Namespace:     "test-ns",
-		Timeout:       5 * time.Minute,
 	}
 }
 
@@ -540,6 +538,12 @@ func TestSandboxAgentCaller_VerificationQueryFraming(t *testing.T) {
 	if strings.Contains(httpClient.lastQuery, "Pod crashing with OOMKilled") {
 		t.Error("verification query should NOT contain the original request")
 	}
+	if !strings.Contains(httpClient.lastQuery, "Convergence-dependent checks") {
+		t.Error("verification query should contain convergence retry guidance")
+	}
+	if !strings.Contains(httpClient.lastQuery, "before you are permitted to report Failed") {
+		t.Error("verification query should instruct agent to retry convergence checks")
+	}
 }
 
 func TestSandboxAgentCaller_ExecutionQueryNilOption(t *testing.T) {
@@ -768,7 +772,7 @@ type trackingMockSandbox struct {
 	errOnClaim string
 }
 
-func (m *trackingMockSandbox) Create(_ context.Context, _ *agenticv1alpha1.AgenticRun, _ string, _ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec, _ string) (string, error) {
+func (m *trackingMockSandbox) Create(_ context.Context, _ *agenticv1alpha1.AgenticRun, _ string, _ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec, _ string, _ time.Duration) (string, error) {
 	return "", nil
 }
 func (m *trackingMockSandbox) WaitReady(_ context.Context, _ string, _ time.Duration) (string, error) {

--- a/controller/agenticrun/sandbox_manager.go
+++ b/controller/agenticrun/sandbox_manager.go
@@ -85,6 +85,7 @@ func (m *SandboxManager) Create(
 	llm *agenticv1alpha1.LLMProvider,
 	tools *agenticv1alpha1.ToolsSpec,
 	serviceAccount string,
+	deadline time.Duration,
 ) (string, error) {
 	cfg := m.config.Get()
 	if cfg == nil {
@@ -94,6 +95,11 @@ func (m *SandboxManager) Create(
 	podSpec, err := m.builder.Build(cfg.Sandbox.PodSpec, agent, llm, tools, &cfg.OTEL, step, string(run.UID), serviceAccount)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", errBuildPodSpec, err)
+	}
+
+	if deadline > 0 {
+		secs := int64(deadline.Seconds())
+		podSpec.ActiveDeadlineSeconds = &secs
 	}
 
 	name := truncateK8sName(fmt.Sprintf("ls-%s-%s", step, run.Name))

--- a/controller/agenticrun/sandbox_manager_test.go
+++ b/controller/agenticrun/sandbox_manager_test.go
@@ -100,7 +100,7 @@ func TestCreate_BarePod(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
 	mgr := newTestSandboxManager(fc, cache)
 
-	name, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa")
+	name, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -121,6 +121,12 @@ func TestCreate_BarePod(t *testing.T) {
 	if pod.OwnerReferences[0].Name != "test-run" {
 		t.Fatalf("expected owner name 'test-run', got %q", pod.OwnerReferences[0].Name)
 	}
+	if pod.Spec.ActiveDeadlineSeconds == nil {
+		t.Fatal("expected ActiveDeadlineSeconds to be set on pod")
+	}
+	if *pod.Spec.ActiveDeadlineSeconds != int64(15*time.Minute/time.Second) {
+		t.Fatalf("expected ActiveDeadlineSeconds=%d, got %d", int64(15*time.Minute/time.Second), *pod.Spec.ActiveDeadlineSeconds)
+	}
 }
 
 func TestCreate_SandboxClaim(t *testing.T) {
@@ -128,7 +134,7 @@ func TestCreate_SandboxClaim(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
 	mgr := newTestSandboxManager(fc, cache)
 
-	name, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa")
+	name, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -157,7 +163,7 @@ func TestCreate_ConfigNotAvailable(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
 	mgr := newTestSandboxManager(fc, cache)
 
-	_, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa")
+	_, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 	if err == nil {
 		t.Fatal("expected error when config is not available")
 	}
@@ -168,11 +174,11 @@ func TestCreate_Idempotent_BarePod(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
 	mgr := newTestSandboxManager(fc, cache)
 
-	name1, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa")
+	name1, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("first Create failed: %v", err)
 	}
-	name2, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa")
+	name2, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("second Create failed: %v", err)
 	}
@@ -186,11 +192,11 @@ func TestCreate_Idempotent_SandboxClaim(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
 	mgr := newTestSandboxManager(fc, cache)
 
-	name1, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa")
+	name1, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("first Create failed: %v", err)
 	}
-	name2, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa")
+	name2, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("second Create failed: %v", err)
 	}
@@ -205,7 +211,7 @@ func TestCreate_OTELEnvVars(t *testing.T) {
 	mgr := newTestSandboxManager(fc, cache)
 
 	run := testSMRun()
-	name, err := mgr.Create(context.Background(), run, "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa")
+	name, err := mgr.Create(context.Background(), run, "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -265,7 +271,7 @@ func TestCreate_NoOTEL_NoEnvVars(t *testing.T) {
 	fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
 	mgr := newTestSandboxManager(fc, cache)
 
-	name, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa")
+	name, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -288,7 +294,7 @@ func TestCreate_OTELEnvVars_SandboxClaim(t *testing.T) {
 	mgr := newTestSandboxManager(fc, cache)
 
 	run := testSMRun()
-	name, err := mgr.Create(context.Background(), run, "execution", testSMAgent(), testLLMForManager(), nil, "test-sa")
+	name, err := mgr.Create(context.Background(), run, "execution", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -332,6 +338,14 @@ func TestCreate_OTELEnvVars_SandboxClaim(t *testing.T) {
 	}
 	if v := envMap["OTEL_EXPORTER_OTLP_CERTIFICATE"]; v != otelCAMountPath+"/"+otelCASecretKey {
 		t.Fatalf("expected OTEL CA cert path in SandboxTemplate, got %q", v)
+	}
+
+	deadline, found, _ := unstructured.NestedInt64(tmpl.Object, "spec", "podTemplate", "spec", "activeDeadlineSeconds")
+	if !found {
+		t.Fatal("expected activeDeadlineSeconds in SandboxTemplate podTemplate spec")
+	}
+	if deadline != int64(15*time.Minute/time.Second) {
+		t.Fatalf("expected activeDeadlineSeconds=%d, got %d", int64(15*time.Minute/time.Second), deadline)
 	}
 }
 
@@ -439,7 +453,7 @@ func TestNamePrefix_LSPrefix(t *testing.T) {
 			fc := fake.NewClientBuilder().WithScheme(testScheme()).Build()
 			mgr := newTestSandboxManager(fc, cache)
 
-			name, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa")
+			name, err := mgr.Create(context.Background(), testSMRun(), "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 			if err != nil {
 				t.Fatalf("Create failed: %v", err)
 			}
@@ -458,7 +472,7 @@ func TestNamePrefix_LongNameTruncated(t *testing.T) {
 	longRun := testSMRun()
 	longRun.Name = "a-very-long-run-name-that-exceeds-sixty-three-characters-in-total-length"
 
-	name, err := mgr.Create(context.Background(), longRun, "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa")
+	name, err := mgr.Create(context.Background(), longRun, "analysis", testSMAgent(), testLLMForManager(), nil, "test-sa", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}

--- a/controller/agenticrun/templates/analysis_query.tmpl
+++ b/controller/agenticrun/templates/analysis_query.tmpl
@@ -1,6 +1,14 @@
-You are an analysis agent for OpenShift clusters. Diagnose the problem. Determine the root cause. Produce a remediation plan. A human will review and approve this plan before execution. Do NOT run commands that change the cluster state. You can only read. Write remediation commands for an execution agent to run after human approval.
+You are an analysis agent. Diagnose the problem. Determine the root cause. Produce a remediation plan. A human will review and approve this plan before execution. Do NOT run commands that change the cluster state. You can only read. Write remediation commands for an execution agent to run after human approval.
 
 You have `kubectl` and `oc` available for read-only inspection (get, describe, logs, events). Use them to inspect the cluster BEFORE you diagnose. Do not guess from local files.
+
+## Before diagnosing — determine the failure scope
+
+1. **Cross-service correlation**: Check whether other workloads in the affected namespace(s) show the same or similar errors. Compare event and log timestamps across services to identify correlated failure onset. Also check recent cluster events for infrastructure changes (node conditions, certificate renewals, network policy updates, operator upgrades). If multiple services fail with the same error class at once, the root cause is likely a shared dependency.
+2. **App vs infrastructure errors**: Distinguish application logic errors from infrastructure errors. Application: NPE, division by zero, assertion failures, panic. Infrastructure: connection refused, pool exhausted, timeout, OOM, disk pressure, certificate expired. Infrastructure errors require infrastructure-level fixes, not application rollbacks.
+3. **Trace the dependency graph**: Inspect environment variables, ConfigMaps, and connection strings to discover shared backends. These may reside in other namespaces. If affected workloads share a backend (database, cache, message bus, external API), check the backend's health first.
+
+Match your remediation and verification to the scope. Infrastructure problems need infrastructure-level fixes and checks. Application bugs need application-specific fixes and checks.
 
 When more than one solution exists, propose multiple remediation options. For each option:
 
@@ -10,7 +18,7 @@ When more than one solution exists, propose multiple remediation options. For ea
    - Mutations: the actual fix commands
    - Wait/status commands: commands to wait for changes to take effect (for example, `kubectl rollout status`, wait for pods to become ready)
 
-   Think step by step. Imagine you run this remediation by hand in a terminal. What commands do you run in sequence? Include ALL of them — not just the key mutation. For example, "scale a deployment" is not one command — it is: patch the replicas, then wait for new pods to become ready.
+   Think step by step. Imagine you run this remediation by hand in a terminal. What commands do you run in sequence? Include ALL of them — not just the key mutation. For example, "scale a deployment" is not one command. It is: patch the replicas, then wait for new pods to become ready.
 
    Good: kubectl set image deployment/foo container=registry/foo:v1.3 -n production
    Bad:  Update the deployment image to the latest version
@@ -40,7 +48,13 @@ When more than one solution exists, propose multiple remediation options. For ea
 {{- end}}
 {{- if .HasVerification}}
 
-- **Verification plan** — checks to confirm the fix worked.
+- **Verification plan** — checks to confirm the fix worked. The verification agent has **read-only cluster access** (get, list, watch only). Do NOT propose `exec`, `port-forward`, `cp`, `attach`, `proxy`, or `get --raw` to service proxy paths. These require escalated permissions the agent lacks. Use `oc get`, `oc describe`, `oc logs`, `oc get events`, or JSONPath queries. Do NOT query Prometheus, Thanos, or alerting endpoints. The agent cannot access `services/proxy`. Do NOT use a large `--tail` (for example `--tail=100`) for absence checks. Old pre-fix lines stay in that window and cause false failures. Use time-bounded logs (`--since=2m` / `--since=5m`) instead.
+
+   **Expected must be an exact observable value** from diagnosis. Do not use relative language.
+   Pin the concrete success criterion the command output must match.
+   Use an image tag, config value, replica count, or log substring.
+   - Good: `image is quay.io/example/app:v1.0.1`
+   - Bad: `image is no longer v1.0.2` / `rolled back to the prior revision`
 {{- end}}
 
 - **Risk assessment** and reversibility.

--- a/controller/agenticrun/templates/execution_query.tmpl
+++ b/controller/agenticrun/templates/execution_query.tmpl
@@ -1,4 +1,4 @@
-You are an execution agent for OpenShift clusters. Execute the approved remediation option below. Do not re-analyze the problem. Do not propose alternative solutions.
+You are an execution agent. Execute the approved remediation option below. Do not re-analyze the problem. Do not propose alternative solutions.
 
 The approved option contains a concrete remediation script — an ordered list of exact bash commands. Follow these rules:
 

--- a/controller/agenticrun/templates/verification_query.tmpl
+++ b/controller/agenticrun/templates/verification_query.tmpl
@@ -1,6 +1,28 @@
-You are a verification agent for OpenShift clusters. Verify that the executed remediation was applied correctly. Verify that the issue is resolved. Do not execute any additional changes. Only verify.
+You are a verification agent. Verify that the issue is resolved. Do not execute changes — only verify.
 
-Run the verification checks from the approved option's verification plan. Compare the current cluster state against the expected outcomes. Report each check as Passed or Failed with evidence.
+Run each check from the approved option's verification plan in order. Report every check as Passed or Failed with evidence.
+
+**Fix syntax errors only.** If a command fails due to a syntax error, fix the syntax and retry. Examples: malformed flag, wrong argument order. Do not change the intent, target, or resource of the command. Do not add checks beyond the verification plan.
+
+**Exception — log absence checks:** If a check asserts an error is gone, rewrite a large `--tail` to `--since=2m` or `--since=5m`. Example of a large tail: `--tail=100`. Large tails retain pre-fix lines and cause false failures. Keep the same resource and message. Only change the log window.
+
+### Convergence-dependent checks — MANDATORY RETRY RULES
+
+Some checks depend on cluster state that converges over time after a remediation: alerts clearing, pods becoming ready, metrics dropping, or error logs stopping.
+
+A result of "Failed" is INVALID for any convergence-dependent check unless you have exhausted the full retry budget below. Reporting a single-attempt failure for a convergence-dependent check is WRONG. There is no exception.
+
+RULE: For **alert checks** (alert stopped firing), you MUST wait 60 seconds and re-run the check at least 10 times (~10 minutes) before you are permitted to report Failed. Alerts have a `for` duration before they clear.
+
+RULE: For **pod readiness / rollout checks**, you MUST wait 30 seconds and re-run the check at least 10 times (~5 minutes) before you are permitted to report Failed. This includes: `rollout status`, deployment Available/Progressing conditions, ReplicaSet scaling, pod restarts settling, image pulls, init containers, and readiness probes. All of these add latency after a change is applied.
+
+RULE: For **metrics checks** (error rate below threshold), you MUST wait 60 seconds and re-run the check at least 10 times (~10 minutes) before you are permitted to report Failed. Metrics windows need time to reflect the new state.
+
+RULE: For **log-absence checks** (error message no longer appears), you MUST wait 2 minutes and then re-run the command with `--since=2m` at least 4 times (~10 minutes) before you are permitted to report Failed. After a fix, connections drain and processes restart. A single clean observation is not sufficient — you MUST observe at least one additional consecutive clean window to confirm the error has stopped, not merely paused.
+
+RULE: **Instant state checks** (image tag, config value, resource field) reflect immediately. Do not retry these.
+
+You MUST use the full retry budget. If a check passes on a later retry, report it as Passed. Only report Failed after all retries are exhausted, with the last observed output as evidence.
 
 ## Approved Option
 


### PR DESCRIPTION
## Summary

This PR improves agent prompt quality, timeout coordination, and sandbox pod lifecycle management.

### Verification agent retry autonomy

The verification query template now instructs the agent to autonomously retry convergence-dependent checks (alerts clearing, pods becoming ready, metrics stabilizing) within its sandbox session. Mandatory retry rules with specific cadences and minimum attempts are defined for alert checks (~10 min), pod readiness (~5 min), and metrics checks (~10 min). The agent is prohibited from reporting a single-attempt failure for convergence-dependent checks.

### Analysis and execution prompt improvements

- **Cross-service correlation**: Analysis agent now checks whether other workloads exhibit the same failure pattern and correlates timestamps across services before diagnosing.
- **App vs infrastructure classification**: Agent distinguishes application-logic errors from infrastructure errors and matches remediation scope accordingly.
- **Dependency graph tracing**: Agent inspects ConfigMaps, env vars, and connection strings to discover shared backends across namespaces.
- **Verification plan guardrails**: Verification plans are constrained to read-only operations the agent actually has access to (no `exec`, `port-forward`, `services/proxy`). Log absence checks use `--since` instead of large `--tail` windows.
- **Expected values must be exact**: Verification expected values must be concrete observable values (image tag, replica count), not relative descriptions.

### Timeout coordination

Previously, step timeouts were hardcoded in Go constants but never communicated to the Python agent — the `TimeoutMs` field in the HTTP request payload was always empty, so the agent used its own internal default (5 min), which was shorter than the controller's budget.

- `Run()` now accepts a `timeout time.Duration` parameter and populates `TimeoutMs` in the request payload.
- The HTTP client timeout is set to `stepTimeout + defaultSandboxTimeout` (agent budget + 5 min startup allowance).
- The `SandboxAgentCaller.Timeout` field is removed; `defaultSandboxTimeout` is used directly.

### Pod activeDeadlineSeconds

Sandbox pods previously had no hard deadline — if the agent process hung and the controller crashed between the HTTP timeout and pod release, the pod would run indefinitely.

- `SandboxLifecycle.Create()` now accepts a `deadline time.Duration` parameter.
- `SandboxManager.Create()` sets `podSpec.ActiveDeadlineSeconds` from the deadline, covering both bare-pod and sandbox-claim modes.
- The deadline is `stepTimeout + defaultSandboxTimeout`, matching the HTTP client timeout.

Timeout layering (analysis/execution example, 10 min step):

| Layer | Value | Enforced by |
|-------|-------|-------------|
| `TimeoutMs` to agent | 10 min | Python agent self-limits |
| HTTP client timeout | 15 min | Go `http.Client` kills connection |
| `activeDeadlineSeconds` | 15 min | kubelet hard-kills pod |

## Test plan

- [ ] Unit tests pass (193 tests in `controller/agenticrun`, all green)
- [ ] `TestAgentHTTPClient_RunSuccess` verifies `TimeoutMs` is serialized correctly in the request payload
- [ ] `TestCreate_BarePod` asserts `ActiveDeadlineSeconds` is set on the pod
- [ ] `TestCreate_OTELEnvVars_SandboxClaim` asserts `activeDeadlineSeconds` in the SandboxTemplate `podTemplate.spec`
- [ ] Verify verification agent retries convergence-dependent checks in a real cluster scenario