### PR TITLE
feat: add per-step timeoutMinutes for sandbox agent calls

### DIFF
--- a/api/v1alpha1/agenticrun_types.go
+++ b/api/v1alpha1/agenticrun_types.go
@@ -271,10 +271,26 @@ type AgenticRunStep struct {
 	// for this step. Use this when different steps need different skills.
 	// +optional
 	Tools ToolsSpec `json:"tools,omitzero"`
+
+	// timeoutMinutes overrides the agent-level and built-in default timeout
+	// for this step's sandbox agent call. This controls how long the operator
+	// allows the agent to run; pod startup uses a separate fixed ceiling.
+	// Increase this for long-running tools (e.g., IntelliAide RCA takes
+	// 10-30 minutes). When omitted, the effective timeout is resolved from
+	// Agent.spec.timeouts for the selected agent, falling back to built-in
+	// defaults (10m analysis/execution, 30m verification).
+	//
+	// Precedence: timeoutMinutes (this field) > Agent.spec.timeouts > built-in default.
+	//
+	// Mutable: can be adjusted at any time; the value is read when the step starts.
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=60
+	TimeoutMinutes int32 `json:"timeoutMinutes,omitempty"`
 }
 
 func (s AgenticRunStep) IsZero() bool {
-	return s.Agent == "" && s.Tools.IsZero()
+	return s.Agent == "" && s.Tools.IsZero() && s.TimeoutMinutes == 0
 }
 
 // AgenticRunSpec defines the desired state of AgenticRun.

--- a/config/crd/bases/agentic.openshift.io_agenticruns.yaml
+++ b/config/crd/bases/agentic.openshift.io_agenticruns.yaml
@@ -83,6 +83,23 @@ spec:
                     - message: 'must be a valid DNS subdomain: lowercase alphanumeric
                         characters, hyphens, and dots'
                       rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                  timeoutMinutes:
+                    description: |-
+                      timeoutMinutes overrides the agent-level and built-in default timeout
+                      for this step's sandbox agent call. This controls how long the operator
+                      allows the agent to run; pod startup uses a separate fixed ceiling.
+                      Increase this for long-running tools (e.g., IntelliAide RCA takes
+                      10-30 minutes). When omitted, the effective timeout is resolved from
+                      Agent.spec.timeouts for the selected agent, falling back to built-in
+                      defaults (10m analysis/execution, 30m verification).
+
+                      Precedence: timeoutMinutes (this field) > Agent.spec.timeouts > built-in default.
+
+                      Mutable: can be adjusted at any time; the value is read when the step starts.
+                    format: int32
+                    maximum: 60
+                    minimum: 1
+                    type: integer
                   tools:
                     description: |-
                       tools provides per-step tools that replace the shared spec.tools
@@ -500,6 +517,23 @@ spec:
                     - message: 'must be a valid DNS subdomain: lowercase alphanumeric
                         characters, hyphens, and dots'
                       rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                  timeoutMinutes:
+                    description: |-
+                      timeoutMinutes overrides the agent-level and built-in default timeout
+                      for this step's sandbox agent call. This controls how long the operator
+                      allows the agent to run; pod startup uses a separate fixed ceiling.
+                      Increase this for long-running tools (e.g., IntelliAide RCA takes
+                      10-30 minutes). When omitted, the effective timeout is resolved from
+                      Agent.spec.timeouts for the selected agent, falling back to built-in
+                      defaults (10m analysis/execution, 30m verification).
+
+                      Precedence: timeoutMinutes (this field) > Agent.spec.timeouts > built-in default.
+
+                      Mutable: can be adjusted at any time; the value is read when the step starts.
+                    format: int32
+                    maximum: 60
+                    minimum: 1
+                    type: integer
                   tools:
                     description: |-
                       tools provides per-step tools that replace the shared spec.tools
@@ -1319,6 +1353,23 @@ spec:
                     - message: 'must be a valid DNS subdomain: lowercase alphanumeric
                         characters, hyphens, and dots'
                       rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                  timeoutMinutes:
+                    description: |-
+                      timeoutMinutes overrides the agent-level and built-in default timeout
+                      for this step's sandbox agent call. This controls how long the operator
+                      allows the agent to run; pod startup uses a separate fixed ceiling.
+                      Increase this for long-running tools (e.g., IntelliAide RCA takes
+                      10-30 minutes). When omitted, the effective timeout is resolved from
+                      Agent.spec.timeouts for the selected agent, falling back to built-in
+                      defaults (10m analysis/execution, 30m verification).
+
+                      Precedence: timeoutMinutes (this field) > Agent.spec.timeouts > built-in default.
+
+                      Mutable: can be adjusted at any time; the value is read when the step starts.
+                    format: int32
+                    maximum: 60
+                    minimum: 1
+                    type: integer
                   tools:
                     description: |-
                       tools provides per-step tools that replace the shared spec.tools

--- a/controller/agenticrun/podspec_builder.go
+++ b/controller/agenticrun/podspec_builder.go
@@ -71,6 +71,7 @@ func (b *PodSpecBuilder) Build(
 	serviceAccount string,
 	inputConfigMapName string,
 	traceparent string,
+	agentTimeoutSeconds int64,
 ) (*corev1.PodSpec, error) {
 	if base == nil || len(base.Containers) == 0 {
 		return nil, fmt.Errorf("%s", ErrBuildBasePodSpec)
@@ -111,6 +112,19 @@ func (b *PodSpecBuilder) Build(
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  "LIGHTSPEED_REASONING_CONFIG",
 			Value: string(rcJSON),
+		})
+	}
+
+	if agentTimeoutSeconds > 0 {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "LIGHTSPEED_AGENT_TIMEOUT_SECONDS",
+			Value: fmt.Sprintf("%d", agentTimeoutSeconds),
+		})
+	}
+	if agent.Spec.MaxTurns > 0 {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "LIGHTSPEED_AGENT_MAX_TURNS",
+			Value: fmt.Sprintf("%d", agent.Spec.MaxTurns),
 		})
 	}
 

--- a/controller/agenticrun/podspec_builder_test.go
+++ b/controller/agenticrun/podspec_builder_test.go
@@ -333,7 +333,7 @@ func TestBuild_NilBase(t *testing.T) {
 	b := &PodSpecBuilder{}
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
-	_, err := b.Build(nil, agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	_, err := b.Build(nil, agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err == nil {
 		t.Fatal("expected error for nil base")
 	}
@@ -342,7 +342,7 @@ func TestBuild_NilBase(t *testing.T) {
 func TestBuild_NilAgent(t *testing.T) {
 	b := &PodSpecBuilder{}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
-	_, err := b.Build(testBasePodSpec(), nil, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	_, err := b.Build(testBasePodSpec(), nil, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err == nil {
 		t.Fatal("expected error for nil agent")
 	}
@@ -351,7 +351,7 @@ func TestBuild_NilAgent(t *testing.T) {
 func TestBuild_NilLLM(t *testing.T) {
 	b := &PodSpecBuilder{}
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
-	_, err := b.Build(testBasePodSpec(), agent, nil, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	_, err := b.Build(testBasePodSpec(), agent, nil, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err == nil {
 		t.Fatal("expected error for nil LLM")
 	}
@@ -361,7 +361,7 @@ func TestBuild_EmptySA(t *testing.T) {
 	b := &PodSpecBuilder{}
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
-	_, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "", "uid-test-run", "")
+	_, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "", "uid-test-run", "", 0)
 	if err == nil {
 		t.Fatal("expected error for empty serviceAccount")
 	}
@@ -372,7 +372,7 @@ func TestBuild_Anthropic(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-opus-4-6"}}
 	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderAnthropic, "https://custom.api")
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid-123", "my-sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid-123", "my-sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -399,7 +399,7 @@ func TestBuild_RequiresInputConfigMapName(t *testing.T) {
 	b := &PodSpecBuilder{}
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
-	_, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "", "")
+	_, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "", "", 0)
 	if err == nil {
 		t.Fatal("expected error for empty inputConfigMapName")
 	}
@@ -411,7 +411,7 @@ func TestBuild_InputConfigMapMount(t *testing.T) {
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 	const cmName = "uid-my-run"
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", cmName, "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", cmName, "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -427,7 +427,7 @@ func TestBuild_Traceparent(t *testing.T) {
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 	const tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", tp)
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", tp, 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -436,7 +436,7 @@ func TestBuild_Traceparent(t *testing.T) {
 		t.Fatalf("TRACEPARENT = %q, want %q", env["TRACEPARENT"], tp)
 	}
 
-	ps, err = b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err = b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -484,7 +484,7 @@ func TestBuild_Vertex(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "gemini-2.0"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -508,7 +508,7 @@ func TestBuild_Azure(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "gpt-4o"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAzureOpenAI)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -529,7 +529,7 @@ func TestBuild_Bedrock(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-v3"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAWSBedrock)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -547,7 +547,7 @@ func TestBuild_OpenAI(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "gpt-4o"}}
 	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderOpenAI, "https://api.example.com")
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -573,7 +573,7 @@ func TestBuild_ReasoningConfig(t *testing.T) {
 	}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -596,7 +596,7 @@ func TestBuild_NoReasoningConfig(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -611,7 +611,7 @@ func TestBuild_CredentialsSecretMounted(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -648,7 +648,7 @@ func TestBuild_RHOKPEndpointAndCA(t *testing.T) {
 		CASecretName: "lightspeed-agentic-rhokp-ca",
 	}
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, rhokp, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, rhokp, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -696,7 +696,7 @@ func TestBuild_RHOKPOmitted(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -739,7 +739,7 @@ func TestBuild_DeduplicatesVolumes(t *testing.T) {
 		}},
 	}
 
-	ps, err := b.Build(base, agent, llm, tools, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(base, agent, llm, tools, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -821,7 +821,7 @@ func TestBuild_GeneratedVolumeOverridesBase(t *testing.T) {
 		Skills: []agenticv1alpha1.SkillsSource{{Image: "quay.io/real/skills:v1"}},
 	}
 
-	ps, err := b.Build(base, agent, llm, tools, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(base, agent, llm, tools, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -860,5 +860,65 @@ func TestTraceparentFromContext_WithSpan(t *testing.T) {
 	want := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
 	if got := traceparentFromContext(ctx); got != want {
 		t.Fatalf("traceparent = %q, want %q", got, want)
+	}
+}
+
+func TestBuild_AgentTimeoutSeconds(t *testing.T) {
+	b := &PodSpecBuilder{}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 1800)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	env := envToMap(ps.Containers[0].Env)
+	if env["LIGHTSPEED_AGENT_TIMEOUT_SECONDS"] != "1800" {
+		t.Errorf("LIGHTSPEED_AGENT_TIMEOUT_SECONDS = %q, want %q", env["LIGHTSPEED_AGENT_TIMEOUT_SECONDS"], "1800")
+	}
+}
+
+func TestBuild_AgentTimeoutSecondsOmittedWhenZero(t *testing.T) {
+	b := &PodSpecBuilder{}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	env := envToMap(ps.Containers[0].Env)
+	if _, ok := env["LIGHTSPEED_AGENT_TIMEOUT_SECONDS"]; ok {
+		t.Error("LIGHTSPEED_AGENT_TIMEOUT_SECONDS should be omitted when agentTimeoutSeconds is 0")
+	}
+}
+
+func TestBuild_MaxTurns(t *testing.T) {
+	b := &PodSpecBuilder{}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m", MaxTurns: 200}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	env := envToMap(ps.Containers[0].Env)
+	if env["LIGHTSPEED_AGENT_MAX_TURNS"] != "200" {
+		t.Errorf("LIGHTSPEED_AGENT_MAX_TURNS = %q, want %q", env["LIGHTSPEED_AGENT_MAX_TURNS"], "200")
+	}
+}
+
+func TestBuild_MaxTurnsOmittedWhenZero(t *testing.T) {
+	b := &PodSpecBuilder{}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 0)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	env := envToMap(ps.Containers[0].Env)
+	if _, ok := env["LIGHTSPEED_AGENT_MAX_TURNS"]; ok {
+		t.Error("LIGHTSPEED_AGENT_MAX_TURNS should be omitted when maxTurns is 0")
 	}
 }

--- a/controller/agenticrun/resolve.go
+++ b/controller/agenticrun/resolve.go
@@ -19,9 +19,10 @@ const (
 )
 
 type resolvedStep struct {
-	Agent *agenticv1alpha1.Agent
-	LLM   *agenticv1alpha1.LLMProvider
-	Tools *agenticv1alpha1.ToolsSpec
+	Agent          *agenticv1alpha1.Agent
+	LLM            *agenticv1alpha1.LLMProvider
+	Tools          *agenticv1alpha1.ToolsSpec
+	TimeoutMinutes int32
 }
 
 type resolvedWorkflow struct {
@@ -80,14 +81,14 @@ func resolveAgenticRun(ctx context.Context, c client.Client, run *agenticv1alpha
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", ErrResolveAnalysisStep, err)
 	}
-	resolved.Analysis = resolvedStep{Agent: agent, LLM: llm, Tools: toolsForStep(run.Spec.Analysis)}
+	resolved.Analysis = resolvedStep{Agent: agent, LLM: llm, Tools: toolsForStep(run.Spec.Analysis), TimeoutMinutes: run.Spec.Analysis.TimeoutMinutes}
 
 	if !run.Spec.Execution.IsZero() {
 		agent, llm, err := resolveAgent(effectiveAgent(agenticv1alpha1.SandboxStepExecution, run.Spec.Execution))
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", ErrResolveExecutionStep, err)
 		}
-		resolved.Execution = &resolvedStep{Agent: agent, LLM: llm, Tools: toolsForStep(run.Spec.Execution)}
+		resolved.Execution = &resolvedStep{Agent: agent, LLM: llm, Tools: toolsForStep(run.Spec.Execution), TimeoutMinutes: run.Spec.Execution.TimeoutMinutes}
 	}
 
 	if !run.Spec.Verification.IsZero() {
@@ -95,7 +96,7 @@ func resolveAgenticRun(ctx context.Context, c client.Client, run *agenticv1alpha
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", ErrResolveVerificationStep, err)
 		}
-		resolved.Verification = &resolvedStep{Agent: agent, LLM: llm, Tools: toolsForStep(run.Spec.Verification)}
+		resolved.Verification = &resolvedStep{Agent: agent, LLM: llm, Tools: toolsForStep(run.Spec.Verification), TimeoutMinutes: run.Spec.Verification.TimeoutMinutes}
 	}
 
 	return resolved, nil

--- a/controller/agenticrun/sandbox_agent.go
+++ b/controller/agenticrun/sandbox_agent.go
@@ -15,9 +15,9 @@ import (
 const (
 	defaultSandboxTimeout = 5 * time.Minute
 
-	analysisStepTimeout     = 10 * time.Minute
-	executionStepTimeout    = 10 * time.Minute
-	verificationStepTimeout = 30 * time.Minute
+	defaultAnalysisTimeout     = 10 * time.Minute
+	defaultExecutionTimeout    = 10 * time.Minute
+	defaultVerificationTimeout = 30 * time.Minute
 
 	ErrClaimSandbox = "claim sandbox"
 
@@ -61,18 +61,55 @@ const (
 	maxLenRBACJustification        = 1024
 )
 
-// stepTimeout returns the hard deadline for a sandbox step (OLS-3781 / PR 423).
-func stepTimeout(step string) time.Duration {
+// builtinStepTimeout returns the built-in default for a step when neither
+// the run nor the Agent provides a timeout.
+func builtinStepTimeout(step string) time.Duration {
 	switch step {
 	case "analysis", "escalation":
-		return analysisStepTimeout
+		return defaultAnalysisTimeout
 	case "execution":
-		return executionStepTimeout
+		return defaultExecutionTimeout
 	case "verification":
-		return verificationStepTimeout
+		return defaultVerificationTimeout
 	default:
-		return analysisStepTimeout
+		return defaultAnalysisTimeout
 	}
+}
+
+// agentStepTimeout returns the Agent-level timeout for a step, or 0 if unset.
+func agentStepTimeout(agent *agenticv1alpha1.Agent, step string) time.Duration {
+	if agent == nil {
+		return 0
+	}
+	var seconds int32
+	switch step {
+	case "analysis", "escalation":
+		seconds = agent.Spec.Timeouts.AnalysisSeconds
+	case "execution":
+		seconds = agent.Spec.Timeouts.ExecutionSeconds
+	case "verification":
+		seconds = agent.Spec.Timeouts.VerificationSeconds
+	}
+	if seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	return 0
+}
+
+// effectiveStepTimeout resolves the layered timeout for a sandbox step.
+//
+// Precedence (highest → lowest):
+//  1. Per-run override: AgenticRunStep.timeoutMinutes
+//  2. Agent-level default: Agent.spec.timeouts.<step>Seconds
+//  3. Built-in default: 10m analysis/execution, 30m verification
+func effectiveStepTimeout(stepName string, step resolvedStep) time.Duration {
+	if step.TimeoutMinutes > 0 {
+		return time.Duration(step.TimeoutMinutes) * time.Minute
+	}
+	if d := agentStepTimeout(step.Agent, stepName); d > 0 {
+		return d
+	}
+	return builtinStepTimeout(stepName)
 }
 
 // Agent context types — shared by input ConfigMap builder and helpers.
@@ -165,7 +202,7 @@ func (s *SandboxAgentCaller) launchSandbox(
 	query string,
 	agentCtx *agentContext,
 ) error {
-	podDeadline := stepTimeout(stepName) + defaultSandboxTimeout
+	podDeadline := effectiveStepTimeout(stepName, step) + defaultSandboxTimeout
 	var name string
 	if err := retryOnTransient(ctx, func() error {
 		var createErr error

--- a/controller/agenticrun/sandbox_agent_test.go
+++ b/controller/agenticrun/sandbox_agent_test.go
@@ -253,15 +253,15 @@ func TestBuildAgentContext_PreviousAttempts(t *testing.T) {
 	}
 }
 
-func TestStepTimeout_Values(t *testing.T) {
-	if got := stepTimeout("analysis"); got != analysisStepTimeout {
-		t.Errorf("analysis timeout = %v, want %v", got, analysisStepTimeout)
+func TestBuiltinStepTimeout_Values(t *testing.T) {
+	if got := builtinStepTimeout("analysis"); got != defaultAnalysisTimeout {
+		t.Errorf("analysis timeout = %v, want %v", got, defaultAnalysisTimeout)
 	}
-	if got := stepTimeout("execution"); got != executionStepTimeout {
-		t.Errorf("execution timeout = %v, want %v", got, executionStepTimeout)
+	if got := builtinStepTimeout("execution"); got != defaultExecutionTimeout {
+		t.Errorf("execution timeout = %v, want %v", got, defaultExecutionTimeout)
 	}
-	if got := stepTimeout("verification"); got != verificationStepTimeout {
-		t.Errorf("verification timeout = %v, want %v", got, verificationStepTimeout)
+	if got := builtinStepTimeout("verification"); got != defaultVerificationTimeout {
+		t.Errorf("verification timeout = %v, want %v", got, defaultVerificationTimeout)
 	}
 }
 
@@ -336,5 +336,82 @@ func TestSandboxAgentCaller_TransientExhaustsRetries(t *testing.T) {
 	}
 	if sandbox.claimCalls != maxCreateRetries {
 		t.Errorf("expected %d Create calls, got %d", maxCreateRetries, sandbox.claimCalls)
+	}
+}
+
+// --- Layered timeout tests ---
+
+func TestEffectiveStepTimeout_RunOverrideTakesPrecedence(t *testing.T) {
+	step := resolvedStep{
+		Agent:          &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Timeouts: agenticv1alpha1.AgentTimeouts{AnalysisSeconds: 300}}},
+		TimeoutMinutes: 45,
+	}
+	got := effectiveStepTimeout("analysis", step)
+	want := 45 * time.Minute
+	if got != want {
+		t.Errorf("effectiveStepTimeout() = %v, want %v (run override should take precedence)", got, want)
+	}
+}
+
+func TestEffectiveStepTimeout_AgentTimeoutUsedWhenNoRunOverride(t *testing.T) {
+	step := resolvedStep{
+		Agent: &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Timeouts: agenticv1alpha1.AgentTimeouts{AnalysisSeconds: 900}}},
+	}
+	got := effectiveStepTimeout("analysis", step)
+	want := 900 * time.Second
+	if got != want {
+		t.Errorf("effectiveStepTimeout() = %v, want %v (Agent timeout should be used)", got, want)
+	}
+}
+
+func TestEffectiveStepTimeout_BuiltinDefaultWhenBothUnset(t *testing.T) {
+	step := resolvedStep{
+		Agent: &agenticv1alpha1.Agent{},
+	}
+	tests := []struct {
+		stepName string
+		want     time.Duration
+	}{
+		{"analysis", defaultAnalysisTimeout},
+		{"execution", defaultExecutionTimeout},
+		{"verification", defaultVerificationTimeout},
+		{"escalation", defaultAnalysisTimeout},
+	}
+	for _, tt := range tests {
+		got := effectiveStepTimeout(tt.stepName, step)
+		if got != tt.want {
+			t.Errorf("effectiveStepTimeout(%q) = %v, want %v", tt.stepName, got, tt.want)
+		}
+	}
+}
+
+func TestEffectiveStepTimeout_NilAgent(t *testing.T) {
+	step := resolvedStep{Agent: nil, TimeoutMinutes: 0}
+	got := effectiveStepTimeout("analysis", step)
+	if got != defaultAnalysisTimeout {
+		t.Errorf("effectiveStepTimeout() = %v, want %v (nil agent should use built-in default)", got, defaultAnalysisTimeout)
+	}
+}
+
+func TestEffectiveStepTimeout_ExecutionAgentTimeout(t *testing.T) {
+	step := resolvedStep{
+		Agent: &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Timeouts: agenticv1alpha1.AgentTimeouts{ExecutionSeconds: 1800}}},
+	}
+	got := effectiveStepTimeout("execution", step)
+	want := 1800 * time.Second
+	if got != want {
+		t.Errorf("effectiveStepTimeout(execution) = %v, want %v", got, want)
+	}
+}
+
+func TestEffectiveStepTimeout_VerificationRunOverride(t *testing.T) {
+	step := resolvedStep{
+		Agent:          &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Timeouts: agenticv1alpha1.AgentTimeouts{VerificationSeconds: 600}}},
+		TimeoutMinutes: 60,
+	}
+	got := effectiveStepTimeout("verification", step)
+	want := 60 * time.Minute
+	if got != want {
+		t.Errorf("effectiveStepTimeout(verification) = %v, want %v", got, want)
 	}
 }

--- a/controller/agenticrun/sandbox_manager.go
+++ b/controller/agenticrun/sandbox_manager.go
@@ -157,6 +157,11 @@ func (m *SandboxManager) Create(
 	}
 	span.AddEvent("sandbox.rbac.created")
 
+	agentBudget := deadline - defaultSandboxTimeout
+	if agentBudget < 0 {
+		agentBudget = deadline
+	}
+
 	podSpec, err := m.builder.Build(
 		cfg.Sandbox.PodSpec,
 		agent,
@@ -169,6 +174,7 @@ func (m *SandboxManager) Create(
 		serviceAccount,
 		inputCM.Name,
 		traceparentFromContext(ctx),
+		int64(agentBudget.Seconds()),
 	)
 	if err != nil {
 		createErr = fmt.Errorf("%s: %w", errBuildPodSpec, err)

--- a/controller/agenticrun/timeout_handler.go
+++ b/controller/agenticrun/timeout_handler.go
@@ -75,12 +75,13 @@ func (r *AgenticRunReconciler) handleTimeEvent(ctx context.Context) {
 			continue
 		}
 
+		timeout := resolveOverallTimeout(ctx, r.Client, &run, e.step)
 		var message string
 		created := e.pod.CreationTimestamp.Time
 		if startTimedOut(phase, created, now, podStartTimeout) {
 			message = fmt.Sprintf("sandbox pod did not start within %s", podStartTimeout)
-		} else if overallTimedOut(created, now, stepTimeout(e.step)) {
-			message = fmt.Sprintf("sandbox exceeded timeout %s", stepTimeout(e.step))
+		} else if overallTimedOut(created, now, timeout) {
+			message = fmt.Sprintf("sandbox exceeded timeout %s", timeout)
 		} else {
 			continue
 		}
@@ -127,6 +128,35 @@ func (r *AgenticRunReconciler) listSandboxPods(ctx context.Context, log logr.Log
 		entries = append(entries, podEntry{pod, step, runName})
 	}
 	return entries
+}
+
+// resolveOverallTimeout computes the effective overall timeout (agent budget +
+// startup padding) for a step of a given run. It reads the per-run override
+// and the Agent CR to apply the layered precedence logic.
+func resolveOverallTimeout(ctx context.Context, c client.Reader, run *agenticv1alpha1.AgenticRun, step string) time.Duration {
+	runStep := runStepForName(run, step)
+	var agent *agenticv1alpha1.Agent
+	agentName := stepAgentName(runStep)
+	a := &agenticv1alpha1.Agent{}
+	if err := c.Get(ctx, client.ObjectKey{Name: agentName}, a); err == nil {
+		agent = a
+	}
+	resolved := resolvedStep{Agent: agent, TimeoutMinutes: runStep.TimeoutMinutes}
+	return effectiveStepTimeout(step, resolved) + defaultSandboxTimeout
+}
+
+// runStepForName returns the AgenticRunStep for a given step name.
+func runStepForName(run *agenticv1alpha1.AgenticRun, step string) agenticv1alpha1.AgenticRunStep {
+	switch step {
+	case "analysis", "escalation":
+		return run.Spec.Analysis
+	case "execution":
+		return run.Spec.Execution
+	case "verification":
+		return run.Spec.Verification
+	default:
+		return run.Spec.Analysis
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
This PR introduces a configurable timeoutMinutes setting for sandbox agent steps (Analysis, Execution, and Verification).

Reason for change:
This flexibility is needed to accommodate and properly support long-running tasks.