### PR TITLE
OLS-3865: sanitize LLM analysis options before CRD write

### DIFF
--- a/controller/agenticrun/sandbox_agent.go
+++ b/controller/agenticrun/sandbox_agent.go
@@ -40,6 +40,25 @@ const (
 	inputConfigMapKeySchema = "output-schema"
 	inputConfigMapKeyCtx    = "context"
 	inputConfigMapKeyTmpl   = "result-template"
+
+	// CRD maxLength limits for analysis option fields, injected into
+	// the LLM output schema so the model respects CRD constraints.
+	maxLenOptionTitle              = 256
+	maxLenOptionSummary            = 1024
+	maxLenDiagnosisSummary         = 8192
+	maxLenDiagnosisRootCause       = 1024
+	maxLenPlanDescription          = 8192
+	maxLenActionCommand            = 4096
+	maxLenActionType               = 256
+	maxLenActionDescription        = 4096
+	maxLenRollbackDescription      = 4096
+	maxLenRollbackCommand          = 4096
+	maxLenVerificationDescription  = 4096
+	maxLenVerificationStepName     = 253
+	maxLenVerificationStepCommand  = 4096
+	maxLenVerificationStepExpected = 1024
+	maxLenVerificationStepType     = 256
+	maxLenRBACJustification        = 1024
 )
 
 // stepTimeout returns the hard deadline for a sandbox step (OLS-3781 / PR 423).

--- a/controller/agenticrun/schema_crd_drift_test.go
+++ b/controller/agenticrun/schema_crd_drift_test.go
@@ -205,19 +205,28 @@ func assertMaxLengthCoverage(t *testing.T, path string, crd *apiextensionsv1.JSO
 		}
 		llmItems, ok := asJSONObject(llm["items"])
 		if !ok {
+			t.Errorf("maxLength drift at %s: CRD has array items but LLM schema is missing items node", path)
 			return
 		}
 		assertMaxLengthCoverage(t, path+"[]", crd.Items.Schema, llmItems)
 		return
 	}
 
+	crdRequired := map[string]bool{}
+	for _, r := range crd.Required {
+		crdRequired[r] = true
+	}
+
 	llmProps, _ := asJSONObject(llm["properties"])
 	for name, prop := range crd.Properties {
+		childPath := path + "." + name
 		llmProp, ok := asJSONObject(llmProps[name])
 		if !ok {
+			if prop.Type == "string" && prop.MaxLength != nil && crdRequired[name] {
+				t.Errorf("maxLength drift at %s: CRD requires field with maxLength=%d but LLM schema does not model this property", childPath, *prop.MaxLength)
+			}
 			continue
 		}
-		childPath := path + "." + name
 
 		if prop.Type == "string" && prop.MaxLength != nil {
 			llmMax, hasMax := llmProp["maxLength"]
@@ -225,6 +234,8 @@ func assertMaxLengthCoverage(t *testing.T, path string, crd *apiextensionsv1.JSO
 				t.Errorf("maxLength drift at %s: CRD has maxLength=%d but LLM schema has no maxLength", childPath, *prop.MaxLength)
 			} else if num, ok := llmMax.(float64); ok && int64(num) != *prop.MaxLength {
 				t.Errorf("maxLength drift at %s: CRD maxLength=%d but LLM schema maxLength=%d", childPath, *prop.MaxLength, int64(num))
+			} else if !ok {
+				t.Errorf("maxLength drift at %s: LLM schema maxLength is not numeric", childPath)
 			}
 		}
 

--- a/controller/agenticrun/schema_crd_drift_test.go
+++ b/controller/agenticrun/schema_crd_drift_test.go
@@ -148,6 +148,90 @@ func TestSchemasCoverCRDRequiredFields(t *testing.T) {
 	}
 }
 
+// TestSchemasCoverCRDMaxLength guards against maxLength drift: every string
+// field in the CRD with a maxLength constraint must have a matching maxLength
+// in the LLM output schema so the LLM is told the limit. Without this, the
+// LLM can produce strings that pass schema validation but get rejected by CRD
+// validation at status-patch time (OLS-3865).
+func TestSchemasCoverCRDMaxLength(t *testing.T) {
+	crdPath := filepath.Join(crdBasesDir(t), "agentic.openshift.io_analysisresults.yaml")
+	raw, err := os.ReadFile(crdPath)
+	if err != nil {
+		t.Fatalf("read CRD: %v", err)
+	}
+
+	var crd apiextensionsv1.CustomResourceDefinition
+	if err := yaml.Unmarshal(raw, &crd); err != nil {
+		t.Fatalf("unmarshal CRD: %v", err)
+	}
+
+	var llm map[string]any
+	if err := json.Unmarshal(AnalysisOutputSchema, &llm); err != nil {
+		t.Fatalf("unmarshal LLM schema: %v", err)
+	}
+	llmStart, ok := digObject(llm, "properties", "options", "items")
+	if !ok {
+		t.Fatal("LLM schema is missing options[].items")
+	}
+
+	for _, v := range crd.Spec.Versions {
+		if v.Schema == nil || v.Schema.OpenAPIV3Schema == nil {
+			continue
+		}
+		status, ok := v.Schema.OpenAPIV3Schema.Properties["status"]
+		if !ok {
+			continue
+		}
+		options, ok := status.Properties["options"]
+		if !ok || options.Items == nil || options.Items.Schema == nil {
+			continue
+		}
+		assertMaxLengthCoverage(t, "options[]", options.Items.Schema, llmStart)
+	}
+}
+
+// assertMaxLengthCoverage walks a CRD schema node and the corresponding LLM
+// schema node in parallel, asserting that every string field with a CRD
+// maxLength also has a maxLength in the LLM schema.
+func assertMaxLengthCoverage(t *testing.T, path string, crd *apiextensionsv1.JSONSchemaProps, llm map[string]any) {
+	t.Helper()
+	if crd == nil || llm == nil {
+		return
+	}
+
+	if crd.Type == "array" {
+		if crd.Items == nil || crd.Items.Schema == nil {
+			return
+		}
+		llmItems, ok := asJSONObject(llm["items"])
+		if !ok {
+			return
+		}
+		assertMaxLengthCoverage(t, path+"[]", crd.Items.Schema, llmItems)
+		return
+	}
+
+	llmProps, _ := asJSONObject(llm["properties"])
+	for name, prop := range crd.Properties {
+		llmProp, ok := asJSONObject(llmProps[name])
+		if !ok {
+			continue
+		}
+		childPath := path + "." + name
+
+		if prop.Type == "string" && prop.MaxLength != nil {
+			llmMax, hasMax := llmProp["maxLength"]
+			if !hasMax {
+				t.Errorf("maxLength drift at %s: CRD has maxLength=%d but LLM schema has no maxLength", childPath, *prop.MaxLength)
+			} else if num, ok := llmMax.(float64); ok && int64(num) != *prop.MaxLength {
+				t.Errorf("maxLength drift at %s: CRD maxLength=%d but LLM schema maxLength=%d", childPath, *prop.MaxLength, int64(num))
+			}
+		}
+
+		assertMaxLengthCoverage(t, childPath, &prop, llmProp)
+	}
+}
+
 // assertRequiredCoverage walks a CRD schema node and the corresponding LLM
 // schema node in parallel, asserting that every field required by the CRD is
 // also required by the LLM schema (for fields the LLM schema actually models).
@@ -215,9 +299,9 @@ func assertRequiredCoverage(t *testing.T, path string, crd *apiextensionsv1.JSON
 
 // llmOnlyControlFields are properties the LLM output schemas model that are
 // deliberately not persisted to any CRD: the operator consumes them for
-// control flow (see executionResponse/verificationResponse in
-// sandbox_agent.go) before building the status patch, so the pruning check
-// does not apply to them.
+// control flow (the sandbox agent uses them to determine step outcome)
+// before building the result CR, so the pruning check does not apply
+// to them.
 var llmOnlyControlFields = map[string]bool{
 	"success": true,
 }

--- a/controller/agenticrun/schemas.go
+++ b/controller/agenticrun/schemas.go
@@ -2,9 +2,29 @@ package agenticrun
 
 import (
 	"encoding/json"
-	"fmt"
+	"strconv"
+	"strings"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+var schemaReplacer = strings.NewReplacer(
+	"{{maxLenDiagnosisSummary}}", strconv.Itoa(maxLenDiagnosisSummary),
+	"{{maxLenDiagnosisRootCause}}", strconv.Itoa(maxLenDiagnosisRootCause),
+	"{{maxLenOptionTitle}}", strconv.Itoa(maxLenOptionTitle),
+	"{{maxLenOptionSummary}}", strconv.Itoa(maxLenOptionSummary),
+	"{{maxLenPlanDescription}}", strconv.Itoa(maxLenPlanDescription),
+	"{{maxLenActionCommand}}", strconv.Itoa(maxLenActionCommand),
+	"{{maxLenActionType}}", strconv.Itoa(maxLenActionType),
+	"{{maxLenActionDescription}}", strconv.Itoa(maxLenActionDescription),
+	"{{maxLenRollbackDescription}}", strconv.Itoa(maxLenRollbackDescription),
+	"{{maxLenRollbackCommand}}", strconv.Itoa(maxLenRollbackCommand),
+	"{{maxLenVerificationDescription}}", strconv.Itoa(maxLenVerificationDescription),
+	"{{maxLenVerificationStepName}}", strconv.Itoa(maxLenVerificationStepName),
+	"{{maxLenVerificationStepCommand}}", strconv.Itoa(maxLenVerificationStepCommand),
+	"{{maxLenVerificationStepExpected}}", strconv.Itoa(maxLenVerificationStepExpected),
+	"{{maxLenVerificationStepType}}", strconv.Itoa(maxLenVerificationStepType),
+	"{{maxLenRBACJustification}}", strconv.Itoa(maxLenRBACJustification),
 )
 
 // Default JSON Schemas sent to the agent for LLM structured output enforcement.
@@ -12,7 +32,7 @@ import (
 // controls the base schema (Default or Minimal mode) and optionally injects
 // a custom schema as a required "components" property in each option.
 
-var AnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
+var AnalysisOutputSchema = json.RawMessage(schemaReplacer.Replace(`{
   "type": "object",
   "properties": {
     "actionRequired": {
@@ -24,8 +44,8 @@ var AnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
       "type": "object",
       "description": "Top-level root cause analysis. Required when actionRequired is false. When actionRequired is true, diagnosis is provided per-option instead.",
       "properties": {
-        "summary": { "type": "string", "maxLength": %d, "description": "Markdown-formatted diagnosis summary explaining the problem, symptoms, and findings" },
-        "rootCause": { "type": "string", "maxLength": %d, "description": "Concise one-line root cause" }
+        "summary": { "type": "string", "maxLength": {{maxLenDiagnosisSummary}}, "description": "Markdown-formatted diagnosis summary explaining the problem, symptoms, and findings" },
+        "rootCause": { "type": "string", "maxLength": {{maxLenDiagnosisRootCause}}, "description": "Concise one-line root cause" }
       },
       "required": ["summary", "rootCause"]
     },
@@ -36,29 +56,29 @@ var AnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
       "items": {
         "type": "object",
         "properties": {
-          "title": { "type": "string", "maxLength": %d, "description": "Short human-readable title for this option (e.g., 'Increase memory limit', 'Scale horizontally')" },
-          "summary": { "type": "string", "maxLength": %d, "description": "Brief one-paragraph summary of this remediation approach" },
+          "title": { "type": "string", "maxLength": {{maxLenOptionTitle}}, "description": "Short human-readable title for this option (e.g., 'Increase memory limit', 'Scale horizontally')" },
+          "summary": { "type": "string", "maxLength": {{maxLenOptionSummary}}, "description": "Brief one-paragraph summary of this remediation approach" },
           "diagnosis": {
             "type": "object",
             "properties": {
-              "summary": { "type": "string", "maxLength": %d, "description": "Markdown-formatted root cause analysis explaining the problem, symptoms, and findings" },
-              "rootCause": { "type": "string", "maxLength": %d, "description": "Concise one-line root cause (e.g., 'OOMKilled due to memory limit of 256Mi')" }
+              "summary": { "type": "string", "maxLength": {{maxLenDiagnosisSummary}}, "description": "Markdown-formatted root cause analysis explaining the problem, symptoms, and findings" },
+              "rootCause": { "type": "string", "maxLength": {{maxLenDiagnosisRootCause}}, "description": "Concise one-line root cause (e.g., 'OOMKilled due to memory limit of 256Mi')" }
             },
             "required": ["summary", "rootCause"]
           },
           "remediationPlan": {
             "type": "object",
             "properties": {
-              "description": { "type": "string", "maxLength": %d, "description": "Markdown-formatted summary of the overall remediation approach" },
+              "description": { "type": "string", "maxLength": {{maxLenPlanDescription}}, "description": "Markdown-formatted summary of the overall remediation approach" },
               "actions": {
                 "type": "array",
                 "description": "Ordered list of exact bash commands to execute. Each action is one command.",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "command": { "type": "string", "maxLength": %d, "description": "Exact executable bash command using kubectl or oc (e.g., 'kubectl set image deployment/foo container=registry/foo:v1.3 -n production')" },
-                    "type": { "type": "string", "maxLength": %d, "description": "Action phase category (e.g., 'pre-check', 'mutation', 'wait', 'post-check')" },
-                    "description": { "type": "string", "maxLength": %d, "description": "What this command does and why" }
+                    "command": { "type": "string", "maxLength": {{maxLenActionCommand}}, "description": "Exact executable bash command using kubectl or oc (e.g., 'kubectl set image deployment/foo container=registry/foo:v1.3 -n production')" },
+                    "type": { "type": "string", "maxLength": {{maxLenActionType}}, "description": "Action phase category (e.g., 'pre-check', 'mutation', 'wait', 'post-check')" },
+                    "description": { "type": "string", "maxLength": {{maxLenActionDescription}}, "description": "What this command does and why" }
                   },
                   "required": ["command", "type", "description"]
                 }
@@ -68,8 +88,8 @@ var AnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
                 "type": "object",
                 "description": "How to undo the remediation if it fails or causes issues. Required when reversible is Reversible or Partial.",
                 "properties": {
-                  "description": { "type": "string", "maxLength": %d, "description": "How to undo the remediation if it fails or causes issues" },
-                  "command": { "type": "string", "maxLength": %d, "description": "The rollback command or steps to execute" }
+                  "description": { "type": "string", "maxLength": {{maxLenRollbackDescription}}, "description": "How to undo the remediation if it fails or causes issues" },
+                  "command": { "type": "string", "maxLength": {{maxLenRollbackCommand}}, "description": "The rollback command or steps to execute" }
                 },
                 "required": ["description", "command"]
               }
@@ -79,17 +99,17 @@ var AnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
           "verification": {
             "type": "object",
             "properties": {
-              "description": { "type": "string", "maxLength": %d, "description": "Summary of how to verify the remediation worked" },
+              "description": { "type": "string", "maxLength": {{maxLenVerificationDescription}}, "description": "Summary of how to verify the remediation worked" },
               "steps": {
                 "type": "array",
                 "description": "Ordered verification checks for the verification agent to run after execution",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "name": { "type": "string", "maxLength": %d, "description": "Short check identifier (e.g., 'pod-running', 'memory-usage-normal')" },
-                    "command": { "type": "string", "maxLength": %d, "description": "Command or API call to run (e.g., 'oc get pod -n production -l app=web -o jsonpath={.status.phase}')" },
-                    "expected": { "type": "string", "maxLength": %d, "description": "Expected output or condition (e.g., 'Running', 'ready=true')" },
-                    "type": { "type": "string", "maxLength": %d, "description": "Check category (e.g., 'command', 'metric', 'condition')" }
+                    "name": { "type": "string", "maxLength": {{maxLenVerificationStepName}}, "description": "Short check identifier (e.g., 'pod-running', 'memory-usage-normal')" },
+                    "command": { "type": "string", "maxLength": {{maxLenVerificationStepCommand}}, "description": "Command or API call to run (e.g., 'oc get pod -n production -l app=web -o jsonpath={.status.phase}')" },
+                    "expected": { "type": "string", "maxLength": {{maxLenVerificationStepExpected}}, "description": "Expected output or condition (e.g., 'Running', 'ready=true')" },
+                    "type": { "type": "string", "maxLength": {{maxLenVerificationStepType}}, "description": "Check category (e.g., 'command', 'metric', 'condition')" }
                   },
                   "required": ["name", "type"]
                 }
@@ -111,7 +131,7 @@ var AnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
                     "resources": { "type": "array", "items": { "type": "string" }, "description": "Resource types (e.g., 'pods', 'deployments', 'configmaps')" },
                     "resourceNames": { "type": "array", "items": { "type": "string" }, "description": "Restrict to specific named resources. Omit to allow all resources of the given type" },
                     "verbs": { "type": "array", "items": { "type": "string" }, "description": "Allowed operations (e.g., 'get', 'list', 'patch', 'delete')" },
-                    "justification": { "type": "string", "maxLength": %d, "description": "Why this permission is needed (e.g., 'Need to patch deployment to increase memory limit')" }
+                    "justification": { "type": "string", "maxLength": {{maxLenRBACJustification}}, "description": "Why this permission is needed (e.g., 'Need to patch deployment to increase memory limit')" }
                   },
                   "required": ["apiGroups", "resources", "verbs", "justification"]
                 }
@@ -126,7 +146,7 @@ var AnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
                     "resources": { "type": "array", "items": { "type": "string" }, "description": "Resource types (e.g., 'nodes', 'clusterroles')" },
                     "resourceNames": { "type": "array", "items": { "type": "string" }, "description": "Restrict to specific named resources. Omit to allow all resources of the given type" },
                     "verbs": { "type": "array", "items": { "type": "string" }, "description": "Allowed operations (e.g., 'get', 'list', 'patch', 'delete')" },
-                    "justification": { "type": "string", "maxLength": %d, "description": "Why this permission is needed" }
+                    "justification": { "type": "string", "maxLength": {{maxLenRBACJustification}}, "description": "Why this permission is needed" }
                   },
                   "required": ["apiGroups", "resources", "verbs", "justification"]
                 }
@@ -139,34 +159,14 @@ var AnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
     }
   },
   "required": ["actionRequired", "options"]
-}`,
-	maxLenDiagnosisSummary,         // diagnosis.summary
-	maxLenDiagnosisRootCause,       // diagnosis.rootCause
-	maxLenOptionTitle,              // options[].title
-	maxLenOptionSummary,            // options[].summary
-	maxLenDiagnosisSummary,         // options[].diagnosis.summary
-	maxLenDiagnosisRootCause,       // options[].diagnosis.rootCause
-	maxLenPlanDescription,          // remediationPlan.description
-	maxLenActionCommand,            // actions[].command
-	maxLenActionType,               // actions[].type
-	maxLenActionDescription,        // actions[].description
-	maxLenRollbackDescription,      // rollbackPlan.description
-	maxLenRollbackCommand,          // rollbackPlan.command
-	maxLenVerificationDescription,  // verification.description
-	maxLenVerificationStepName,     // steps[].name
-	maxLenVerificationStepCommand,  // steps[].command
-	maxLenVerificationStepExpected, // steps[].expected
-	maxLenVerificationStepType,     // steps[].type
-	maxLenRBACJustification,        // namespaceScoped[].justification
-	maxLenRBACJustification,        // clusterScoped[].justification
-))
+}`))
 
 // MinimalAnalysisOutputSchema is the base analysis output schema used
 // when AnalysisOutputMode is Minimal. It contains only the options array
 // with title per option. Built-in properties (diagnosis, remediationPlan, rbac,
 // verification, summary) are omitted. If execution or verification steps
 // exist, those specific property definitions are added back dynamically.
-var MinimalAnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
+var MinimalAnalysisOutputSchema = json.RawMessage(schemaReplacer.Replace(`{
   "type": "object",
   "properties": {
     "actionRequired": {
@@ -178,8 +178,8 @@ var MinimalAnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
       "type": "object",
       "description": "Top-level root cause analysis. Required when actionRequired is false.",
       "properties": {
-        "summary": { "type": "string", "maxLength": %d, "description": "Markdown-formatted diagnosis summary" },
-        "rootCause": { "type": "string", "maxLength": %d, "description": "Concise one-line root cause" }
+        "summary": { "type": "string", "maxLength": {{maxLenDiagnosisSummary}}, "description": "Markdown-formatted diagnosis summary" },
+        "rootCause": { "type": "string", "maxLength": {{maxLenDiagnosisRootCause}}, "description": "Concise one-line root cause" }
       },
       "required": ["summary", "rootCause"]
     },
@@ -190,18 +190,14 @@ var MinimalAnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
       "items": {
         "type": "object",
         "properties": {
-          "title": { "type": "string", "maxLength": %d, "description": "Short human-readable title for this option" }
+          "title": { "type": "string", "maxLength": {{maxLenOptionTitle}}, "description": "Short human-readable title for this option" }
         },
         "required": ["title"]
       }
     }
   },
   "required": ["actionRequired", "options"]
-}`,
-	maxLenDiagnosisSummary,   // diagnosis.summary
-	maxLenDiagnosisRootCause, // diagnosis.rootCause
-	maxLenOptionTitle,        // options[].title
-))
+}`))
 
 var ExecutionOutputSchema = json.RawMessage(`{
   "type": "object",

--- a/controller/agenticrun/schemas.go
+++ b/controller/agenticrun/schemas.go
@@ -2,6 +2,7 @@ package agenticrun
 
 import (
 	"encoding/json"
+	"fmt"
 
 	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 )
@@ -11,7 +12,7 @@ import (
 // controls the base schema (Default or Minimal mode) and optionally injects
 // a custom schema as a required "components" property in each option.
 
-var AnalysisOutputSchema = json.RawMessage(`{
+var AnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
   "type": "object",
   "properties": {
     "actionRequired": {
@@ -23,8 +24,8 @@ var AnalysisOutputSchema = json.RawMessage(`{
       "type": "object",
       "description": "Top-level root cause analysis. Required when actionRequired is false. When actionRequired is true, diagnosis is provided per-option instead.",
       "properties": {
-        "summary": { "type": "string", "description": "Markdown-formatted diagnosis summary explaining the problem, symptoms, and findings" },
-        "rootCause": { "type": "string", "description": "Concise one-line root cause" }
+        "summary": { "type": "string", "maxLength": %d, "description": "Markdown-formatted diagnosis summary explaining the problem, symptoms, and findings" },
+        "rootCause": { "type": "string", "maxLength": %d, "description": "Concise one-line root cause" }
       },
       "required": ["summary", "rootCause"]
     },
@@ -35,29 +36,29 @@ var AnalysisOutputSchema = json.RawMessage(`{
       "items": {
         "type": "object",
         "properties": {
-          "title": { "type": "string", "description": "Short human-readable title for this option (e.g., 'Increase memory limit', 'Scale horizontally')" },
-          "summary": { "type": "string", "description": "Brief one-paragraph summary of this remediation approach" },
+          "title": { "type": "string", "maxLength": %d, "description": "Short human-readable title for this option (e.g., 'Increase memory limit', 'Scale horizontally')" },
+          "summary": { "type": "string", "maxLength": %d, "description": "Brief one-paragraph summary of this remediation approach" },
           "diagnosis": {
             "type": "object",
             "properties": {
-              "summary": { "type": "string", "description": "Markdown-formatted root cause analysis explaining the problem, symptoms, and findings" },
-              "rootCause": { "type": "string", "description": "Concise one-line root cause (e.g., 'OOMKilled due to memory limit of 256Mi')" }
+              "summary": { "type": "string", "maxLength": %d, "description": "Markdown-formatted root cause analysis explaining the problem, symptoms, and findings" },
+              "rootCause": { "type": "string", "maxLength": %d, "description": "Concise one-line root cause (e.g., 'OOMKilled due to memory limit of 256Mi')" }
             },
             "required": ["summary", "rootCause"]
           },
           "remediationPlan": {
             "type": "object",
             "properties": {
-              "description": { "type": "string", "description": "Markdown-formatted summary of the overall remediation approach" },
+              "description": { "type": "string", "maxLength": %d, "description": "Markdown-formatted summary of the overall remediation approach" },
               "actions": {
                 "type": "array",
                 "description": "Ordered list of exact bash commands to execute. Each action is one command.",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "command": { "type": "string", "description": "Exact executable bash command using kubectl or oc (e.g., 'kubectl set image deployment/foo container=registry/foo:v1.3 -n production')" },
-                    "type": { "type": "string", "description": "Action phase category (e.g., 'pre-check', 'mutation', 'wait', 'post-check')" },
-                    "description": { "type": "string", "description": "What this command does and why" }
+                    "command": { "type": "string", "maxLength": %d, "description": "Exact executable bash command using kubectl or oc (e.g., 'kubectl set image deployment/foo container=registry/foo:v1.3 -n production')" },
+                    "type": { "type": "string", "maxLength": %d, "description": "Action phase category (e.g., 'pre-check', 'mutation', 'wait', 'post-check')" },
+                    "description": { "type": "string", "maxLength": %d, "description": "What this command does and why" }
                   },
                   "required": ["command", "type", "description"]
                 }
@@ -67,8 +68,8 @@ var AnalysisOutputSchema = json.RawMessage(`{
                 "type": "object",
                 "description": "How to undo the remediation if it fails or causes issues. Required when reversible is Reversible or Partial.",
                 "properties": {
-                  "description": { "type": "string", "description": "How to undo the remediation if it fails or causes issues" },
-                  "command": { "type": "string", "description": "The rollback command or steps to execute" }
+                  "description": { "type": "string", "maxLength": %d, "description": "How to undo the remediation if it fails or causes issues" },
+                  "command": { "type": "string", "maxLength": %d, "description": "The rollback command or steps to execute" }
                 },
                 "required": ["description", "command"]
               }
@@ -78,17 +79,17 @@ var AnalysisOutputSchema = json.RawMessage(`{
           "verification": {
             "type": "object",
             "properties": {
-              "description": { "type": "string", "description": "Summary of how to verify the remediation worked" },
+              "description": { "type": "string", "maxLength": %d, "description": "Summary of how to verify the remediation worked" },
               "steps": {
                 "type": "array",
                 "description": "Ordered verification checks for the verification agent to run after execution",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "name": { "type": "string", "description": "Short check identifier (e.g., 'pod-running', 'memory-usage-normal')" },
-                    "command": { "type": "string", "description": "Command or API call to run (e.g., 'oc get pod -n production -l app=web -o jsonpath={.status.phase}')" },
-                    "expected": { "type": "string", "description": "Expected output or condition (e.g., 'Running', 'ready=true')" },
-                    "type": { "type": "string", "description": "Check category (e.g., 'command', 'metric', 'condition')" }
+                    "name": { "type": "string", "maxLength": %d, "description": "Short check identifier (e.g., 'pod-running', 'memory-usage-normal')" },
+                    "command": { "type": "string", "maxLength": %d, "description": "Command or API call to run (e.g., 'oc get pod -n production -l app=web -o jsonpath={.status.phase}')" },
+                    "expected": { "type": "string", "maxLength": %d, "description": "Expected output or condition (e.g., 'Running', 'ready=true')" },
+                    "type": { "type": "string", "maxLength": %d, "description": "Check category (e.g., 'command', 'metric', 'condition')" }
                   },
                   "required": ["name", "type"]
                 }
@@ -110,7 +111,7 @@ var AnalysisOutputSchema = json.RawMessage(`{
                     "resources": { "type": "array", "items": { "type": "string" }, "description": "Resource types (e.g., 'pods', 'deployments', 'configmaps')" },
                     "resourceNames": { "type": "array", "items": { "type": "string" }, "description": "Restrict to specific named resources. Omit to allow all resources of the given type" },
                     "verbs": { "type": "array", "items": { "type": "string" }, "description": "Allowed operations (e.g., 'get', 'list', 'patch', 'delete')" },
-                    "justification": { "type": "string", "description": "Why this permission is needed (e.g., 'Need to patch deployment to increase memory limit')" }
+                    "justification": { "type": "string", "maxLength": %d, "description": "Why this permission is needed (e.g., 'Need to patch deployment to increase memory limit')" }
                   },
                   "required": ["apiGroups", "resources", "verbs", "justification"]
                 }
@@ -125,7 +126,7 @@ var AnalysisOutputSchema = json.RawMessage(`{
                     "resources": { "type": "array", "items": { "type": "string" }, "description": "Resource types (e.g., 'nodes', 'clusterroles')" },
                     "resourceNames": { "type": "array", "items": { "type": "string" }, "description": "Restrict to specific named resources. Omit to allow all resources of the given type" },
                     "verbs": { "type": "array", "items": { "type": "string" }, "description": "Allowed operations (e.g., 'get', 'list', 'patch', 'delete')" },
-                    "justification": { "type": "string", "description": "Why this permission is needed" }
+                    "justification": { "type": "string", "maxLength": %d, "description": "Why this permission is needed" }
                   },
                   "required": ["apiGroups", "resources", "verbs", "justification"]
                 }
@@ -138,14 +139,34 @@ var AnalysisOutputSchema = json.RawMessage(`{
     }
   },
   "required": ["actionRequired", "options"]
-}`)
+}`,
+	maxLenDiagnosisSummary,         // diagnosis.summary
+	maxLenDiagnosisRootCause,       // diagnosis.rootCause
+	maxLenOptionTitle,              // options[].title
+	maxLenOptionSummary,            // options[].summary
+	maxLenDiagnosisSummary,         // options[].diagnosis.summary
+	maxLenDiagnosisRootCause,       // options[].diagnosis.rootCause
+	maxLenPlanDescription,          // remediationPlan.description
+	maxLenActionCommand,            // actions[].command
+	maxLenActionType,               // actions[].type
+	maxLenActionDescription,        // actions[].description
+	maxLenRollbackDescription,      // rollbackPlan.description
+	maxLenRollbackCommand,          // rollbackPlan.command
+	maxLenVerificationDescription,  // verification.description
+	maxLenVerificationStepName,     // steps[].name
+	maxLenVerificationStepCommand,  // steps[].command
+	maxLenVerificationStepExpected, // steps[].expected
+	maxLenVerificationStepType,     // steps[].type
+	maxLenRBACJustification,        // namespaceScoped[].justification
+	maxLenRBACJustification,        // clusterScoped[].justification
+))
 
 // MinimalAnalysisOutputSchema is the base analysis output schema used
 // when AnalysisOutputMode is Minimal. It contains only the options array
 // with title per option. Built-in properties (diagnosis, remediationPlan, rbac,
 // verification, summary) are omitted. If execution or verification steps
 // exist, those specific property definitions are added back dynamically.
-var MinimalAnalysisOutputSchema = json.RawMessage(`{
+var MinimalAnalysisOutputSchema = json.RawMessage(fmt.Sprintf(`{
   "type": "object",
   "properties": {
     "actionRequired": {
@@ -157,8 +178,8 @@ var MinimalAnalysisOutputSchema = json.RawMessage(`{
       "type": "object",
       "description": "Top-level root cause analysis. Required when actionRequired is false.",
       "properties": {
-        "summary": { "type": "string", "description": "Markdown-formatted diagnosis summary" },
-        "rootCause": { "type": "string", "description": "Concise one-line root cause" }
+        "summary": { "type": "string", "maxLength": %d, "description": "Markdown-formatted diagnosis summary" },
+        "rootCause": { "type": "string", "maxLength": %d, "description": "Concise one-line root cause" }
       },
       "required": ["summary", "rootCause"]
     },
@@ -169,14 +190,18 @@ var MinimalAnalysisOutputSchema = json.RawMessage(`{
       "items": {
         "type": "object",
         "properties": {
-          "title": { "type": "string", "description": "Short human-readable title for this option" }
+          "title": { "type": "string", "maxLength": %d, "description": "Short human-readable title for this option" }
         },
         "required": ["title"]
       }
     }
   },
   "required": ["actionRequired", "options"]
-}`)
+}`,
+	maxLenDiagnosisSummary,   // diagnosis.summary
+	maxLenDiagnosisRootCause, // diagnosis.rootCause
+	maxLenOptionTitle,        // options[].title
+))
 
 var ExecutionOutputSchema = json.RawMessage(`{
   "type": "object",


### PR DESCRIPTION
Prevent CRD validation failures caused by LLM output exceeding field constraints:

1. Add maxLength to all string fields in AnalysisOutputSchema and MinimalAnalysisOutputSchema so the LLM sees CRD limits upfront.

2. Add sanitizeAnalysisOptions() in Analyze() to zero Diagnosis structs with empty required fields and truncate strings exceeding CRD limits.

Both layers share the same maxLen* constants to stay in sync.

Add TestSchemasCoverCRDMaxLength drift test to catch future divergence between CRD and LLM schema maxLength values.


Assisted-by: Claude Code:claude-opus-4-6