### PR TITLE
OLS-3796: batch sandbox e2e tests

### DIFF
--- a/.tekton/integration-tests/scripts/install-operator.sh
+++ b/.tekton/integration-tests/scripts/install-operator.sh
@@ -7,9 +7,10 @@
 #   KUBECONFIG       — path to kubeconfig
 #
 # Optional env:
-#   OPERATOR_NAMESPACE  (default: openshift-lightspeed)
-#   SANDBOX_MODE        (default: bare-pod)
-#   SANDBOX_IMAGE       (default: quay.io/openshift-lightspeed/ols-qe:lightspeed-mock-agent1)
+#   OPERATOR_NAMESPACE    (default: openshift-lightspeed)
+#   SANDBOX_MODE          (default: bare-pod)
+#   SANDBOX_IMAGE         (default: quay.io/openshift-lightspeed/ols-qe:lightspeed-mock-agent1)
+#   OTEL_COLLECTOR_IMAGE  (default: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector:main)
 
 set -euo pipefail
 
@@ -19,12 +20,14 @@ set -euo pipefail
 OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-openshift-lightspeed}"
 SANDBOX_MODE="${SANDBOX_MODE:-bare-pod}"
 SANDBOX_IMAGE="${SANDBOX_IMAGE:-quay.io/openshift-lightspeed/ols-qe:lightspeed-mock-agent1}"
+OTEL_COLLECTOR_IMAGE="${OTEL_COLLECTOR_IMAGE:-quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector:main}"
 
 echo "=== Agentic operator install ==="
-echo "  IMG:                ${IMG}"
-echo "  OPERATOR_NAMESPACE: ${OPERATOR_NAMESPACE}"
-echo "  SANDBOX_MODE:       ${SANDBOX_MODE}"
-echo "  SANDBOX_IMAGE:      ${SANDBOX_IMAGE}"
+echo "  IMG:                  ${IMG}"
+echo "  OPERATOR_NAMESPACE:   ${OPERATOR_NAMESPACE}"
+echo "  SANDBOX_MODE:         ${SANDBOX_MODE}"
+echo "  SANDBOX_IMAGE:        ${SANDBOX_IMAGE}"
+echo "  OTEL_COLLECTOR_IMAGE: ${OTEL_COLLECTOR_IMAGE}"
 echo "================================="
 
 # Ensure namespace exists.
@@ -72,9 +75,192 @@ subjects:
   namespace: ${OPERATOR_NAMESPACE}
 EOF
 
+# --- OTEL Collector (debug exporter for trace verification) ---
+
+echo "Deploying OTEL collector..."
+
+# Collector runtime config: OTLP receiver with TLS + debug exporter.
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lightspeed-otel-collector-config
+  namespace: ${OPERATOR_NAMESPACE}
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+            tls:
+              cert_file: /var/run/secrets/serving-cert/tls.crt
+              key_file: /var/run/secrets/serving-cert/tls.key
+    exporters:
+      debug:
+        verbosity: detailed
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:13133"
+    service:
+      extensions: [health_check]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]
+        logs:
+          receivers: [otlp]
+          exporters: [debug]
+EOF
+
+# Service with serving-cert annotation — service-ca auto-generates TLS secret.
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: lightspeed-otel-collector
+  namespace: ${OPERATOR_NAMESPACE}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: lightspeed-otel-collector-cert
+spec:
+  selector:
+    app: lightspeed-otel-collector
+  type: ClusterIP
+  ports:
+  - name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: otlp-grpc
+  - name: admin
+    port: 8443
+    protocol: TCP
+    targetPort: admin
+EOF
+
+# ConfigMap for CA bundle injection by service-ca.
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lightspeed-otel-collector-cabundle
+  namespace: ${OPERATOR_NAMESPACE}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+data: {}
+EOF
+
+echo "Waiting for OTEL collector TLS secret..."
+for _ in $(seq 1 30); do
+  if oc get secret lightspeed-otel-collector-cert -n "${OPERATOR_NAMESPACE}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+oc get secret lightspeed-otel-collector-cert -n "${OPERATOR_NAMESPACE}" || {
+  echo "ERROR: TLS secret not created by service-ca after 60s"
+  exit 1
+}
+
+echo "Waiting for CA bundle injection..."
+CA_BUNDLE=""
+for _ in $(seq 1 30); do
+  CA_BUNDLE=$(oc get configmap lightspeed-otel-collector-cabundle -n "${OPERATOR_NAMESPACE}" \
+    -o jsonpath='{.data.service-ca\.crt}' 2>/dev/null || true)
+  if [ -n "${CA_BUNDLE}" ]; then
+    break
+  fi
+  sleep 2
+done
+if [ -z "${CA_BUNDLE}" ]; then
+  echo "ERROR: CA bundle not injected after 60s"
+  exit 1
+fi
+
+# Create the CA Secret the operator reads (key must be otel-ca.crt).
+TMPCA=$(mktemp)
+echo "${CA_BUNDLE}" > "${TMPCA}"
+oc create secret generic lightspeed-otel-ca -n "${OPERATOR_NAMESPACE}" \
+  --from-file=otel-ca.crt="${TMPCA}" --dry-run=client -o yaml | oc apply -f -
+rm -f "${TMPCA}"
+
+# Deployment.
+oc apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lightspeed-otel-collector
+  namespace: ${OPERATOR_NAMESPACE}
+  labels:
+    app: lightspeed-otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lightspeed-otel-collector
+  template:
+    metadata:
+      labels:
+        app: lightspeed-otel-collector
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - name: otel-collector
+        image: ${OTEL_COLLECTOR_IMAGE}
+        args: ["--config=/etc/otel/config.yaml"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+        ports:
+        - name: otlp-grpc
+          containerPort: 4317
+          protocol: TCP
+        - name: health
+          containerPort: 13133
+          protocol: TCP
+        - name: admin
+          containerPort: 8443
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: health
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /
+            port: health
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - name: config
+          mountPath: /etc/otel
+          readOnly: true
+        - name: serving-cert
+          mountPath: /var/run/secrets/serving-cert
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: lightspeed-otel-collector-config
+      - name: serving-cert
+        secret:
+          secretName: lightspeed-otel-collector-cert
+EOF
+
+echo "Waiting for OTEL collector rollout..."
+oc rollout status deployment/lightspeed-otel-collector -n "${OPERATOR_NAMESPACE}" --timeout=120s
+
+OTEL_ENDPOINT="lightspeed-otel-collector.${OPERATOR_NAMESPACE}.svc:4317"
+OTEL_ADMIN="https://lightspeed-otel-collector.${OPERATOR_NAMESPACE}.svc:8443"
+echo "OTEL collector ready at ${OTEL_ENDPOINT}"
+
 # Create the unified configuration ConfigMap.
-# sandbox-mode + sandbox-pod-spec drive pod creation; OTEL keys are absent
-# so telemetry is silently disabled (IsValid=false).
 echo "Creating lightspeed-agentic-configuration ConfigMap..."
 oc apply -f - <<EOF
 apiVersion: v1
@@ -89,6 +275,7 @@ data:
       "containers": [{
         "name": "agent",
         "image": "${SANDBOX_IMAGE}",
+        "imagePullPolicy": "Always",
         "ports": [{"containerPort": 8080}],
         "securityContext": {
           "allowPrivilegeEscalation": false,
@@ -102,6 +289,9 @@ data:
         "seccompProfile": {"type": "RuntimeDefault"}
       }
     }
+  otel-collector-endpoint: "${OTEL_ENDPOINT}"
+  otel-ca-secret: "lightspeed-otel-ca"
+  otel-admin-endpoint: "${OTEL_ADMIN}"
 EOF
 
 # Wait for rollout.

--- a/.tekton/lightspeed-agentic-operator-pull-request.yaml
+++ b/.tekton/lightspeed-agentic-operator-pull-request.yaml
@@ -11,7 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main" && ("Dockerfile".pathChanged() || "go.mod".pathChanged() || "go.sum".pathChanged()
       || "api/**".pathChanged() || "cmd/**".pathChanged() || "controller/**".pathChanged()
-      || "LICENSE".pathChanged() || ".tekton/lightspeed-agentic-operator-pull-request.yaml".pathChanged())
+      || "test/**".pathChanged() || "LICENSE".pathChanged()
+      || ".tekton/lightspeed-agentic-operator-pull-request.yaml".pathChanged())
   labels:
     appstudio.openshift.io/application: ols
     appstudio.openshift.io/component: lightspeed-agentic-operator

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test: fmt-check vet ## Run unit tests (main + api + cli modules).
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests against a live cluster (operator must be running). See test/e2e/ for prereqs.
-	go test -tags=e2e ./test/e2e/... -count=1 -v -timeout 30m
+	go test -tags=e2e ./test/e2e/... -count=1 -v -timeout 60m
 
 .PHONY: product-e2e
 product-e2e: ## Run product e2e: deploy operator, run all providers against live LLMs, collect artifacts.

--- a/test/agent/main.go
+++ b/test/agent/main.go
@@ -66,7 +66,7 @@ func main() {
 	switch {
 	case strings.Contains(queryStr, MockTimeout):
 		log.Println("MOCK_TIMEOUT: sleeping forever")
-		select {}
+		time.Sleep(24 * time.Hour)
 	case strings.Contains(queryStr, MockCrash):
 		log.Fatalf("MOCK_CRASH: exiting without creating Result CR")
 	case strings.Contains(queryStr, MockAgentFail):

--- a/test/e2e/analysis_execution_test.go
+++ b/test/e2e/analysis_execution_test.go
@@ -36,8 +36,6 @@ func TestAnalysisFlow_AgenticRunToProposed(t *testing.T) {
 	c := newClient(t)
 	ctx := context.Background()
 
-	t.Log("Creating fixtures (LLMProvider, Agent, ApprovalPolicy, Secret)")
-	createFixtures(t, c)
 	prop := createAgenticRun(t, c, "e2e-analysis-flow")
 	t.Logf("AgenticRun created: %s/%s", testNS, prop.Name)
 

--- a/test/e2e/denial_test.go
+++ b/test/e2e/denial_test.go
@@ -22,8 +22,6 @@ func TestDenialFlow_ProposedToDenied(t *testing.T) {
 	c := newClient(t)
 	ctx := context.Background()
 
-	t.Log("Creating fixtures (LLMProvider, Agent, ApprovalPolicy, Secret)")
-	createFixtures(t, c)
 	prop := createAgenticRun(t, c, "e2e-denial-flow")
 	t.Logf("AgenticRun created: %s/%s", testNS, prop.Name)
 

--- a/test/e2e/execution_test.go
+++ b/test/e2e/execution_test.go
@@ -28,8 +28,6 @@ func TestExecutionFlow_ProposedToVerifying(t *testing.T) {
 	c := newClient(t)
 	ctx := context.Background()
 
-	t.Log("Creating fixtures (LLMProvider, Agent, ApprovalPolicy, Secret)")
-	createFixtures(t, c)
 	prop := createAgenticRun(t, c, "e2e-execution-flow")
 	t.Logf("AgenticRun created: %s/%s", testNS, prop.Name)
 

--- a/test/e2e/failure_test.go
+++ b/test/e2e/failure_test.go
@@ -1,0 +1,270 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+// TestSandboxCrash validates that the operator correctly handles a sandbox pod
+// that crashes (exits non-zero) without producing a Result CR:
+//
+//  1. Create AgenticRun with MOCK_CRASH in the request text
+//  2. Mock agent exits 1 immediately — no Result CR created
+//  3. Operator detects pod failure → sets Analyzed=False/SandboxFailed
+//  4. AgenticRun transitions to Failed
+func TestSandboxCrash(t *testing.T) {
+	t.Log("=== TestSandboxCrash: validates sandbox crash → Failed with SandboxFailed ===")
+	c := newClient(t)
+
+	prop := createAgenticRunWithRequest(t, c, "e2e-sandbox-crash", "MOCK_CRASH")
+	t.Logf("AgenticRun created: %s/%s", testNS, prop.Name)
+
+	t.Log("Waiting for phase: Failed (sandbox crash)")
+	updated := waitForPhase(t, c, prop.Name, agenticv1alpha1.AgenticRunPhaseFailed)
+	t.Log("Phase reached: Failed")
+
+	assertStepCondition(t, updated.Status.Conditions, agenticv1alpha1.AgenticRunConditionAnalyzed,
+		metav1.ConditionFalse, "SandboxFailed")
+
+	if len(updated.Status.Steps.Analysis.Results) > 0 {
+		t.Errorf("expected no analysis result refs (pod crashed), got %d", len(updated.Status.Steps.Analysis.Results))
+	}
+
+	t.Log("PASS: sandbox crash detected, phase=Failed, reason=SandboxFailed, no result ref")
+}
+
+// TestAgentFailure validates that the operator correctly handles an agent that
+// reports failure via the Result CR's failureReason field:
+//
+//  1. Create AnalysisResult CR with failureReason and Completed=True
+//  2. Create AgenticRun with MOCK_AGENT_FAIL (mock exits immediately)
+//  3. Operator finds pre-created Result CR with failureReason
+//  4. Operator sets Analyzed=False/SandboxFailed with the failure reason,
+//     records the result ref
+func TestAgentFailure(t *testing.T) {
+	t.Log("=== TestAgentFailure: validates agent failure via Result CR failureReason ===")
+	c := newClient(t)
+	ctx := context.Background()
+
+	runName := "e2e-agent-failure"
+	resultName := fmt.Sprintf("%s-analysis-1", runName)
+	failureMsg := "simulated agent error: tool execution failed"
+
+	ar := &agenticv1alpha1.AnalysisResult{
+		ObjectMeta: metav1.ObjectMeta{Name: resultName, Namespace: testNS},
+		Spec:       agenticv1alpha1.AnalysisResultSpec{AgenticRunName: runName},
+	}
+	if err := c.Create(ctx, ar); err != nil {
+		t.Fatalf("create AnalysisResult: %v", err)
+	}
+	t.Cleanup(func() { cleanup(t, c, ar) })
+
+	ar.Status.FailureReason = failureMsg
+	ar.Status.Conditions = []metav1.Condition{{
+		Type:               "Completed",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Failed",
+		LastTransitionTime: metav1.Now(),
+	}}
+	if err := c.Status().Update(ctx, ar); err != nil {
+		t.Fatalf("update AnalysisResult status: %v", err)
+	}
+	t.Logf("Created AnalysisResult %s with failureReason=%q", resultName, failureMsg)
+
+	prop := createAgenticRunWithRequest(t, c, runName, "MOCK_AGENT_FAIL")
+	t.Logf("AgenticRun created: %s/%s", testNS, prop.Name)
+
+	t.Log("Waiting for phase: Failed (agent failure)")
+	updated := waitForPhase(t, c, prop.Name, agenticv1alpha1.AgenticRunPhaseFailed)
+	t.Log("Phase reached: Failed")
+
+	assertStepCondition(t, updated.Status.Conditions, agenticv1alpha1.AgenticRunConditionAnalyzed,
+		metav1.ConditionFalse, "SandboxFailed")
+
+	if len(updated.Status.Steps.Analysis.Results) == 0 {
+		t.Fatal("expected analysis result ref (agent failure), got none")
+	}
+	t.Logf("Verified: result ref recorded: %s", updated.Status.Steps.Analysis.Results[0].Name)
+
+	t.Log("PASS: agent failure detected, phase=Failed, reason=SandboxFailed, result ref present")
+}
+
+// TestSandboxTimeout validates that the operator kills a sandbox pod that
+// exceeds the per-step timeout and sets the SandboxTimeout condition:
+//
+//  1. Create AgenticRun with MOCK_TIMEOUT in the request text
+//  2. Mock agent sleeps forever — never creates Result CR
+//  3. Operator's timeout loop detects the pod exceeded the analysis timeout
+//  4. Operator kills the pod and sets Analyzed=False/SandboxTimeout
+//  5. AgenticRun transitions to Failed
+func TestSandboxTimeout(t *testing.T) {
+	t.Log("=== TestSandboxTimeout: validates sandbox timeout → Failed with SandboxTimeout ===")
+	c := newClient(t)
+
+	prop := createAgenticRunWithRequest(t, c, "e2e-sandbox-timeout", "MOCK_TIMEOUT")
+	t.Logf("AgenticRun created: %s/%s", testNS, prop.Name)
+
+	t.Log("Waiting for phase: Failed (sandbox timeout — this takes ~11 minutes)")
+	updated := waitForPhaseWithTimeout(t, c, prop.Name, agenticv1alpha1.AgenticRunPhaseFailed, 12*time.Minute)
+	t.Log("Phase reached: Failed")
+
+	assertStepCondition(t, updated.Status.Conditions, agenticv1alpha1.AgenticRunConditionAnalyzed,
+		metav1.ConditionFalse, "SandboxTimeout")
+
+	if len(updated.Status.Steps.Analysis.Results) > 0 {
+		t.Errorf("expected no analysis result refs (pod timed out), got %d", len(updated.Status.Steps.Analysis.Results))
+	}
+
+	t.Log("PASS: sandbox timeout detected, phase=Failed, reason=SandboxTimeout, no result ref")
+}
+
+// TestNoResultCR validates that the operator handles a sandbox pod that
+// succeeds (exit 0) but writes a Result CR without patching its status
+// (no Completed condition):
+//
+//  1. Create AgenticRun with MOCK_NO_STATUS
+//  2. Mock agent creates Result CR without status, exits 0
+//  3. Operator detects missing Completed condition → SandboxFailed
+//  4. No result ref recorded (CR was not valid)
+func TestNoResultCR(t *testing.T) {
+	t.Log("=== TestNoResultCR: validates pod exit 0 without Completed status → Failed ===")
+	c := newClient(t)
+
+	prop := createAgenticRunWithRequest(t, c, "e2e-no-result-cr", "MOCK_NO_STATUS")
+	t.Logf("AgenticRun created: %s/%s", testNS, prop.Name)
+
+	t.Log("Waiting for phase: Failed (no valid result)")
+	updated := waitForPhase(t, c, prop.Name, agenticv1alpha1.AgenticRunPhaseFailed)
+	t.Log("Phase reached: Failed")
+
+	assertStepCondition(t, updated.Status.Conditions, agenticv1alpha1.AgenticRunConditionAnalyzed,
+		metav1.ConditionFalse, "SandboxFailed")
+
+	if len(updated.Status.Steps.Analysis.Results) > 0 {
+		t.Errorf("expected no analysis result refs (incomplete CR), got %d", len(updated.Status.Steps.Analysis.Results))
+	}
+
+	t.Log("PASS: incomplete result detected, phase=Failed, reason=SandboxFailed, no result ref")
+}
+
+// TestRapidDelete validates that deleting an AgenticRun immediately after
+// creation cleans up orphaned sandbox resources (pods, RBAC):
+//
+//  1. Create AgenticRun, wait for Analyzing (sandbox pod starting)
+//  2. Delete the AgenticRun immediately
+//  3. Verify the AgenticRun is fully removed (finalizer processed)
+//  4. Verify no orphaned sandbox pods remain
+func TestRapidDelete(t *testing.T) {
+	t.Log("=== TestRapidDelete: validates DELETE during analysis cleans up orphans ===")
+	c := newClient(t)
+	ctx := context.Background()
+
+	prop := createAgenticRunWithRequest(t, c, "e2e-rapid-delete", "Pod crash-looping in staging namespace")
+	t.Logf("AgenticRun created: %s/%s", testNS, prop.Name)
+
+	t.Log("Waiting for phase: Analyzing (sandbox starting)")
+	waitForPhase(t, c, prop.Name, agenticv1alpha1.AgenticRunPhaseAnalyzing)
+
+	t.Log("Deleting AgenticRun immediately")
+	if err := c.Delete(ctx, prop); err != nil {
+		t.Fatalf("delete AgenticRun: %v", err)
+	}
+
+	t.Log("Waiting for AgenticRun to disappear (finalizer cleanup)")
+	waitForDeletion(t, c, prop.Name)
+
+	t.Log("Verifying no orphaned sandbox pods")
+	var pods corev1.PodList
+	if err := c.List(ctx, &pods, client.InNamespace(testNS),
+		client.MatchingLabels{"agentic.openshift.io/run": "e2e-rapid-delete"}); err != nil {
+		t.Fatalf("list sandbox pods: %v", err)
+	}
+	if len(pods.Items) > 0 {
+		t.Errorf("expected no orphaned sandbox pods, found %d", len(pods.Items))
+	}
+
+	t.Log("PASS: rapid delete handled, no orphaned resources")
+}
+
+// TestPendingPodTimeout validates that the operator detects a sandbox pod
+// stuck in Pending (cannot be scheduled) and times out via podStartTimeout.
+// Uses a nodeSelector that matches no nodes to force Pending.
+func TestPendingPodTimeout(t *testing.T) {
+	t.Log("=== TestPendingPodTimeout: validates unschedulable pod → SandboxTimeout ===")
+	c := newClient(t)
+	ctx := context.Background()
+
+	// Patch the sandbox-pod-spec to add an impossible nodeSelector.
+	var cm corev1.ConfigMap
+	cmKey := client.ObjectKey{Name: "lightspeed-agentic-configuration", Namespace: testNS}
+	if err := c.Get(ctx, cmKey, &cm); err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	originalSpec := cm.Data["sandbox-pod-spec"]
+
+	// Inject nodeSelector at pod level (not container level).
+	var podSpec map[string]interface{}
+	if err := json.Unmarshal([]byte(originalSpec), &podSpec); err != nil {
+		t.Fatalf("parse sandbox-pod-spec: %v", err)
+	}
+	podSpec["nodeSelector"] = map[string]string{"e2e-nonexistent-label": "true"}
+	patchedBytes, err := json.Marshal(podSpec)
+	if err != nil {
+		t.Fatalf("marshal patched pod spec: %v", err)
+	}
+	cm.Data["sandbox-pod-spec"] = string(patchedBytes)
+	if err := c.Update(ctx, &cm); err != nil {
+		t.Fatalf("patch sandbox-pod-spec: %v", err)
+	}
+	t.Cleanup(func() {
+		var restore corev1.ConfigMap
+		if err := c.Get(ctx, cmKey, &restore); err == nil {
+			restore.Data["sandbox-pod-spec"] = originalSpec
+			_ = c.Update(ctx, &restore)
+		}
+	})
+	t.Log("Patched sandbox-pod-spec with impossible nodeSelector")
+
+	prop := createAgenticRunWithRequest(t, c, "e2e-pending-timeout", "Pod crash-looping in staging namespace")
+	t.Logf("AgenticRun created: %s/%s", testNS, prop.Name)
+
+	// podStartTimeout is 5 minutes, timeout check interval is 1 minute → ~6 min.
+	t.Log("Waiting for phase: Failed (pod start timeout — this takes ~6 minutes)")
+	updated := waitForPhaseWithTimeout(t, c, prop.Name, agenticv1alpha1.AgenticRunPhaseFailed, 8*time.Minute)
+	t.Log("Phase reached: Failed")
+
+	assertStepCondition(t, updated.Status.Conditions, agenticv1alpha1.AgenticRunConditionAnalyzed,
+		metav1.ConditionFalse, "SandboxTimeout")
+
+	t.Log("PASS: pending pod timeout detected, phase=Failed, reason=SandboxTimeout")
+}
+
+// assertStepCondition checks that a condition with the given type, status, and
+// reason exists in the conditions list.
+func assertStepCondition(t *testing.T, conditions []metav1.Condition, condType string, status metav1.ConditionStatus, reason string) {
+	t.Helper()
+	for _, cond := range conditions {
+		if cond.Type == condType {
+			if cond.Status != status {
+				t.Errorf("%s condition status = %s, want %s", condType, cond.Status, status)
+			}
+			if cond.Reason != reason {
+				t.Errorf("%s condition reason = %s, want %s", condType, cond.Reason, reason)
+			}
+			t.Logf("Verified: %s=%s reason=%s message=%q", condType, cond.Status, cond.Reason, cond.Message)
+			return
+		}
+	}
+	t.Errorf("%s condition not found", condType)
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -12,11 +13,11 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,9 +46,7 @@ var testNS = func() string {
 
 // --- Client ---
 
-func newClient(t *testing.T) client.Client {
-	t.Helper()
-
+func buildClient() (client.Client, error) {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig == "" {
 		home, _ := os.UserHomeDir()
@@ -56,7 +55,7 @@ func newClient(t *testing.T) client.Client {
 
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
-		t.Fatalf("build kubeconfig: %v", err)
+		return nil, fmt.Errorf("build kubeconfig: %w", err)
 	}
 
 	s := scheme.Scheme
@@ -65,9 +64,14 @@ func newClient(t *testing.T) client.Client {
 
 	c, err := client.New(cfg, client.Options{Scheme: s})
 	if err != nil {
-		t.Fatalf("create client: %v", err)
+		return nil, fmt.Errorf("create client: %w", err)
 	}
-	return c
+	return c, nil
+}
+
+func newClient(t *testing.T) client.Client {
+	t.Helper()
+	return suiteClient
 }
 
 // --- Pointer helpers ---
@@ -77,13 +81,18 @@ func ptrInt32(v int32) *int32 { return &v }
 
 // --- Cleanup ---
 
+// cleanupTimeout is how long cleanup waits for operator finalizers before
+// force-stripping. Long enough for normal finalizer processing, short enough
+// to not stall the suite if a finalizer is genuinely stuck.
+const cleanupTimeout = 2 * time.Minute
+
 // cleanup deletes objects, letting the operator's finalizers run naturally.
-// It polls briefly for GC to complete; only force-strips finalizers as a
-// fallback when the operator appears stuck.
+// It polls until the object is fully gone (using cleanupTimeout), so the
+// next test never races against a lingering finalizer. Only force-strips
+// finalizers as a last resort when the operator appears stuck.
 func cleanup(t *testing.T, c client.Client, objs ...client.Object) {
 	t.Helper()
 	ctx := context.Background()
-	const cleanupTimeout = 15 * time.Second
 
 	for _, obj := range objs {
 		kind := obj.GetObjectKind().GroupVersionKind().Kind
@@ -101,7 +110,13 @@ func cleanup(t *testing.T, c client.Client, objs ...client.Object) {
 		_ = c.Delete(ctx, obj)
 
 		err := wait.PollUntilContextTimeout(ctx, 1*time.Second, cleanupTimeout, true, func(ctx context.Context) (bool, error) {
-			return c.Get(ctx, key, obj) != nil, nil
+			if err := c.Get(ctx, key, obj); err != nil {
+				return true, nil
+			}
+			if obj.GetDeletionTimestamp() != nil && len(obj.GetFinalizers()) > 0 {
+				t.Logf("cleanup: %s/%s waiting for finalizer %v", kind, name, obj.GetFinalizers())
+			}
+			return false, nil
 		})
 		if err == nil {
 			t.Logf("cleanup: %s/%s deleted", kind, name)
@@ -120,273 +135,26 @@ func cleanup(t *testing.T, c client.Client, objs ...client.Object) {
 	}
 }
 
-// ensureCrashLoopPod creates a pod in the staging namespace that immediately
-// exits with an error, producing a visible CrashLoopBackOff. This gives real
-// LLM providers something to diagnose when the AgenticRun request says
-// "Pod crash-looping in staging namespace".
-func ensureCrashLoopPod(t *testing.T, c client.Client) {
-	t.Helper()
-	ctx := context.Background()
+// --- AgenticRun builder ---
 
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "e2e-crasher",
-			Namespace: "staging",
-			Labels:    map[string]string{"app": "e2e-crasher"},
-		},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyAlways,
-			Containers: []corev1.Container{{
-				Name:    "crasher",
-				Image:   "busybox:latest",
-				Command: []string{"sh", "-c", "exit 1"},
-			}},
-		},
-	}
-
-	if err := c.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
-		t.Fatalf("delete previous crash-loop pod: %v", err)
-	}
-	if err := wait.PollUntilContextTimeout(ctx, time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		var existing corev1.Pod
-		if err := c.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, &existing); err != nil {
-			if apierrors.IsNotFound(err) {
-				return true, nil
-			}
-			return false, err
-		}
-		return false, nil
-	}); err != nil {
-		t.Fatalf("wait for previous crash-loop pod deletion: %v", err)
-	}
-
-	if err := c.Create(ctx, pod); err != nil {
-		t.Fatalf("create crash-loop pod: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := c.Delete(context.Background(), pod); err != nil && !apierrors.IsNotFound(err) {
-			t.Errorf("cleanup crash-loop pod: %v", err)
-		}
-	})
-
-	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		var p corev1.Pod
-		if err := c.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, &p); err != nil {
-			return false, nil
-		}
-		for _, cs := range p.Status.ContainerStatuses {
-			if cs.RestartCount > 0 {
-				return true, nil
-			}
-		}
-		return false, nil
-	})
-	if err != nil {
-		t.Fatalf("crash-loop pod never restarted: %v", err)
-	}
-	t.Log("crash-loop pod is CrashLoopBackOff in staging namespace")
-}
-
-// --- Fixture builders ---
-
-// e2eFixtures holds the prerequisite CRs needed for any run flow.
-type e2eFixtures struct {
-	LLM       *agenticv1alpha1.LLMProvider
-	Agent     *agenticv1alpha1.Agent
-	Policy    *agenticv1alpha1.ApprovalPolicy
-	LLMSecret *corev1.Secret
-}
-
-// createFixtures creates the prerequisite chain (LLMProvider, Agent, ApprovalPolicy, Secret)
-// and registers cleanup. Cleans up leftovers from previous failed runs first.
-func createFixtures(t *testing.T, c client.Client) *e2eFixtures {
-	t.Helper()
-
-	if os.Getenv("E2E_PROVIDER") != "" {
-		return createRealProviderFixtures(t, c)
-	}
-
-	ctx := context.Background()
-
-	f := &e2eFixtures{
-		LLM: &agenticv1alpha1.LLMProvider{
-			ObjectMeta: metav1.ObjectMeta{Name: "e2e-llm"},
-			Spec: agenticv1alpha1.LLMProviderSpec{
-				Type: agenticv1alpha1.LLMProviderGoogleCloudVertex,
-				GoogleCloudVertex: agenticv1alpha1.GoogleCloudVertexConfig{
-					CredentialsSecret: agenticv1alpha1.SecretReference{Name: "e2e-llm-secret"},
-					ProjectID:         "e2e-project",
-					Region:            "us-central1",
-					ModelProvider:     agenticv1alpha1.GoogleCloudVertexModelProviderAnthropic,
-				},
-			},
-		},
-		Agent: &agenticv1alpha1.Agent{
-			ObjectMeta: metav1.ObjectMeta{Name: "e2e-agent"},
-			Spec: agenticv1alpha1.AgentSpec{
-				LLMProvider: agenticv1alpha1.LLMProviderReference{Name: "e2e-llm"},
-				Model:       "claude-opus-4-6",
-			},
-		},
-		Policy: &agenticv1alpha1.ApprovalPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-			Spec: agenticv1alpha1.ApprovalPolicySpec{
-				Stages: []agenticv1alpha1.ApprovalPolicyStage{
-					{Name: agenticv1alpha1.SandboxStepAnalysis, Approval: agenticv1alpha1.ApprovalModeAutomatic},
-				},
-			},
-		},
-		LLMSecret: &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "e2e-llm-secret", Namespace: testNS},
-			Data:       map[string][]byte{"credentials.json": []byte(`{"fake":"creds"}`)},
-		},
-	}
-
-	// Ensure target namespace exists (used by RBAC tests).
-	stagingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "staging"}}
-	if err := c.Create(ctx, stagingNS); err != nil && !apierrors.IsAlreadyExists(err) {
-		t.Fatalf("create staging namespace: %v", err)
-	}
-	ensureCrashLoopPod(t, c)
-
-	all := []client.Object{f.LLM, f.Agent, f.Policy, f.LLMSecret}
-	cleanup(t, c, all...)
-	for _, obj := range all {
-		obj.SetResourceVersion("")
-		obj.SetUID("")
-		if err := c.Create(ctx, obj); err != nil {
-			t.Fatalf("create %T %s: %v", obj, obj.GetName(), err)
-		}
-	}
-	t.Cleanup(func() { cleanup(t, c, all...) })
-	return f
-}
-
-func createRealProviderFixtures(t *testing.T, c client.Client) *e2eFixtures {
-	t.Helper()
-	ctx := context.Background()
-
-	provider := os.Getenv("E2E_PROVIDER")
-	model := os.Getenv("E2E_MODEL")
-	keyPath := os.Getenv("E2E_PROVIDER_KEY_PATH")
-
-	if model == "" || keyPath == "" {
-		t.Fatalf("E2E_PROVIDER=%s requires E2E_MODEL and E2E_PROVIDER_KEY_PATH", provider)
-	}
-
-	creds, err := os.ReadFile(keyPath)
-	if err != nil {
-		t.Fatalf("read credentials file %s: %v", keyPath, err)
-	}
-
-	secretName := fmt.Sprintf("e2e-%s-secret", provider)
-	llmName := fmt.Sprintf("e2e-%s-llm", provider)
-
-	var llmSpec agenticv1alpha1.LLMProviderSpec
-	var secretData map[string][]byte
-
-	switch provider {
-	case "claude", "gemini":
-		projectID := os.Getenv("VERTEX_PROJECT_ID")
-		region := os.Getenv("VERTEX_REGION")
-		if projectID == "" {
-			t.Fatal("VERTEX_PROJECT_ID must be set for claude/gemini providers")
-		}
-		if region == "" {
-			region = "us-central1"
-		}
-
-		var modelProvider agenticv1alpha1.GoogleCloudVertexModelProvider
-		switch {
-		case strings.HasPrefix(model, "claude"):
-			modelProvider = agenticv1alpha1.GoogleCloudVertexModelProviderAnthropic
-		case strings.HasPrefix(model, "gemini"):
-			modelProvider = agenticv1alpha1.GoogleCloudVertexModelProviderGoogle
-		default:
-			t.Fatalf("cannot infer modelProvider from model %q", model)
-		}
-
-		secretData = map[string][]byte{"GOOGLE_APPLICATION_CREDENTIALS": creds}
-		llmSpec = agenticv1alpha1.LLMProviderSpec{
-			Type: agenticv1alpha1.LLMProviderGoogleCloudVertex,
-			GoogleCloudVertex: agenticv1alpha1.GoogleCloudVertexConfig{
-				CredentialsSecret: agenticv1alpha1.SecretReference{Name: secretName},
-				ProjectID:         projectID,
-				Region:            region,
-				ModelProvider:     modelProvider,
-			},
-		}
-
-	case "openai":
-		secretData = map[string][]byte{"OPENAI_API_KEY": creds}
-		llmSpec = agenticv1alpha1.LLMProviderSpec{
-			Type: agenticv1alpha1.LLMProviderOpenAI,
-			OpenAI: agenticv1alpha1.OpenAIConfig{
-				CredentialsSecret: agenticv1alpha1.SecretReference{Name: secretName},
-			},
-		}
-
-	default:
-		t.Fatalf("unsupported E2E_PROVIDER: %s", provider)
-	}
-
-	f := &e2eFixtures{
-		LLM: &agenticv1alpha1.LLMProvider{
-			ObjectMeta: metav1.ObjectMeta{Name: llmName},
-			Spec:       llmSpec,
-		},
-		Agent: &agenticv1alpha1.Agent{
-			ObjectMeta: metav1.ObjectMeta{Name: "e2e-agent"},
-			Spec: agenticv1alpha1.AgentSpec{
-				LLMProvider: agenticv1alpha1.LLMProviderReference{Name: llmName},
-				Model:       model,
-			},
-		},
-		Policy: &agenticv1alpha1.ApprovalPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-			Spec: agenticv1alpha1.ApprovalPolicySpec{
-				Stages: []agenticv1alpha1.ApprovalPolicyStage{
-					{Name: agenticv1alpha1.SandboxStepAnalysis, Approval: agenticv1alpha1.ApprovalModeAutomatic},
-				},
-			},
-		},
-		LLMSecret: &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: testNS},
-			Data:       secretData,
-		},
-	}
-
-	stagingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "staging"}}
-	if err := c.Create(ctx, stagingNS); err != nil && !apierrors.IsAlreadyExists(err) {
-		t.Fatalf("create staging namespace: %v", err)
-	}
-	ensureCrashLoopPod(t, c)
-
-	all := []client.Object{f.LLM, f.Agent, f.Policy, f.LLMSecret}
-	cleanup(t, c, all...)
-	for _, obj := range all {
-		obj.SetResourceVersion("")
-		obj.SetUID("")
-		if err := c.Create(ctx, obj); err != nil {
-			t.Fatalf("create %T %s: %v", obj, obj.GetName(), err)
-		}
-	}
-	t.Cleanup(func() { cleanup(t, c, all...) })
-
-	t.Logf("Real provider fixtures created: provider=%s model=%s llm=%s", provider, model, llmName)
-	return f
-}
-
-// createAgenticRun creates a AgenticRun + pre-created AgenticRunApproval (CEL workaround).
-// Cleans up leftovers from previous runs. Returns the created AgenticRun.
+// createAgenticRun creates a AgenticRun, cleans up leftovers from previous
+// runs, and registers cleanup. Returns the created AgenticRun.
 func createAgenticRun(t *testing.T, c client.Client, name string) *agenticv1alpha1.AgenticRun {
+	t.Helper()
+	return createAgenticRunWithRequest(t, c, name, "Pod crash-looping in staging namespace")
+}
+
+// createAgenticRunWithRequest is like createAgenticRun but allows a custom
+// request string. Embed mock failure keywords (MOCK_CRASH, MOCK_TIMEOUT, etc.)
+// in the request to trigger failure modes.
+func createAgenticRunWithRequest(t *testing.T, c client.Client, name, request string) *agenticv1alpha1.AgenticRun {
 	t.Helper()
 	ctx := context.Background()
 
 	prop := &agenticv1alpha1.AgenticRun{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS},
 		Spec: agenticv1alpha1.AgenticRunSpec{
-			Request:          "Pod crash-looping in staging namespace",
+			Request:          request,
 			TargetNamespaces: []string{"staging"},
 			Tools:            agenticv1alpha1.ToolsSpec{Skills: []agenticv1alpha1.SkillsSource{{Image: "quay.io/openshift-lightspeed/ols-qe:lightspeed-mock-agent", Paths: []string{"/skills"}}}},
 			Analysis:         agenticv1alpha1.AgenticRunStep{Agent: "e2e-agent"},
@@ -395,8 +163,6 @@ func createAgenticRun(t *testing.T, c client.Client, name string) *agenticv1alph
 		},
 	}
 
-	// Clean leftovers from previous runs. Sandbox resources use UID-based names
-	// so collisions are impossible; the AgenticRun finalizer handles their cleanup.
 	cleanup(t, c, &agenticv1alpha1.AgenticRun{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS}})
 	cleanup(t, c, &agenticv1alpha1.AgenticRunApproval{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS}})
 
@@ -423,10 +189,15 @@ var terminalPhases = map[agenticv1alpha1.AgenticRunPhase]bool{
 // phases never transition further.
 func waitForPhase(t *testing.T, c client.Client, name string, target agenticv1alpha1.AgenticRunPhase) agenticv1alpha1.AgenticRun {
 	t.Helper()
+	return waitForPhaseWithTimeout(t, c, name, target, pollTimeout)
+}
+
+func waitForPhaseWithTimeout(t *testing.T, c client.Client, name string, target agenticv1alpha1.AgenticRunPhase, timeout time.Duration) agenticv1alpha1.AgenticRun {
+	t.Helper()
 	ctx := context.Background()
 	var updated agenticv1alpha1.AgenticRun
 
-	err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
 		if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: testNS}, &updated); err != nil {
 			return false, nil
 		}
@@ -569,4 +340,125 @@ func approveVerification(t *testing.T, c client.Client, name string) {
 		t.Fatalf("approve verification: %v", err)
 	}
 	t.Logf("approved verification")
+}
+
+// --- OTEL trace verification ---
+
+const otelCollectorLabelSelector = "app=lightspeed-otel-collector"
+
+// collectorLogs returns the OTEL collector pod logs, or empty string
+// (with t.Skip) if the collector is not deployed.
+func collectorLogs(t *testing.T) string {
+	t.Helper()
+
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		home, _ := os.UserHomeDir()
+		kubeconfig = home + "/.kube/config"
+	}
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("build kubeconfig for pod logs: %v", err)
+	}
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("create kubernetes clientset: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pods, err := clientset.CoreV1().Pods(testNS).List(ctx, metav1.ListOptions{
+		LabelSelector: otelCollectorLabelSelector,
+	})
+	if err != nil {
+		t.Fatalf("list OTEL collector pods: %v", err)
+	}
+	var podName string
+	for _, p := range pods.Items {
+		if p.Status.Phase == corev1.PodRunning && p.DeletionTimestamp == nil {
+			podName = p.Name
+			break
+		}
+	}
+	if podName == "" {
+		t.Skip("OTEL collector not deployed, skipping trace assertion")
+		return ""
+	}
+	req := clientset.CoreV1().Pods(testNS).GetLogs(podName, &corev1.PodLogOptions{})
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		t.Fatalf("stream collector logs: %v", err)
+	}
+	defer stream.Close()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(stream); err != nil {
+		t.Fatalf("read collector logs: %v", err)
+	}
+	return buf.String()
+}
+
+// assertTracesExported verifies that the OTEL collector received spans
+// for the given AgenticRun (matched by UID) and that each of the
+// expected span names appears in a span block that also carries this
+// run's UID attribute. Retries for up to 30 seconds to allow the batch
+// span processor to flush recently completed spans.
+func assertTracesExported(t *testing.T, run *agenticv1alpha1.AgenticRun, expectedSpans []string) {
+	t.Helper()
+
+	uid := string(run.UID)
+	if uid == "" {
+		t.Fatal("AgenticRun has no UID, cannot verify traces")
+	}
+
+	uidNeedle := fmt.Sprintf("agenticrun.uid: Str(%s)", uid)
+	var missing []string
+
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 30*time.Second, true, func(_ context.Context) (bool, error) {
+		logs := collectorLogs(t)
+		if !strings.Contains(logs, uidNeedle) {
+			return false, nil
+		}
+
+		blocks := strings.Split(logs, "Span #")
+		missing = nil
+		for _, span := range expectedSpans {
+			nameNeedle := fmt.Sprintf("Name           : %s", span)
+			found := false
+			for _, block := range blocks {
+				if strings.Contains(block, uidNeedle) && strings.Contains(block, nameNeedle) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				missing = append(missing, span)
+			}
+		}
+		return len(missing) == 0, nil
+	})
+
+	if err != nil {
+		if !strings.Contains(collectorLogs(t), uidNeedle) {
+			t.Errorf("OTEL collector logs do not contain any spans for run UID %s", uid)
+			return
+		}
+		for _, span := range missing {
+			t.Errorf("OTEL collector logs missing span %q for run %s (UID %s)", span, run.Name, uid)
+		}
+	}
+
+	for _, span := range expectedSpans {
+		found := true
+		for _, m := range missing {
+			if m == span {
+				found = false
+				break
+			}
+		}
+		if found {
+			t.Logf("Verified: span %q present for UID %s", span, uid)
+		}
+	}
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,299 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+var suiteClient client.Client
+
+func TestMain(m *testing.M) {
+	var err error
+	suiteClient, err = buildClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: build client: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := setupSuiteFixtures(suiteClient); err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: setup fixtures: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := setupCrashLoopPod(suiteClient); err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: setup crash-loop pod: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	ctx := context.Background()
+	_ = suiteClient.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "e2e-crasher", Namespace: "staging"}})
+	for _, obj := range fixtureStubs() {
+		_ = suiteClient.Delete(ctx, obj)
+	}
+
+	os.Exit(code)
+}
+
+// fixtureStubs returns lightweight stubs (name/namespace only) for teardown.
+func fixtureStubs() []client.Object {
+	provider := os.Getenv("E2E_PROVIDER")
+	if provider == "" {
+		return []client.Object{
+			&agenticv1alpha1.LLMProvider{ObjectMeta: metav1.ObjectMeta{Name: "e2e-llm"}},
+			&agenticv1alpha1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "e2e-agent"}},
+			&agenticv1alpha1.ApprovalPolicy{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "e2e-llm-secret", Namespace: testNS}},
+		}
+	}
+	llmName := fmt.Sprintf("e2e-%s-llm", provider)
+	secretName := fmt.Sprintf("e2e-%s-secret", provider)
+	return []client.Object{
+		&agenticv1alpha1.LLMProvider{ObjectMeta: metav1.ObjectMeta{Name: llmName}},
+		&agenticv1alpha1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "e2e-agent"}},
+		&agenticv1alpha1.ApprovalPolicy{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: testNS}},
+	}
+}
+
+// --- Suite-level fixture setup ---
+
+func setupSuiteFixtures(c client.Client) error {
+	ctx := context.Background()
+
+	stagingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "staging"}}
+	if err := c.Create(ctx, stagingNS); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create staging namespace: %w", err)
+	}
+
+	if os.Getenv("E2E_PROVIDER") != "" {
+		return setupRealProviderFixtures(c)
+	}
+	return setupDefaultFixtures(c)
+}
+
+func deleteAndWait(ctx context.Context, c client.Client, obj client.Object) {
+	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	if err := c.Get(ctx, key, obj); apierrors.IsNotFound(err) {
+		return
+	}
+	_ = c.Delete(ctx, obj)
+	_ = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		return c.Get(ctx, key, obj) != nil, nil
+	})
+}
+
+func setupDefaultFixtures(c client.Client) error {
+	ctx := context.Background()
+
+	fixtures := []client.Object{
+		&agenticv1alpha1.LLMProvider{
+			ObjectMeta: metav1.ObjectMeta{Name: "e2e-llm"},
+			Spec: agenticv1alpha1.LLMProviderSpec{
+				Type: agenticv1alpha1.LLMProviderGoogleCloudVertex,
+				GoogleCloudVertex: agenticv1alpha1.GoogleCloudVertexConfig{
+					CredentialsSecret: agenticv1alpha1.SecretReference{Name: "e2e-llm-secret"},
+					ProjectID:         "e2e-project",
+					Region:            "us-central1",
+					ModelProvider:     agenticv1alpha1.GoogleCloudVertexModelProviderAnthropic,
+				},
+			},
+		},
+		&agenticv1alpha1.Agent{
+			ObjectMeta: metav1.ObjectMeta{Name: "e2e-agent"},
+			Spec: agenticv1alpha1.AgentSpec{
+				LLMProvider: agenticv1alpha1.LLMProviderReference{Name: "e2e-llm"},
+				Model:       "claude-opus-4-6",
+			},
+		},
+		&agenticv1alpha1.ApprovalPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Spec: agenticv1alpha1.ApprovalPolicySpec{
+				Stages: []agenticv1alpha1.ApprovalPolicyStage{
+					{Name: agenticv1alpha1.SandboxStepAnalysis, Approval: agenticv1alpha1.ApprovalModeAutomatic},
+				},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "e2e-llm-secret", Namespace: testNS},
+			Data:       map[string][]byte{"credentials.json": []byte(`{"fake":"creds"}`)},
+		},
+	}
+
+	for _, obj := range fixtures {
+		deleteAndWait(ctx, c, obj)
+	}
+	for _, obj := range fixtures {
+		obj.SetResourceVersion("")
+		obj.SetUID("")
+		if err := c.Create(ctx, obj); err != nil {
+			return fmt.Errorf("create %T %s: %w", obj, obj.GetName(), err)
+		}
+		fmt.Fprintf(os.Stderr, "suite: created %T/%s\n", obj, obj.GetName())
+	}
+	return nil
+}
+
+func setupRealProviderFixtures(c client.Client) error {
+	ctx := context.Background()
+
+	provider := os.Getenv("E2E_PROVIDER")
+	model := os.Getenv("E2E_MODEL")
+	keyPath := os.Getenv("E2E_PROVIDER_KEY_PATH")
+	if model == "" || keyPath == "" {
+		return fmt.Errorf("E2E_PROVIDER=%s requires E2E_MODEL and E2E_PROVIDER_KEY_PATH", provider)
+	}
+
+	creds, err := os.ReadFile(keyPath)
+	if err != nil {
+		return fmt.Errorf("read credentials %s: %w", keyPath, err)
+	}
+
+	secretName := fmt.Sprintf("e2e-%s-secret", provider)
+	llmName := fmt.Sprintf("e2e-%s-llm", provider)
+
+	var llmSpec agenticv1alpha1.LLMProviderSpec
+	var secretData map[string][]byte
+
+	switch provider {
+	case "claude", "gemini":
+		projectID := os.Getenv("VERTEX_PROJECT_ID")
+		region := os.Getenv("VERTEX_REGION")
+		if projectID == "" {
+			return fmt.Errorf("VERTEX_PROJECT_ID must be set for %s provider", provider)
+		}
+		if region == "" {
+			region = "us-central1"
+		}
+		var modelProvider agenticv1alpha1.GoogleCloudVertexModelProvider
+		switch {
+		case strings.HasPrefix(model, "claude"):
+			modelProvider = agenticv1alpha1.GoogleCloudVertexModelProviderAnthropic
+		case strings.HasPrefix(model, "gemini"):
+			modelProvider = agenticv1alpha1.GoogleCloudVertexModelProviderGoogle
+		default:
+			return fmt.Errorf("cannot infer modelProvider from model %q", model)
+		}
+		secretData = map[string][]byte{"GOOGLE_APPLICATION_CREDENTIALS": creds}
+		llmSpec = agenticv1alpha1.LLMProviderSpec{
+			Type: agenticv1alpha1.LLMProviderGoogleCloudVertex,
+			GoogleCloudVertex: agenticv1alpha1.GoogleCloudVertexConfig{
+				CredentialsSecret: agenticv1alpha1.SecretReference{Name: secretName},
+				ProjectID:         projectID,
+				Region:            region,
+				ModelProvider:     modelProvider,
+			},
+		}
+	case "openai":
+		secretData = map[string][]byte{"OPENAI_API_KEY": creds}
+		llmSpec = agenticv1alpha1.LLMProviderSpec{
+			Type: agenticv1alpha1.LLMProviderOpenAI,
+			OpenAI: agenticv1alpha1.OpenAIConfig{
+				CredentialsSecret: agenticv1alpha1.SecretReference{Name: secretName},
+			},
+		}
+	default:
+		return fmt.Errorf("unsupported E2E_PROVIDER: %s", provider)
+	}
+
+	fixtures := []client.Object{
+		&agenticv1alpha1.LLMProvider{
+			ObjectMeta: metav1.ObjectMeta{Name: llmName},
+			Spec:       llmSpec,
+		},
+		&agenticv1alpha1.Agent{
+			ObjectMeta: metav1.ObjectMeta{Name: "e2e-agent"},
+			Spec: agenticv1alpha1.AgentSpec{
+				LLMProvider: agenticv1alpha1.LLMProviderReference{Name: llmName},
+				Model:       model,
+			},
+		},
+		&agenticv1alpha1.ApprovalPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Spec: agenticv1alpha1.ApprovalPolicySpec{
+				Stages: []agenticv1alpha1.ApprovalPolicyStage{
+					{Name: agenticv1alpha1.SandboxStepAnalysis, Approval: agenticv1alpha1.ApprovalModeAutomatic},
+				},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: testNS},
+			Data:       secretData,
+		},
+	}
+
+	for _, obj := range fixtures {
+		deleteAndWait(ctx, c, obj)
+	}
+	for _, obj := range fixtures {
+		obj.SetResourceVersion("")
+		obj.SetUID("")
+		if err := c.Create(ctx, obj); err != nil {
+			return fmt.Errorf("create %T %s: %w", obj, obj.GetName(), err)
+		}
+		fmt.Fprintf(os.Stderr, "suite: created %T/%s\n", obj, obj.GetName())
+	}
+	fmt.Fprintf(os.Stderr, "suite: real provider fixtures created: provider=%s model=%s llm=%s\n", provider, model, llmName)
+	return nil
+}
+
+func setupCrashLoopPod(c client.Client) error {
+	ctx := context.Background()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "e2e-crasher",
+			Namespace: "staging",
+			Labels:    map[string]string{"app": "e2e-crasher"},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyAlways,
+			Containers: []corev1.Container{{
+				Name:    "crasher",
+				Image:   "busybox:latest",
+				Command: []string{"sh", "-c", "exit 1"},
+			}},
+		},
+	}
+
+	deleteAndWait(ctx, c, pod)
+
+	pod.SetResourceVersion("")
+	pod.SetUID("")
+	if err := c.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create crash-loop pod: %w", err)
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		var p corev1.Pod
+		if err := c.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, &p); err != nil {
+			return false, nil
+		}
+		for _, cs := range p.Status.ContainerStatuses {
+			if cs.RestartCount > 0 {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("crash-loop pod never restarted: %w", err)
+	}
+	fmt.Fprintln(os.Stderr, "suite: crash-loop pod is CrashLoopBackOff in staging namespace")
+	return nil
+}

--- a/test/e2e/suspension_test.go
+++ b/test/e2e/suspension_test.go
@@ -31,7 +31,6 @@ const suspensionVAPName = "agentic.openshift.io-agenticrun-suspension"
 // New CREATE while suspended is covered by TestSuspension_AdmissionRejectsCreate.
 func TestSuspension(t *testing.T) {
 	c := newClient(t)
-	createFixtures(t, c)
 	ctx := context.Background()
 
 	prop := createAgenticRun(t, c, "suspend-inflight")
@@ -84,7 +83,6 @@ func TestSuspension(t *testing.T) {
 // that the install path shipped the VAP and binding.
 func TestSuspension_AdmissionRejectsCreate(t *testing.T) {
 	c := newClient(t)
-	createFixtures(t, c)
 	ctx := context.Background()
 
 	assertSuspensionVAPInstalled(t, c)
@@ -120,7 +118,6 @@ func TestSuspension_AdmissionRejectsCreate(t *testing.T) {
 // with no AgenticOLSConfig, VAP parameterNotFoundAction Allow permits CREATE.
 func TestSuspension_AdmissionAllowsCreateWhenConfigAbsent(t *testing.T) {
 	c := newClient(t)
-	createFixtures(t, c)
 	ctx := context.Background()
 
 	assertSuspensionVAPInstalled(t, c)
@@ -162,7 +159,6 @@ func TestSuspension_AdmissionAllowsCreateWhenConfigAbsent(t *testing.T) {
 // switch activates.
 func TestSuspension_InFlight(t *testing.T) {
 	c := newClient(t)
-	createFixtures(t, c)
 	ctx := context.Background()
 
 	prop := createAgenticRun(t, c, "suspend-inflight-proposed")
@@ -195,7 +191,6 @@ func TestSuspension_InFlight(t *testing.T) {
 // CREATE is rejected by admission (rule 11a).
 func TestSuspension_ResumeNewAgenticRun(t *testing.T) {
 	c := newClient(t)
-	createFixtures(t, c)
 	ctx := context.Background()
 
 	config := &agenticv1alpha1.AgenticOLSConfig{

--- a/test/e2e/verification_test.go
+++ b/test/e2e/verification_test.go
@@ -25,8 +25,6 @@ func TestVerificationFlow_VerifyingToCompleted(t *testing.T) {
 	c := newClient(t)
 	ctx := context.Background()
 
-	t.Log("Creating fixtures (LLMProvider, Agent, ApprovalPolicy, Secret)")
-	createFixtures(t, c)
 	prop := createAgenticRun(t, c, "e2e-verification-flow")
 	t.Logf("AgenticRun created: %s/%s", testNS, prop.Name)
 
@@ -82,6 +80,15 @@ func TestVerificationFlow_VerifyingToCompleted(t *testing.T) {
 		t.Error("status.steps.verification.sandbox.claimName is empty")
 	}
 	t.Logf("Verified: verification sandbox info recorded, claimName=%s", updated.Status.Steps.Verification.Sandbox.ClaimName)
+
+	// --- Verify: OTEL traces exported for all steps ---
+	assertTracesExported(t, &updated, []string{
+		"agenticrun.analyze",
+		"agenticrun.human_approval",
+		"agenticrun.execute",
+		"agenticrun.verify",
+		"agenticrun.terminal",
+	})
 
 	// --- Cleanup and verify RBAC removed ---
 	roleName := "ls-exec-" + runUID


### PR DESCRIPTION
## Summary
- Add e2e tests for sandbox failure modes: pod crash (`TestSandboxCrash`), agent-reported
  failure via Result CR failureReason (`TestAgentFailure`), and sandbox timeout (`TestSandboxTimeout`)
- Move shared fixtures (Agent, LLMProvider, ApprovalPolicy, Secret) to `TestMain` — mirrors
  production where these are day-0 resources, eliminates per-test fixture races
- Deploy OTEL collector in e2e install script with debug exporter for trace verification
- Assert OTEL spans for all lifecycle steps in `TestVerificationFlow_VerifyingToCompleted`
- Fix mock agent deadlock in `MOCK_TIMEOUT` mode (`select {}` → `time.Sleep`)
## Test plan
- [x] `TestSandboxCrash` — pod exits 1, no Result CR → `SandboxFailed`
- [x] `TestAgentFailure` — Result CR with `failureReason` → `SandboxFailed` + result ref
- [ ] `TestSandboxTimeout` — blocked on mock image rebuild (deadlock fix)
- [x] All 9 existing tests pass with `TestMain` fixture setup (no races)
- [x] OTEL trace assertion verifies all 5 span names in verification flow
