### PR TITLE
OLS-0000 make Konflux e2e tests mandatory

### DIFF
--- a/.tekton/integration-tests/integration-test-scenarios.yaml
+++ b/.tekton/integration-tests/integration-test-scenarios.yaml
@@ -13,8 +13,6 @@ kind: IntegrationTestScenario
 metadata:
   name: agentic-operator-e2e-tests
   namespace: crt-nshift-lightspeed-tenant
-  labels:
-    test.appstudio.openshift.io/optional: "true"
 spec:
   application: ols
   contexts:
@@ -28,7 +26,7 @@ spec:
     - name: sandbox-mode
       value: bare-pod
     - name: openshift-version-prefix
-      value: "4.19."
+      value: "4.22."
   resolverRef:
     resolver: git
     resourceKind: pipeline
@@ -45,8 +43,6 @@ kind: IntegrationTestScenario
 metadata:
   name: agentic-operator-e2e-sandbox-claim
   namespace: crt-nshift-lightspeed-tenant
-  labels:
-    test.appstudio.openshift.io/optional: "true"
 spec:
   application: ols
   contexts:
@@ -60,7 +56,7 @@ spec:
     - name: sandbox-mode
       value: sandbox-claim
     - name: openshift-version-prefix
-      value: "4.19."
+      value: "4.22."
   resolverRef:
     resolver: git
     resourceKind: pipeline

--- a/.tekton/integration-tests/pipelines/agentic-operator-e2e-pipeline.yaml
+++ b/.tekton/integration-tests/pipelines/agentic-operator-e2e-pipeline.yaml
@@ -26,8 +26,8 @@ spec:
       default: 'bare-pod'
       type: string
     - name: openshift-version-prefix
-      description: 'Minor line prefix for eaas-get-latest-openshift-version-by-prefix (include trailing dot, e.g. 4.19.)'
-      default: '4.19.'
+      description: 'Minor line prefix for eaas-get-latest-openshift-version-by-prefix (include trailing dot, e.g. 4.22.)'
+      default: '4.22.'
       type: string
   tasks:
     - name: eaas-provision-space

--- a/.tekton/lightspeed-agentic-operator-pull-request.yaml
+++ b/.tekton/lightspeed-agentic-operator-pull-request.yaml
@@ -12,7 +12,8 @@ metadata:
       == "main" && ("Dockerfile".pathChanged() || "go.mod".pathChanged() || "go.sum".pathChanged()
       || "api/**".pathChanged() || "cmd/**".pathChanged() || "controller/**".pathChanged()
       || "test/**".pathChanged() || "LICENSE".pathChanged()
-      || ".tekton/lightspeed-agentic-operator-pull-request.yaml".pathChanged())
+      || ".tekton/lightspeed-agentic-operator-pull-request.yaml".pathChanged()
+      || ".tekton/integration-tests/**".pathChanged())
   labels:
     appstudio.openshift.io/application: ols
     appstudio.openshift.io/component: lightspeed-agentic-operator


### PR DESCRIPTION
## What
- remove the optional label from operator e2e IntegrationTestScenarios
- remove the optional label from the product e2e IntegrationTestScenario

This makes the Konflux e2e scenarios required while retaining the existing artifact collection and failure propagation in the pipelines.

## Validation
- git diff --check
- parsed both scenario manifests and both pipeline manifests with PyYAML