### PR TITLE
OLS-3864,OLS-3865: sanitize LLM analysis options before CRD write

### DIFF
--- a/controller/agenticrun/sandbox_agent.go
+++ b/controller/agenticrun/sandbox_agent.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -31,6 +32,26 @@ const (
 	ErrParseEscalationResponse   = "parse escalation response"
 	ErrClaimSandbox              = "claim sandbox"
 	ErrWaitForSandbox            = "wait for sandbox"
+
+	// CRD maxLength limits for analysis option fields, used by
+	// sanitizeAnalysisOptions as a safety net for LLM output that
+	// exceeds CRD validation constraints.
+	maxLenOptionTitle              = 256
+	maxLenOptionSummary            = 1024
+	maxLenDiagnosisSummary         = 8192
+	maxLenDiagnosisRootCause       = 1024
+	maxLenPlanDescription          = 8192
+	maxLenActionCommand            = 4096
+	maxLenActionType               = 256
+	maxLenActionDescription        = 4096
+	maxLenRollbackDescription      = 4096
+	maxLenRollbackCommand          = 4096
+	maxLenVerificationDescription  = 4096
+	maxLenVerificationStepName     = 253
+	maxLenVerificationStepCommand  = 4096
+	maxLenVerificationStepExpected = 1024
+	maxLenVerificationStepType     = 256
+	maxLenRBACJustification        = 1024
 )
 
 type analysisResponse struct {
@@ -94,6 +115,8 @@ func (s *SandboxAgentCaller) Analyze(ctx context.Context, run *agenticv1alpha1.A
 			}
 		}
 	}
+
+	sanitizeAnalysisOptions(log, run.Name, resp.Options)
 
 	if resp.Diagnosis != nil && (resp.Diagnosis.Summary == "" || resp.Diagnosis.RootCause == "") {
 		log.Info("ignoring empty top-level diagnosis (per-option diagnoses used instead)", "run", run.Name)
@@ -310,6 +333,107 @@ func collectFailedResults(results []agenticv1alpha1.StepResultRef, stepName stri
 		}
 	}
 	return attempts
+}
+
+// truncate returns s unchanged if its byte length is within max,
+// otherwise it returns the first max bytes.
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max]
+}
+
+// sanitizeAnalysisOptions cleans up LLM-produced options before they are
+// written to an AnalysisResult CR. It addresses two failure modes:
+//   - per-option Diagnosis with empty required fields (Summary or RootCause)
+//     is zeroed so omitzero omits the struct entirely, preventing CRD
+//     MinLength validation failures.
+//   - string fields that exceed CRD MaxLength limits are truncated to the
+//     constant-defined cap so the status patch is not rejected.
+func sanitizeAnalysisOptions(log logr.Logger, runName string, options []agenticv1alpha1.RemediationOption) {
+	for i := range options {
+		opt := &options[i]
+
+		if opt.Diagnosis.Summary == "" || opt.Diagnosis.RootCause == "" {
+			log.Info("zeroing per-option diagnosis with empty required fields", "run", runName, "option", i)
+			opt.Diagnosis = agenticv1alpha1.DiagnosisResult{}
+		}
+
+		if n := len(opt.Title); n > maxLenOptionTitle {
+			log.Info("truncating option title", "run", runName, "option", i, "from", n, "to", maxLenOptionTitle)
+			opt.Title = truncate(opt.Title, maxLenOptionTitle)
+		}
+		if n := len(opt.Summary); n > maxLenOptionSummary {
+			log.Info("truncating option summary", "run", runName, "option", i, "from", n, "to", maxLenOptionSummary)
+			opt.Summary = truncate(opt.Summary, maxLenOptionSummary)
+		}
+		if n := len(opt.Diagnosis.Summary); n > maxLenDiagnosisSummary {
+			log.Info("truncating option diagnosis summary", "run", runName, "option", i, "from", n, "to", maxLenDiagnosisSummary)
+			opt.Diagnosis.Summary = truncate(opt.Diagnosis.Summary, maxLenDiagnosisSummary)
+		}
+		if n := len(opt.Diagnosis.RootCause); n > maxLenDiagnosisRootCause {
+			log.Info("truncating option diagnosis rootCause", "run", runName, "option", i, "from", n, "to", maxLenDiagnosisRootCause)
+			opt.Diagnosis.RootCause = truncate(opt.Diagnosis.RootCause, maxLenDiagnosisRootCause)
+		}
+
+		if n := len(opt.RemediationPlan.Description); n > maxLenPlanDescription {
+			log.Info("truncating remediationPlan description", "run", runName, "option", i, "from", n, "to", maxLenPlanDescription)
+			opt.RemediationPlan.Description = truncate(opt.RemediationPlan.Description, maxLenPlanDescription)
+		}
+		for j := range opt.RemediationPlan.Actions {
+			a := &opt.RemediationPlan.Actions[j]
+			if n := len(a.Command); n > maxLenActionCommand {
+				log.Info("truncating action command", "run", runName, "option", i, "action", j, "from", n, "to", maxLenActionCommand)
+				a.Command = truncate(a.Command, maxLenActionCommand)
+			}
+			if n := len(a.Type); n > maxLenActionType {
+				a.Type = truncate(a.Type, maxLenActionType)
+			}
+			if n := len(a.Description); n > maxLenActionDescription {
+				a.Description = truncate(a.Description, maxLenActionDescription)
+			}
+		}
+
+		if n := len(opt.RemediationPlan.RollbackPlan.Description); n > maxLenRollbackDescription {
+			opt.RemediationPlan.RollbackPlan.Description = truncate(opt.RemediationPlan.RollbackPlan.Description, maxLenRollbackDescription)
+		}
+		if n := len(opt.RemediationPlan.RollbackPlan.Command); n > maxLenRollbackCommand {
+			opt.RemediationPlan.RollbackPlan.Command = truncate(opt.RemediationPlan.RollbackPlan.Command, maxLenRollbackCommand)
+		}
+
+		if n := len(opt.Verification.Description); n > maxLenVerificationDescription {
+			opt.Verification.Description = truncate(opt.Verification.Description, maxLenVerificationDescription)
+		}
+		for j := range opt.Verification.Steps {
+			s := &opt.Verification.Steps[j]
+			if n := len(s.Name); n > maxLenVerificationStepName {
+				s.Name = truncate(s.Name, maxLenVerificationStepName)
+			}
+			if n := len(s.Command); n > maxLenVerificationStepCommand {
+				s.Command = truncate(s.Command, maxLenVerificationStepCommand)
+			}
+			if n := len(s.Expected); n > maxLenVerificationStepExpected {
+				s.Expected = truncate(s.Expected, maxLenVerificationStepExpected)
+			}
+			if n := len(s.Type); n > maxLenVerificationStepType {
+				s.Type = truncate(s.Type, maxLenVerificationStepType)
+			}
+		}
+
+		for j := range opt.RBAC.NamespaceScoped {
+			r := &opt.RBAC.NamespaceScoped[j]
+			if n := len(r.Justification); n > maxLenRBACJustification {
+				r.Justification = truncate(r.Justification, maxLenRBACJustification)
+			}
+		}
+		for j := range opt.RBAC.ClusterScoped {
+			r := &opt.RBAC.ClusterScoped[j]
+			if n := len(r.Justification); n > maxLenRBACJustification {
+				r.Justification = truncate(r.Justification, maxLenRBACJustification)
+			}
+		}
+	}
 }
 
 func buildAgentContext(run *agenticv1alpha1.AgenticRun) *agentContext {

--- a/controller/agenticrun/sandbox_agent_test.go
+++ b/controller/agenticrun/sandbox_agent_test.go
@@ -412,6 +412,100 @@ func TestSandboxAgentCaller_Analyze_EmptyTopLevelDiagnosis(t *testing.T) {
 	}
 }
 
+// --- OLS-3864: empty per-option diagnosis sanitization ---
+
+func TestSandboxAgentCaller_Analyze_EmptyPerOptionDiagnosis(t *testing.T) {
+	cases := []struct {
+		name         string
+		diagnosis    string
+		expectZeroed bool
+	}{
+		{"both empty", `"diagnosis": {"summary": "", "rootCause": ""}`, true},
+		{"summary empty", `"diagnosis": {"summary": "", "rootCause": "some cause"}`, true},
+		{"rootCause empty", `"diagnosis": {"summary": "some summary", "rootCause": ""}`, true},
+		{"both present", `"diagnosis": {"summary": "OOM detected", "rootCause": "memory limit"}`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sandbox := &mockSandboxProvider{claimName: "ls-analysis-fix-crash", endpoint: "http://sandbox:8080"}
+			httpClient := &mockHTTPClient{
+				response: &agentRunResponse{
+					Response: json.RawMessage(fmt.Sprintf(`{
+						"success": true,
+						"actionRequired": true,
+						"options": [{
+							"title": "Fix it",
+							%s,
+							"remediationPlan": {"description": "Do stuff", "actions": [{"command": "kubectl patch", "type": "patch", "description": "patch it"}]}
+						}]
+					}`, tc.diagnosis)),
+				},
+			}
+
+			caller := newTestSandboxAgentCaller(sandbox, httpClient)
+			result, err := caller.Analyze(context.Background(), testSandboxAgenticRun(), testSandboxStep(), "test", defaultSandboxSA)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(result.Options) != 1 {
+				t.Fatalf("expected 1 option, got %d", len(result.Options))
+			}
+			diag := result.Options[0].Diagnosis
+			if tc.expectZeroed {
+				if diag.Summary != "" || diag.RootCause != "" {
+					t.Errorf("expected zeroed diagnosis, got summary=%q rootCause=%q", diag.Summary, diag.RootCause)
+				}
+			} else {
+				if diag.Summary == "" || diag.RootCause == "" {
+					t.Errorf("expected preserved diagnosis, got summary=%q rootCause=%q", diag.Summary, diag.RootCause)
+				}
+			}
+		})
+	}
+}
+
+// --- OLS-3865: truncation of long option fields ---
+
+func TestSandboxAgentCaller_Analyze_TruncatesLongFields(t *testing.T) {
+	longTitle := strings.Repeat("x", 300)
+	longSummary := strings.Repeat("y", 2000)
+
+	sandbox := &mockSandboxProvider{claimName: "ls-analysis-fix-crash", endpoint: "http://sandbox:8080"}
+	httpClient := &mockHTTPClient{
+		response: &agentRunResponse{
+			Response: json.RawMessage(fmt.Sprintf(`{
+				"success": true,
+				"actionRequired": true,
+				"options": [{
+					"title": %q,
+					"summary": %q,
+					"diagnosis": {"summary": "short", "rootCause": "short"},
+					"remediationPlan": {"description": "Do stuff", "actions": [{"command": "kubectl patch", "type": "patch", "description": "patch it"}]}
+				}]
+			}`, longTitle, longSummary)),
+		},
+	}
+
+	caller := newTestSandboxAgentCaller(sandbox, httpClient)
+	result, err := caller.Analyze(context.Background(), testSandboxAgenticRun(), testSandboxStep(), "test", defaultSandboxSA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Options) != 1 {
+		t.Fatalf("expected 1 option, got %d", len(result.Options))
+	}
+	opt := result.Options[0]
+	if len(opt.Title) != maxLenOptionTitle {
+		t.Errorf("title length = %d, want %d", len(opt.Title), maxLenOptionTitle)
+	}
+	if len(opt.Summary) != maxLenOptionSummary {
+		t.Errorf("summary length = %d, want %d", len(opt.Summary), maxLenOptionSummary)
+	}
+}
+
 // --- Per-phase query construction tests ---
 
 func TestSandboxAgentCaller_AnalysisQueryFraming(t *testing.T) {

--- a/controller/agenticrun/schema_crd_drift_test.go
+++ b/controller/agenticrun/schema_crd_drift_test.go
@@ -148,6 +148,90 @@ func TestSchemasCoverCRDRequiredFields(t *testing.T) {
 	}
 }
 
+// TestSchemasCoverCRDMaxLength guards against maxLength drift: every string
+// field in the CRD with a maxLength constraint must have a matching maxLength
+// in the LLM output schema so the LLM is told the limit. Without this, the
+// LLM can produce strings that pass schema validation but get rejected by CRD
+// validation at status-patch time (OLS-3865).
+func TestSchemasCoverCRDMaxLength(t *testing.T) {
+	crdPath := filepath.Join(crdBasesDir(t), "agentic.openshift.io_analysisresults.yaml")
+	raw, err := os.ReadFile(crdPath)
+	if err != nil {
+		t.Fatalf("read CRD: %v", err)
+	}
+
+	var crd apiextensionsv1.CustomResourceDefinition
+	if err := yaml.Unmarshal(raw, &crd); err != nil {
+		t.Fatalf("unmarshal CRD: %v", err)
+	}
+
+	var llm map[string]any
+	if err := json.Unmarshal(AnalysisOutputSchema, &llm); err != nil {
+		t.Fatalf("unmarshal LLM schema: %v", err)
+	}
+	llmStart, ok := digObject(llm, "properties", "options", "items")
+	if !ok {
+		t.Fatal("LLM schema is missing options[].items")
+	}
+
+	for _, v := range crd.Spec.Versions {
+		if v.Schema == nil || v.Schema.OpenAPIV3Schema == nil {
+			continue
+		}
+		status, ok := v.Schema.OpenAPIV3Schema.Properties["status"]
+		if !ok {
+			continue
+		}
+		options, ok := status.Properties["options"]
+		if !ok || options.Items == nil || options.Items.Schema == nil {
+			continue
+		}
+		assertMaxLengthCoverage(t, "options[]", options.Items.Schema, llmStart)
+	}
+}
+
+// assertMaxLengthCoverage walks a CRD schema node and the corresponding LLM
+// schema node in parallel, asserting that every string field with a CRD
+// maxLength also has a maxLength in the LLM schema.
+func assertMaxLengthCoverage(t *testing.T, path string, crd *apiextensionsv1.JSONSchemaProps, llm map[string]any) {
+	t.Helper()
+	if crd == nil || llm == nil {
+		return
+	}
+
+	if crd.Type == "array" {
+		if crd.Items == nil || crd.Items.Schema == nil {
+			return
+		}
+		llmItems, ok := asJSONObject(llm["items"])
+		if !ok {
+			return
+		}
+		assertMaxLengthCoverage(t, path+"[]", crd.Items.Schema, llmItems)
+		return
+	}
+
+	llmProps, _ := asJSONObject(llm["properties"])
+	for name, prop := range crd.Properties {
+		llmProp, ok := asJSONObject(llmProps[name])
+		if !ok {
+			continue
+		}
+		childPath := path + "." + name
+
+		if prop.Type == "string" && prop.MaxLength != nil {
+			llmMax, hasMax := llmProp["maxLength"]
+			if !hasMax {
+				t.Errorf("maxLength drift at %s: CRD has maxLength=%d but LLM schema has no maxLength", childPath, *prop.MaxLength)
+			} else if num, ok := llmMax.(float64); ok && int64(num) != *prop.MaxLength {
+				t.Errorf("maxLength drift at %s: CRD maxLength=%d but LLM schema maxLength=%d", childPath, *prop.MaxLength, int64(num))
+			}
+		}
+
+		assertMaxLengthCoverage(t, childPath, &prop, llmProp)
+	}
+}
+
 // assertRequiredCoverage walks a CRD schema node and the corresponding LLM
 // schema node in parallel, asserting that every field required by the CRD is
 // also required by the LLM schema (for fields the LLM schema actually models).

--- a/controller/agenticrun/schemas.go
+++ b/controller/agenticrun/schemas.go
@@ -2,6 +2,7 @@ package agenticrun
 
 import (
 	"encoding/json"
+	"fmt"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
@@ -11,7 +12,7 @@ import (
 // controls the base schema (Default or Minimal mode) and optionally injects
 // a custom schema as a required "components" property in each option.
 
-var AnalysisOutputSchema = json.RawMessage(`{
+var AnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
   "type": "object",
   "properties": {
     "actionRequired": {
@@ -22,8 +23,8 @@ var AnalysisOutputSchema = json.RawMessage(`{
       "type": "object",
       "description": "Top-level root cause analysis. Required when actionRequired is false. When actionRequired is true, diagnosis is provided per-option instead.",
       "properties": {
-        "summary": { "type": "string", "description": "Markdown-formatted diagnosis summary explaining the problem, symptoms, and findings" },
-        "rootCause": { "type": "string", "description": "Concise one-line root cause" }
+        "summary": { "type": "string", "maxLength": %d, "description": "Markdown-formatted diagnosis summary explaining the problem, symptoms, and findings" },
+        "rootCause": { "type": "string", "maxLength": %d, "description": "Concise one-line root cause" }
       },
       "required": ["summary", "rootCause"]
     },
@@ -34,29 +35,29 @@ var AnalysisOutputSchema = json.RawMessage(`{
       "items": {
         "type": "object",
         "properties": {
-          "title": { "type": "string", "description": "Short human-readable title for this option (e.g., 'Increase memory limit', 'Scale horizontally')" },
-          "summary": { "type": "string", "description": "Brief one-paragraph summary of this remediation approach" },
+          "title": { "type": "string", "maxLength": %d, "description": "Short human-readable title for this option (e.g., 'Increase memory limit', 'Scale horizontally')" },
+          "summary": { "type": "string", "maxLength": %d, "description": "Brief one-paragraph summary of this remediation approach" },
           "diagnosis": {
             "type": "object",
             "properties": {
-              "summary": { "type": "string", "description": "Markdown-formatted root cause analysis explaining the problem, symptoms, and findings" },
-              "rootCause": { "type": "string", "description": "Concise one-line root cause (e.g., 'OOMKilled due to memory limit of 256Mi')" }
+              "summary": { "type": "string", "maxLength": %d, "description": "Markdown-formatted root cause analysis explaining the problem, symptoms, and findings" },
+              "rootCause": { "type": "string", "maxLength": %d, "description": "Concise one-line root cause (e.g., 'OOMKilled due to memory limit of 256Mi')" }
             },
             "required": ["summary", "rootCause"]
           },
           "remediationPlan": {
             "type": "object",
             "properties": {
-              "description": { "type": "string", "description": "Markdown-formatted summary of the overall remediation approach" },
+              "description": { "type": "string", "maxLength": %d, "description": "Markdown-formatted summary of the overall remediation approach" },
               "actions": {
                 "type": "array",
                 "description": "Ordered list of exact bash commands to execute. Each action is one command.",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "command": { "type": "string", "description": "Exact executable bash command using kubectl or oc (e.g., 'kubectl set image deployment/foo container=registry/foo:v1.3 -n production')" },
-                    "type": { "type": "string", "description": "Action phase category (e.g., 'pre-check', 'mutation', 'wait', 'post-check')" },
-                    "description": { "type": "string", "description": "What this command does and why" }
+                    "command": { "type": "string", "maxLength": %d, "description": "Exact executable bash command using kubectl or oc (e.g., 'kubectl set image deployment/foo container=registry/foo:v1.3 -n production')" },
+                    "type": { "type": "string", "maxLength": %d, "description": "Action phase category (e.g., 'pre-check', 'mutation', 'wait', 'post-check')" },
+                    "description": { "type": "string", "maxLength": %d, "description": "What this command does and why" }
                   },
                   "required": ["command", "type", "description"]
                 }
@@ -66,8 +67,8 @@ var AnalysisOutputSchema = json.RawMessage(`{
                 "type": "object",
                 "description": "How to undo the remediation if it fails or causes issues. Required when reversible is Reversible or Partial.",
                 "properties": {
-                  "description": { "type": "string", "description": "How to undo the remediation if it fails or causes issues" },
-                  "command": { "type": "string", "description": "The rollback command or steps to execute" }
+                  "description": { "type": "string", "maxLength": %d, "description": "How to undo the remediation if it fails or causes issues" },
+                  "command": { "type": "string", "maxLength": %d, "description": "The rollback command or steps to execute" }
                 },
                 "required": ["description", "command"]
               }
@@ -77,17 +78,17 @@ var AnalysisOutputSchema = json.RawMessage(`{
           "verification": {
             "type": "object",
             "properties": {
-              "description": { "type": "string", "description": "Summary of how to verify the remediation worked" },
+              "description": { "type": "string", "maxLength": %d, "description": "Summary of how to verify the remediation worked" },
               "steps": {
                 "type": "array",
                 "description": "Ordered verification checks for the verification agent to run after execution",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "name": { "type": "string", "description": "Short check identifier (e.g., 'pod-running', 'memory-usage-normal')" },
-                    "command": { "type": "string", "description": "Command or API call to run (e.g., 'oc get pod -n production -l app=web -o jsonpath={.status.phase}')" },
-                    "expected": { "type": "string", "description": "Expected output or condition (e.g., 'Running', 'ready=true')" },
-                    "type": { "type": "string", "description": "Check category (e.g., 'command', 'metric', 'condition')" }
+                    "name": { "type": "string", "maxLength": %d, "description": "Short check identifier (e.g., 'pod-running', 'memory-usage-normal')" },
+                    "command": { "type": "string", "maxLength": %d, "description": "Command or API call to run (e.g., 'oc get pod -n production -l app=web -o jsonpath={.status.phase}')" },
+                    "expected": { "type": "string", "maxLength": %d, "description": "Expected output or condition (e.g., 'Running', 'ready=true')" },
+                    "type": { "type": "string", "maxLength": %d, "description": "Check category (e.g., 'command', 'metric', 'condition')" }
                   },
                   "required": ["name", "type"]
                 }
@@ -109,7 +110,7 @@ var AnalysisOutputSchema = json.RawMessage(`{
                     "resources": { "type": "array", "items": { "type": "string" }, "description": "Resource types (e.g., 'pods', 'deployments', 'configmaps')" },
                     "resourceNames": { "type": "array", "items": { "type": "string" }, "description": "Restrict to specific named resources. Omit to allow all resources of the given type" },
                     "verbs": { "type": "array", "items": { "type": "string" }, "description": "Allowed operations (e.g., 'get', 'list', 'patch', 'delete')" },
-                    "justification": { "type": "string", "description": "Why this permission is needed (e.g., 'Need to patch deployment to increase memory limit')" }
+                    "justification": { "type": "string", "maxLength": %d, "description": "Why this permission is needed (e.g., 'Need to patch deployment to increase memory limit')" }
                   },
                   "required": ["apiGroups", "resources", "verbs", "justification"]
                 }
@@ -124,7 +125,7 @@ var AnalysisOutputSchema = json.RawMessage(`{
                     "resources": { "type": "array", "items": { "type": "string" }, "description": "Resource types (e.g., 'nodes', 'clusterroles')" },
                     "resourceNames": { "type": "array", "items": { "type": "string" }, "description": "Restrict to specific named resources. Omit to allow all resources of the given type" },
                     "verbs": { "type": "array", "items": { "type": "string" }, "description": "Allowed operations (e.g., 'get', 'list', 'patch', 'delete')" },
-                    "justification": { "type": "string", "description": "Why this permission is needed" }
+                    "justification": { "type": "string", "maxLength": %d, "description": "Why this permission is needed" }
                   },
                   "required": ["apiGroups", "resources", "verbs", "justification"]
                 }
@@ -137,14 +138,34 @@ var AnalysisOutputSchema = json.RawMessage(`{
     }
   },
   "required": ["actionRequired", "options"]
-}`)
+}`,
+	maxLenDiagnosisSummary,         // diagnosis.summary
+	maxLenDiagnosisRootCause,       // diagnosis.rootCause
+	maxLenOptionTitle,              // options[].title
+	maxLenOptionSummary,            // options[].summary
+	maxLenDiagnosisSummary,         // options[].diagnosis.summary
+	maxLenDiagnosisRootCause,       // options[].diagnosis.rootCause
+	maxLenPlanDescription,          // remediationPlan.description
+	maxLenActionCommand,            // actions[].command
+	maxLenActionType,               // actions[].type
+	maxLenActionDescription,        // actions[].description
+	maxLenRollbackDescription,      // rollbackPlan.description
+	maxLenRollbackCommand,          // rollbackPlan.command
+	maxLenVerificationDescription,  // verification.description
+	maxLenVerificationStepName,     // steps[].name
+	maxLenVerificationStepCommand,  // steps[].command
+	maxLenVerificationStepExpected, // steps[].expected
+	maxLenVerificationStepType,     // steps[].type
+	maxLenRBACJustification,        // namespaceScoped[].justification
+	maxLenRBACJustification,        // clusterScoped[].justification
+))
 
 // MinimalAnalysisOutputSchema is the base analysis output schema used
 // when AnalysisOutputMode is Minimal. It contains only the options array
 // with title per option. Built-in properties (diagnosis, remediationPlan, rbac,
 // verification, summary) are omitted. If execution or verification steps
 // exist, those specific property definitions are added back dynamically.
-var MinimalAnalysisOutputSchema = json.RawMessage(`{
+var MinimalAnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
   "type": "object",
   "properties": {
     "actionRequired": {
@@ -155,8 +176,8 @@ var MinimalAnalysisOutputSchema = json.RawMessage(`{
       "type": "object",
       "description": "Top-level root cause analysis. Required when actionRequired is false.",
       "properties": {
-        "summary": { "type": "string", "description": "Markdown-formatted diagnosis summary" },
-        "rootCause": { "type": "string", "description": "Concise one-line root cause" }
+        "summary": { "type": "string", "maxLength": %d, "description": "Markdown-formatted diagnosis summary" },
+        "rootCause": { "type": "string", "maxLength": %d, "description": "Concise one-line root cause" }
       },
       "required": ["summary", "rootCause"]
     },
@@ -167,14 +188,18 @@ var MinimalAnalysisOutputSchema = json.RawMessage(`{
       "items": {
         "type": "object",
         "properties": {
-          "title": { "type": "string", "description": "Short human-readable title for this option" }
+          "title": { "type": "string", "maxLength": %d, "description": "Short human-readable title for this option" }
         },
         "required": ["title"]
       }
     }
   },
   "required": ["actionRequired", "options"]
-}`)
+}`,
+	maxLenDiagnosisSummary,   // diagnosis.summary
+	maxLenDiagnosisRootCause, // diagnosis.rootCause
+	maxLenOptionTitle,        // options[].title
+))
 
 var ExecutionOutputSchema = json.RawMessage(`{
   "type": "object",


### PR DESCRIPTION
Add two-layer defense against LLM output that violates CRD constraints:

1. Schema enforcement: add maxLength to all string fields in AnalysisOutputSchema and MinimalAnalysisOutputSchema so the LLM is told the limits upfront.

2. Go-side sanitization: add sanitizeAnalysisOptions() called from Analyze() that zeros per-option Diagnosis structs with empty required fields (prevents MinLength rejection) and truncates strings exceeding CRD MaxLength limits (prevents Too Long rejection).

Both the JSON schemas and the sanitization function share the same maxLen* constants to keep limits in sync.

Add TestSchemasCoverCRDMaxLength drift test to catch future divergence between CRD and LLM schema maxLength values.


Assisted-by: Claude Code:claude-opus-4-6