### PR TITLE
OLS-3283: Add transient retry for sandbox pod creation

### DIFF
--- a/controller/agenticrun/helpers.go
+++ b/controller/agenticrun/helpers.go
@@ -5,11 +5,14 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
+	"net"
 	"reflect"
 	"text/template"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -62,7 +65,60 @@ const (
 	LogKeyPhase     = "phase"
 	LogKeyClaim     = "claimName"
 	LogKeyCondition = "condition"
+
+	maxCreateRetries = 3
 )
+
+// retryBaseDelay is the base delay for exponential backoff between transient
+// retries. Package-level var so tests can override it.
+var retryBaseDelay = 5 * time.Second
+
+// isTransient returns true for Kubernetes API errors that are likely to
+// succeed on retry (server timeouts, throttling, temporary unavailability).
+func isTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.IsServerTimeout(err) || errors.IsTimeout(err) ||
+		errors.IsTooManyRequests(err) || errors.IsServiceUnavailable(err) ||
+		errors.IsInternalError(err) || errors.IsConflict(err) {
+		return true
+	}
+	var netErr net.Error
+	return stderrors.As(err, &netErr)
+}
+
+// retryBackoff returns the delay before the given attempt (1-indexed).
+// Uses exponential backoff: 5s, 10s, 20s, …
+func retryBackoff(attempt int) time.Duration {
+	return retryBaseDelay * (1 << (attempt - 1))
+}
+
+// retryOnTransient calls fn up to maxCreateRetries times, retrying only
+// when the error is transient. Permanent errors and context cancellation
+// are returned immediately.
+func retryOnTransient(ctx context.Context, fn func() error) error {
+	log := logf.FromContext(ctx)
+	var lastErr error
+	for attempt := 1; attempt <= maxCreateRetries; attempt++ {
+		if err := fn(); err == nil {
+			return nil
+		} else if !isTransient(err) {
+			return err
+		} else {
+			lastErr = err
+		}
+		log.Info("transient failure, retrying", "attempt", attempt, "maxRetries", maxCreateRetries, "error", lastErr)
+		if attempt < maxCreateRetries {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(retryBackoff(attempt)):
+			}
+		}
+	}
+	return lastErr
+}
 
 func isSuspended(ctx context.Context, c client.Client) (bool, error) {
 	var config agenticv1alpha1.AgenticOLSConfig

--- a/controller/agenticrun/helpers_test.go
+++ b/controller/agenticrun/helpers_test.go
@@ -2,9 +2,14 @@ package agenticrun
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"testing"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -235,5 +240,152 @@ func TestTrimNonSelectedOptions_OutOfRange(t *testing.T) {
 	_, err := r.trimNonSelectedOptions(context.Background(), run, approval)
 	if err == nil {
 		t.Fatal("expected error for out-of-range option index")
+	}
+}
+
+// --- isTransient tests ---
+
+type fakeNetError struct{ temporary bool }
+
+func (e *fakeNetError) Error() string   { return "network error" }
+func (e *fakeNetError) Timeout() bool   { return e.temporary }
+func (e *fakeNetError) Temporary() bool { return e.temporary }
+
+var _ net.Error = (*fakeNetError)(nil)
+
+func TestIsTransient(t *testing.T) {
+	gr := schema.GroupResource{Group: "", Resource: "pods"}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", fmt.Errorf("something broke"), false},
+		{"not found", apierrors.NewNotFound(gr, "x"), false},
+		{"forbidden", apierrors.NewForbidden(gr, "x", fmt.Errorf("nope")), false},
+		{"invalid", apierrors.NewInvalid(schema.GroupKind{Group: "", Kind: "Pod"}, "x", nil), false},
+		{"server timeout", apierrors.NewServerTimeout(gr, "create", 5), true},
+		{"too many requests", apierrors.NewTooManyRequests("slow down", 1), true},
+		{"service unavailable", apierrors.NewServiceUnavailable("gone"), true},
+		{"internal error", apierrors.NewInternalError(fmt.Errorf("oops")), true},
+		{"conflict", apierrors.NewConflict(gr, "x", fmt.Errorf("conflict")), true},
+		{"net error", &fakeNetError{temporary: true}, true},
+		{"wrapped transient", fmt.Errorf("outer: %w", apierrors.NewServerTimeout(gr, "get", 1)), true},
+		{"wrapped permanent", fmt.Errorf("outer: %w", apierrors.NewNotFound(gr, "x")), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransient(tt.err); got != tt.want {
+				t.Errorf("isTransient() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryBackoff(t *testing.T) {
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, 5 * time.Second},
+		{2, 10 * time.Second},
+		{3, 20 * time.Second},
+	}
+	for _, tt := range tests {
+		if got := retryBackoff(tt.attempt); got != tt.want {
+			t.Errorf("retryBackoff(%d) = %v, want %v", tt.attempt, got, tt.want)
+		}
+	}
+}
+
+func withFastRetry(t *testing.T) {
+	t.Helper()
+	orig := retryBaseDelay
+	retryBaseDelay = 1 * time.Millisecond
+	t.Cleanup(func() { retryBaseDelay = orig })
+}
+
+func TestRetryOnTransient_SucceedsImmediately(t *testing.T) {
+	withFastRetry(t)
+	calls := 0
+	err := retryOnTransient(context.Background(), func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryOnTransient_PermanentErrorNoRetry(t *testing.T) {
+	withFastRetry(t)
+	calls := 0
+	permErr := apierrors.NewNotFound(schema.GroupResource{}, "x")
+	err := retryOnTransient(context.Background(), func() error {
+		calls++
+		return permErr
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("permanent error should not retry, got %d calls", calls)
+	}
+}
+
+func TestRetryOnTransient_TransientThenSuccess(t *testing.T) {
+	withFastRetry(t)
+	gr := schema.GroupResource{Group: "", Resource: "pods"}
+	calls := 0
+	err := retryOnTransient(context.Background(), func() error {
+		calls++
+		if calls < 2 {
+			return apierrors.NewServerTimeout(gr, "create", 0)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls (1 transient + 1 success), got %d", calls)
+	}
+}
+
+func TestRetryOnTransient_ExhaustsRetries(t *testing.T) {
+	withFastRetry(t)
+	gr := schema.GroupResource{Group: "", Resource: "pods"}
+	calls := 0
+	err := retryOnTransient(context.Background(), func() error {
+		calls++
+		return apierrors.NewServerTimeout(gr, "create", 0)
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if calls != maxCreateRetries {
+		t.Errorf("expected %d calls, got %d", maxCreateRetries, calls)
+	}
+}
+
+func TestRetryOnTransient_RespectsContextCancellation(t *testing.T) {
+	withFastRetry(t)
+	gr := schema.GroupResource{Group: "", Resource: "pods"}
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := retryOnTransient(ctx, func() error {
+		calls++
+		cancel()
+		return apierrors.NewServerTimeout(gr, "create", 0)
+	})
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call before cancellation, got %d", calls)
 	}
 }

--- a/controller/agenticrun/sandbox_agent.go
+++ b/controller/agenticrun/sandbox_agent.go
@@ -166,8 +166,12 @@ func (s *SandboxAgentCaller) launchSandbox(
 	agentCtx *agentContext,
 ) error {
 	podDeadline := stepTimeout(stepName) + defaultSandboxTimeout
-	name, err := s.Sandbox.Create(ctx, run, stepName, step.Agent, step.LLM, step.Tools, podDeadline, query, agentCtx)
-	if err != nil {
+	var name string
+	if err := retryOnTransient(ctx, func() error {
+		var createErr error
+		name, createErr = s.Sandbox.Create(ctx, run, stepName, step.Agent, step.LLM, step.Tools, podDeadline, query, agentCtx)
+		return createErr
+	}); err != nil {
 		return fmt.Errorf("%s: %w", ErrClaimSandbox, err)
 	}
 

--- a/controller/agenticrun/sandbox_agent_test.go
+++ b/controller/agenticrun/sandbox_agent_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -18,6 +20,7 @@ import (
 type mockSandboxProvider struct {
 	claimName    string
 	claimErr     error
+	claimErrors  []error // per-call errors; takes precedence over claimErr when non-empty
 	releaseErr   error
 	claimCalls   int
 	releaseCalls int
@@ -25,6 +28,16 @@ type mockSandboxProvider struct {
 
 func (m *mockSandboxProvider) Create(_ context.Context, _ *agenticv1alpha1.AgenticRun, _ string, _ *agenticv1alpha1.Agent, _ *agenticv1alpha1.LLMProvider, _ *agenticv1alpha1.ToolsSpec, _ time.Duration, _ string, _ *agentContext) (string, error) {
 	m.claimCalls++
+	if len(m.claimErrors) > 0 {
+		idx := m.claimCalls - 1
+		if idx >= len(m.claimErrors) {
+			idx = len(m.claimErrors) - 1
+		}
+		if err := m.claimErrors[idx]; err != nil {
+			return "", err
+		}
+		return m.claimName, nil
+	}
 	return m.claimName, m.claimErr
 }
 func (m *mockSandboxProvider) Release(_ context.Context, _ *agenticv1alpha1.AgenticRun, _ string) error {
@@ -267,4 +280,61 @@ func (m *trackingMockSandbox) Release(_ context.Context, run *agenticv1alpha1.Ag
 		return fmt.Errorf("simulated release error for %s", claimName)
 	}
 	return nil
+}
+
+// --- Retry integration tests ---
+
+func TestSandboxAgentCaller_TransientRetryThenSuccess(t *testing.T) {
+	withFastRetry(t)
+	gr := schema.GroupResource{Group: "", Resource: "pods"}
+	sandbox := &mockSandboxProvider{
+		claimName: "ls-analysis-fix-crash",
+		claimErrors: []error{
+			apierrors.NewServerTimeout(gr, "create", 0),
+			nil,
+		},
+	}
+	run := testSandboxAgenticRun()
+	caller := newTestSandboxAgentCallerWithAgenticRun(sandbox, run)
+
+	err := caller.Analyze(context.Background(), run, testSandboxStep(), "Pod crashing")
+	if err != nil {
+		t.Fatalf("expected success after transient retry, got: %v", err)
+	}
+	if sandbox.claimCalls != 2 {
+		t.Errorf("expected 2 Create calls (1 transient + 1 success), got %d", sandbox.claimCalls)
+	}
+}
+
+func TestSandboxAgentCaller_PermanentErrorNoRetry(t *testing.T) {
+	withFastRetry(t)
+	sandbox := &mockSandboxProvider{
+		claimErr: apierrors.NewForbidden(schema.GroupResource{}, "x", fmt.Errorf("escalation")),
+	}
+	caller := newTestSandboxAgentCaller(sandbox)
+
+	err := caller.Analyze(context.Background(), testSandboxAgenticRun(), testSandboxStep(), "Pod crashing")
+	if err == nil {
+		t.Fatal("expected error for permanent failure")
+	}
+	if sandbox.claimCalls != 1 {
+		t.Errorf("permanent error should not retry, got %d calls", sandbox.claimCalls)
+	}
+}
+
+func TestSandboxAgentCaller_TransientExhaustsRetries(t *testing.T) {
+	withFastRetry(t)
+	gr := schema.GroupResource{Group: "", Resource: "pods"}
+	sandbox := &mockSandboxProvider{
+		claimErr: apierrors.NewServerTimeout(gr, "create", 0),
+	}
+	caller := newTestSandboxAgentCaller(sandbox)
+
+	err := caller.Analyze(context.Background(), testSandboxAgenticRun(), testSandboxStep(), "Pod crashing")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if sandbox.claimCalls != maxCreateRetries {
+		t.Errorf("expected %d Create calls, got %d", maxCreateRetries, sandbox.claimCalls)
+	}
 }


### PR DESCRIPTION
**Summary**
Adds retry-with-exponential-backoff for transient errors during sandbox pod creation. Addresses intermittent failures where API server throttling, timeouts, or temporary unavailability cause the step to fail permanently when a simple retry would succeed.

**Transient error classification**

_Retries on:_
- ServerTimeout, Timeout (API server overloaded)
- TooManyRequests (throttled)
- ServiceUnavailable (API server temporarily down)
- InternalError (transient 500s)
- Conflict (optimistic concurrency collision)
- net.Error (network-level failures)

_Does NOT retry:_
- NotFound, Forbidden, Invalid (permanent)
- Validation errors
- Context cancellation
