### PR TITLE
OBSINTA-1595: scope alerts adapter RBAC to openshift-lightspeed namespace

### DIFF
--- a/hack/quickstart/deploy-alerts-adapter.sh
+++ b/hack/quickstart/deploy-alerts-adapter.sh
@@ -83,9 +83,10 @@ metadata:
     app.kubernetes.io/component: alerts-adapter
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: ${ADAPTER_NAME}-agenticruns
+  namespace: ${NAMESPACE}
   labels:
     app: ${ADAPTER_NAME}
     app.kubernetes.io/name: ${ADAPTER_NAME}
@@ -96,16 +97,17 @@ rules:
   verbs: ["create", "list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: ${ADAPTER_NAME}-agenticruns
+  namespace: ${NAMESPACE}
   labels:
     app: ${ADAPTER_NAME}
     app.kubernetes.io/name: ${ADAPTER_NAME}
     app.kubernetes.io/component: alerts-adapter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: ${ADAPTER_NAME}-agenticruns
 subjects:
 - kind: ServiceAccount

--- a/hack/quickstart/undeploy-alerts-adapter.sh
+++ b/hack/quickstart/undeploy-alerts-adapter.sh
@@ -19,10 +19,10 @@ step "Deleting alerts adapter resources"
 oc delete deployment "${ADAPTER_NAME}" -n "${NAMESPACE}" --ignore-not-found
 oc delete configmap alerts-adapter-config -n "${NAMESPACE}" --ignore-not-found
 oc delete sa "${ADAPTER_NAME}" -n "${NAMESPACE}" --ignore-not-found
-oc delete clusterrolebinding "${ADAPTER_NAME}-agenticruns" --ignore-not-found ||
-  echo "  ! Warning: could not delete ClusterRoleBinding (managed cluster?)"
-oc delete clusterrole "${ADAPTER_NAME}-agenticruns" --ignore-not-found ||
-  echo "  ! Warning: could not delete ClusterRole (managed cluster?)"
+oc delete rolebinding "${ADAPTER_NAME}-agenticruns" -n "${NAMESPACE}" --ignore-not-found ||
+  echo "  ! Warning: could not delete RoleBinding (managed cluster?)"
+oc delete role "${ADAPTER_NAME}-agenticruns" -n "${NAMESPACE}" --ignore-not-found ||
+  echo "  ! Warning: could not delete Role (managed cluster?)"
 oc delete rolebinding "${ADAPTER_NAME}-alertmanager" -n openshift-monitoring --ignore-not-found ||
   echo "  ! Warning: could not delete RoleBinding in openshift-monitoring (managed cluster?)"
 


### PR DESCRIPTION
Replace ClusterRole/ClusterRoleBinding with namespaced Role/RoleBinding for AgenticRun access. The adapter only creates and lists AgenticRuns in openshift-lightspeed, so cluster-wide RBAC is unnecessarily permissive.

Ref: [OBSINTA-1595](https://redhat.atlassian.net/browse/OBSINTA-1595)