### PR TITLE
fix: use Outcome field in escalation_request template

### DIFF
--- a/controller/agenticrun/templates/escalation_request.tmpl
+++ b/controller/agenticrun/templates/escalation_request.tmpl
@@ -6,13 +6,13 @@ Original request:
 
 Step results (use `oc get <kind> <name> -n {{.Namespace}} -o yaml` to inspect):
 {{- range .AnalysisResults}}
-  - AnalysisResult: {{.Name}} (success={{.Success}})
+  - AnalysisResult: {{.Name}} (outcome={{.Outcome}})
 {{- end}}
 {{- range .ExecutionResults}}
-  - ExecutionResult: {{.Name}} (success={{.Success}})
+  - ExecutionResult: {{.Name}} (outcome={{.Outcome}})
 {{- end}}
 {{- range .VerificationResults}}
-  - VerificationResult: {{.Name}} (success={{.Success}})
+  - VerificationResult: {{.Name}} (outcome={{.Outcome}})
 {{- end}}
 
 Review the failed step results, diagnose why remediation did not succeed,

--- a/controller/agenticrun/templates_test.go
+++ b/controller/agenticrun/templates_test.go
@@ -44,10 +44,13 @@ func TestBuildEscalationRequest_UsesOutcome(t *testing.T) {
 		t.Fatalf("template rendering failed: %s", result)
 	}
 
-	if !strings.Contains(result, "outcome=Succeeded") {
-		t.Errorf("expected outcome=Succeeded for analysis result, got: %s", result)
+	if !strings.Contains(result, "AnalysisResult: analysis-1 (outcome=Succeeded)") {
+		t.Errorf("expected %q, got: %s", "AnalysisResult: analysis-1 (outcome=Succeeded)", result)
 	}
-	if !strings.Contains(result, "outcome=Failed") {
-		t.Errorf("expected outcome=Failed for execution/verification results, got: %s", result)
+	if !strings.Contains(result, "ExecutionResult: exec-1 (outcome=Failed)") {
+		t.Errorf("expected %q, got: %s", "ExecutionResult: exec-1 (outcome=Failed)", result)
+	}
+	if !strings.Contains(result, "VerificationResult: verify-1 (outcome=Failed)") {
+		t.Errorf("expected %q, got: %s", "VerificationResult: verify-1 (outcome=Failed)", result)
 	}
 }

--- a/controller/agenticrun/templates_test.go
+++ b/controller/agenticrun/templates_test.go
@@ -1,0 +1,53 @@
+package agenticrun
+
+import (
+	"strings"
+	"testing"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildEscalationRequest_UsesOutcome(t *testing.T) {
+	run := &agenticv1alpha1.AgenticRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-run",
+			Namespace: "default",
+		},
+		Spec: agenticv1alpha1.AgenticRunSpec{
+			Request: "fix the widget",
+		},
+		Status: agenticv1alpha1.AgenticRunStatus{
+			Steps: agenticv1alpha1.StepsStatus{
+				Analysis: agenticv1alpha1.AnalysisStepStatus{
+					Results: []agenticv1alpha1.StepResultRef{
+						{Name: "analysis-1", Outcome: agenticv1alpha1.ActionOutcomeSucceeded},
+					},
+				},
+				Execution: agenticv1alpha1.ExecutionStepStatus{
+					Results: []agenticv1alpha1.StepResultRef{
+						{Name: "exec-1", Outcome: agenticv1alpha1.ActionOutcomeFailed},
+					},
+				},
+				Verification: agenticv1alpha1.VerificationStepStatus{
+					Results: []agenticv1alpha1.StepResultRef{
+						{Name: "verify-1", Outcome: agenticv1alpha1.ActionOutcomeFailed},
+					},
+				},
+			},
+		},
+	}
+
+	result := buildEscalationRequest(run)
+
+	if strings.Contains(result, "template") && strings.Contains(result, "error") {
+		t.Fatalf("template rendering failed: %s", result)
+	}
+
+	if !strings.Contains(result, "outcome=Succeeded") {
+		t.Errorf("expected outcome=Succeeded for analysis result, got: %s", result)
+	}
+	if !strings.Contains(result, "outcome=Failed") {
+		t.Errorf("expected outcome=Failed for execution/verification results, got: %s", result)
+	}
+}


### PR DESCRIPTION
## Summary
- The `escalation_request.tmpl` template referenced `.Success` on `StepResultRef`, but the field was renamed to `.Outcome` (of type `ActionOutcome`). This caused a template rendering failure at runtime when escalation is triggered:
  ```
  template "escalation_request.tmpl" error: template: escalation_request.tmpl:9:41: executing "escalation_request.tmpl" at <.Success>: can't evaluate field Success in type v1alpha1.StepResultRef
  ```
- Updated all three references (analysis, execution, verification results) from `.Success` to `.Outcome`.
- Added a unit test (`TestBuildEscalationRequest_UsesOutcome`) that exercises `buildEscalationRequest` with populated step results, covering the template rendering path that was previously untested.

## Test plan
- [x] `make test` passes
- [x] New test fails on the broken template, passes on the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)