### PR TITLE
OLS-3938 Fix escalation template referencing non-existent .Success field

### DIFF
--- a/controller/agenticrun/templates/escalation_request.tmpl
+++ b/controller/agenticrun/templates/escalation_request.tmpl
@@ -6,13 +6,13 @@ Original request:
 
 Step results (use `oc get <kind> <name> -n {{.Namespace}} -o yaml` to inspect):
 {{- range .AnalysisResults}}
-  - AnalysisResult: {{.Name}} (success={{.Success}})
+  - AnalysisResult: {{.Name}} (outcome={{.Outcome}})
 {{- end}}
 {{- range .ExecutionResults}}
-  - ExecutionResult: {{.Name}} (success={{.Success}})
+  - ExecutionResult: {{.Name}} (outcome={{.Outcome}})
 {{- end}}
 {{- range .VerificationResults}}
-  - VerificationResult: {{.Name}} (success={{.Success}})
+  - VerificationResult: {{.Name}} (outcome={{.Outcome}})
 {{- end}}
 
 Review the failed step results, diagnose why remediation did not succeed,


### PR DESCRIPTION
## Problem
`controller/agenticrun/templates/escalation_request.tmpl` references `{{.Success}}` on the items of `.AnalysisResults` / `.ExecutionResults` / `.VerificationResults`, but those are `[]v1alpha1.StepResultRef` — whose only fields are `Name` and `Outcome`. There is no `Success` field.

Go's `text/template` errors at execution (`can't evaluate field Success in type v1alpha1.StepResultRef`). `renderTemplate` swallows the error and returns `(template "escalation_request.tmpl" error: ...)` as the escalation request body, which is then sent to the escalation agent. The resulting escalation summary describes the template bug instead of the actual remediation failure.

## Fix
Use `{{.Outcome}}` (the `Succeeded`/`Failed` enum) on the three lines.

## Impact
Escalation still completed before this fix (the run reached the Escalated state), so this restores escalation **quality** — the escalation agent now receives the real step outcomes instead of a template error string.

## How it was found
Surfaced during the first end-to-end cluster test of the escalate-on-verification-failure flow (epic [OLS-3816](https://redhat.atlassian.net/browse/OLS-3816)). Confirmed pre-existing on `main` — not introduced by that epic.

Jira: https://redhat.atlassian.net/browse/OLS-3938

🤖 Generated with [Claude Code](https://claude.com/claude-code)