### PR TITLE
OLS-4025 Wire Agent limits and enforce sandbox lifecycle deadlines

### DIFF
--- a/api/v1alpha1/agent_types.go
+++ b/api/v1alpha1/agent_types.go
@@ -22,33 +22,37 @@ import (
 )
 
 // AgentTimeouts configures per-step and per-turn timeout limits.
-// All values are in seconds.
+// All values are in seconds. Zero or omitted values use built-in defaults.
 //
 // +kubebuilder:validation:MinProperties=1
 type AgentTimeouts struct {
 	// analysisSeconds is the timeout for the analysis step in seconds.
+	// When zero or omitted, the default (600 seconds) is used.
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=3600
 	AnalysisSeconds int32 `json:"analysisSeconds,omitempty"`
 
 	// executionSeconds is the timeout for the execution step in seconds.
+	// When zero or omitted, the default (600 seconds) is used.
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=3600
 	ExecutionSeconds int32 `json:"executionSeconds,omitempty"`
 
 	// verificationSeconds is the timeout for the verification step in seconds.
+	// When zero or omitted, the default (1800 seconds) is used.
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=3600
 	VerificationSeconds int32 `json:"verificationSeconds,omitempty"`
 
-	// chatSeconds is the timeout for each chat turn with the LLM in seconds.
+	// escalationSeconds is the timeout for the escalation step in seconds.
+	// When zero or omitted, the default (600 seconds) is used.
 	// +optional
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=600
-	ChatSeconds int32 `json:"chatSeconds,omitempty"`
+	// +kubebuilder:validation:Maximum=3600
+	EscalationSeconds int32 `json:"escalationSeconds,omitempty"`
 }
 
 // StepInstructions holds the system and user prompt instructions for a single step.
@@ -117,7 +121,7 @@ type AgentSpec struct {
 
 	// maxTurns is the maximum number of tool-use turns the agent may take
 	// in a single step invocation. Prevents runaway loops.
-	// When omitted, the agent sandbox uses its built-in default.
+	// When zero or omitted, the default (200) is used.
 	// Minimum 1, maximum 500.
 	// +optional
 	// +kubebuilder:validation:Minimum=1

--- a/api/v1alpha1/result_types.go
+++ b/api/v1alpha1/result_types.go
@@ -27,6 +27,9 @@ const (
 	ResultReasonStepStarted = "StepStarted"
 	ResultReasonSucceeded   = "Succeeded"
 	ResultReasonFailed      = "Failed"
+	// ResultReasonAgentTimeout indicates cooperative expiration of the
+	// operator-provided whole-agent execution budget.
+	ResultReasonAgentTimeout = "AgentTimeout"
 )
 
 func (r *AnalysisResult) GetConditions() []metav1.Condition      { return r.Status.Conditions }

--- a/config/crd/bases/agentic.openshift.io_agents.yaml
+++ b/config/crd/bases/agentic.openshift.io_agents.yaml
@@ -188,7 +188,7 @@ spec:
                 description: |-
                   maxTurns is the maximum number of tool-use turns the agent may take
                   in a single step invocation. Prevents runaway loops.
-                  When omitted, the agent sandbox uses its built-in default.
+                  When zero or omitted, the default (200) is used.
                   Minimum 1, maximum 500.
                 format: int32
                 maximum: 500
@@ -232,29 +232,33 @@ spec:
                 minProperties: 1
                 properties:
                   analysisSeconds:
-                    description: analysisSeconds is the timeout for the analysis step
-                      in seconds.
+                    description: |-
+                      analysisSeconds is the timeout for the analysis step in seconds.
+                      When zero or omitted, the default (600 seconds) is used.
                     format: int32
                     maximum: 3600
                     minimum: 1
                     type: integer
-                  chatSeconds:
-                    description: chatSeconds is the timeout for each chat turn with
-                      the LLM in seconds.
+                  escalationSeconds:
+                    description: |-
+                      escalationSeconds is the timeout for the escalation step in seconds.
+                      When zero or omitted, the default (600 seconds) is used.
                     format: int32
-                    maximum: 600
+                    maximum: 3600
                     minimum: 1
                     type: integer
                   executionSeconds:
-                    description: executionSeconds is the timeout for the execution
-                      step in seconds.
+                    description: |-
+                      executionSeconds is the timeout for the execution step in seconds.
+                      When zero or omitted, the default (600 seconds) is used.
                     format: int32
                     maximum: 3600
                     minimum: 1
                     type: integer
                   verificationSeconds:
-                    description: verificationSeconds is the timeout for the verification
-                      step in seconds.
+                    description: |-
+                      verificationSeconds is the timeout for the verification step in seconds.
+                      When zero or omitted, the default (1800 seconds) is used.
                     format: int32
                     maximum: 3600
                     minimum: 1

--- a/controller/agenticrun/approval_test.go
+++ b/controller/agenticrun/approval_test.go
@@ -174,6 +174,26 @@ func TestGetStageOverrideAgent_OmittedMeansNoOverride(t *testing.T) {
 	}
 }
 
+func TestEffectiveStepAgentName_EscalationFallbackAndOverride(t *testing.T) {
+	analysis := agenticv1alpha1.AgenticRunStep{Agent: "analysis-agent"}
+	approval := &agenticv1alpha1.AgenticRunApproval{Spec: agenticv1alpha1.AgenticRunApprovalSpec{
+		Stages: []agenticv1alpha1.ApprovalStage{
+			agenticv1alpha1.NewApprovalStage(agenticv1alpha1.ApprovalStageAnalysis, "", "analysis-override", nil),
+		},
+	}}
+	if got := effectiveStepAgentName(approval, agenticv1alpha1.SandboxStepAnalysis, analysis); got != "analysis-override" {
+		t.Fatalf("analysis override = %q, want analysis-override", got)
+	}
+	if got := effectiveStepAgentName(approval, agenticv1alpha1.SandboxStepEscalation, analysis); got != "analysis-agent" {
+		t.Fatalf("escalation fallback = %q, want analysis-agent", got)
+	}
+	approval.Spec.Stages = append(approval.Spec.Stages,
+		agenticv1alpha1.NewApprovalStage(agenticv1alpha1.ApprovalStageEscalation, "", "escalation-agent", nil))
+	if got := getStageOverrideAgent(approval, agenticv1alpha1.SandboxStepEscalation); got != "escalation-agent" {
+		t.Fatalf("escalation override = %q, want escalation-agent", got)
+	}
+}
+
 func TestGetStageOption_FromApproval(t *testing.T) {
 	option := int32(2)
 	approval := &agenticv1alpha1.AgenticRunApproval{

--- a/controller/agenticrun/limits.go
+++ b/controller/agenticrun/limits.go
@@ -1,0 +1,63 @@
+package agenticrun
+
+import (
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+const (
+	// Default timeout values for each step in seconds
+	DefaultAnalysisTimeout     = 600  // 10 minutes
+	DefaultExecutionTimeout    = 600  // 10 minutes
+	DefaultVerificationTimeout = 1800 // 30 minutes
+	DefaultEscalationTimeout   = 600  // 10 minutes
+
+	// Default max turns per step
+	DefaultMaxTurns = 200
+)
+
+// resolveTimeout returns the effective agent timeout in seconds for the given step.
+// It checks the Agent CR for configured timeouts and falls back to defaults.
+// The step parameter uses lowercase strings ("analysis", "execution", etc.)
+// as used throughout the controller, not the title-case SandboxStep constants.
+func resolveTimeout(agent *agenticv1alpha1.Agent, step string) int {
+	if agent != nil {
+		switch step {
+		case "analysis":
+			if agent.Spec.Timeouts.AnalysisSeconds > 0 {
+				return int(agent.Spec.Timeouts.AnalysisSeconds)
+			}
+		case "execution":
+			if agent.Spec.Timeouts.ExecutionSeconds > 0 {
+				return int(agent.Spec.Timeouts.ExecutionSeconds)
+			}
+		case "verification":
+			if agent.Spec.Timeouts.VerificationSeconds > 0 {
+				return int(agent.Spec.Timeouts.VerificationSeconds)
+			}
+		case "escalation":
+			if agent.Spec.Timeouts.EscalationSeconds > 0 {
+				return int(agent.Spec.Timeouts.EscalationSeconds)
+			}
+		}
+	}
+
+	switch step {
+	case "execution":
+		return DefaultExecutionTimeout
+	case "verification":
+		return DefaultVerificationTimeout
+	case "escalation":
+		return DefaultEscalationTimeout
+	default:
+		return DefaultAnalysisTimeout
+	}
+}
+
+// resolveMaxTurns returns the effective max turns.
+// It checks the Agent CR for configured max turns and falls back to the default.
+func resolveMaxTurns(agent *agenticv1alpha1.Agent) int {
+	if agent != nil && agent.Spec.MaxTurns > 0 {
+		return int(agent.Spec.MaxTurns)
+	}
+	return DefaultMaxTurns
+}

--- a/controller/agenticrun/limits_test.go
+++ b/controller/agenticrun/limits_test.go
@@ -1,0 +1,166 @@
+package agenticrun
+
+import (
+	"testing"
+
+	agenticv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
+)
+
+func TestResolveTimeout(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent *agenticv1alpha1.Agent
+		step  string
+		want  int
+	}{
+		{
+			name:  "nil agent uses default for analysis",
+			agent: nil,
+			step:  "analysis",
+			want:  DefaultAnalysisTimeout,
+		},
+		{
+			name:  "nil agent uses default for execution",
+			agent: nil,
+			step:  "execution",
+			want:  DefaultExecutionTimeout,
+		},
+		{
+			name:  "nil agent uses default for verification",
+			agent: nil,
+			step:  "verification",
+			want:  DefaultVerificationTimeout,
+		},
+		{
+			name:  "nil agent uses default for escalation",
+			agent: nil,
+			step:  "escalation",
+			want:  DefaultEscalationTimeout,
+		},
+		{
+			name: "configured analysis timeout",
+			agent: &agenticv1alpha1.Agent{
+				Spec: agenticv1alpha1.AgentSpec{
+					Timeouts: agenticv1alpha1.AgentTimeouts{
+						AnalysisSeconds: 300,
+					},
+				},
+			},
+			step: "analysis",
+			want: 300,
+		},
+		{
+			name: "configured execution timeout",
+			agent: &agenticv1alpha1.Agent{
+				Spec: agenticv1alpha1.AgentSpec{
+					Timeouts: agenticv1alpha1.AgentTimeouts{
+						ExecutionSeconds: 900,
+					},
+				},
+			},
+			step: "execution",
+			want: 900,
+		},
+		{
+			name: "configured verification timeout",
+			agent: &agenticv1alpha1.Agent{
+				Spec: agenticv1alpha1.AgentSpec{
+					Timeouts: agenticv1alpha1.AgentTimeouts{
+						VerificationSeconds: 2400,
+					},
+				},
+			},
+			step: "verification",
+			want: 2400,
+		},
+		{
+			name: "configured escalation timeout",
+			agent: &agenticv1alpha1.Agent{
+				Spec: agenticv1alpha1.AgentSpec{
+					Timeouts: agenticv1alpha1.AgentTimeouts{
+						EscalationSeconds: 450,
+					},
+				},
+			},
+			step: "escalation",
+			want: 450,
+		},
+		{
+			name: "empty timeouts uses defaults",
+			agent: &agenticv1alpha1.Agent{
+				Spec: agenticv1alpha1.AgentSpec{},
+			},
+			step: "analysis",
+			want: DefaultAnalysisTimeout,
+		},
+		{
+			name: "partial config falls back to default for unconfigured step",
+			agent: &agenticv1alpha1.Agent{
+				Spec: agenticv1alpha1.AgentSpec{
+					Timeouts: agenticv1alpha1.AgentTimeouts{
+						AnalysisSeconds: 250,
+					},
+				},
+			},
+			step: "execution",
+			want: DefaultExecutionTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveTimeout(tt.agent, tt.step)
+			if got != tt.want {
+				t.Errorf("resolveTimeout() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveMaxTurns(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent *agenticv1alpha1.Agent
+		want  int
+	}{
+		{
+			name:  "nil agent uses default",
+			agent: nil,
+			want:  DefaultMaxTurns,
+		},
+		{
+			name: "configured maxTurns",
+			agent: &agenticv1alpha1.Agent{
+				Spec: agenticv1alpha1.AgentSpec{
+					MaxTurns: 100,
+				},
+			},
+			want: 100,
+		},
+		{
+			name: "zero maxTurns uses default",
+			agent: &agenticv1alpha1.Agent{
+				Spec: agenticv1alpha1.AgentSpec{},
+			},
+			want: DefaultMaxTurns,
+		},
+		{
+			name: "max maxTurns value",
+			agent: &agenticv1alpha1.Agent{
+				Spec: agenticv1alpha1.AgentSpec{
+					MaxTurns: 500,
+				},
+			},
+			want: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveMaxTurns(tt.agent)
+			if got != tt.want {
+				t.Errorf("resolveMaxTurns() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/controller/agenticrun/pod_handler.go
+++ b/controller/agenticrun/pod_handler.go
@@ -66,7 +66,7 @@ func (r *AgenticRunReconciler) handlePodEvent(ctx context.Context, obj client.Ob
 		return nil
 	}
 
-	if err := r.completeStep(ctx, &run, pod, step, condType, ""); err != nil {
+	if err := r.completeStep(ctx, &run, pod, step, condType, "", ""); err != nil {
 		return nil
 	}
 	return nil
@@ -111,10 +111,11 @@ func resolveSandboxPodMetadata(ctx context.Context, c client.Client, pod *corev1
 
 // completeStep handles step completion: patches the step condition (and result ref
 // on success), emits audit events, and releases the sandbox. When timeoutMsg is
-// non-empty the pod phase is ignored and a timeout failure is recorded. Returns an
-// error if the status patch fails — the caller should bail so the timeout loop
+// non-empty the pod phase is ignored and a timeout failure is recorded. The timeoutReason
+// specifies which timeout condition occurred (e.g., ReasonSandboxStartupTimeout or ReasonSandboxTimeout).
+// Returns an error if the status patch fails — the caller should bail so the timeout loop
 // can retry.
-func (r *AgenticRunReconciler) completeStep(ctx context.Context, run *agenticv1alpha1.AgenticRun, pod *corev1.Pod, step, condType, timeoutMsg string) error {
+func (r *AgenticRunReconciler) completeStep(ctx context.Context, run *agenticv1alpha1.AgenticRun, pod *corev1.Pod, step, condType, timeoutMsg, timeoutReason string) error {
 	stepCondMu.Lock()
 	defer stepCondMu.Unlock()
 
@@ -128,7 +129,10 @@ func (r *AgenticRunReconciler) completeStep(ctx context.Context, run *agenticv1a
 
 	if timeoutMsg != "" {
 		log.Info("sandbox timeout", "message", timeoutMsg)
-		patchErr = r.patchStepCondition(ctx, run, condType, metav1.ConditionFalse, ReasonSandboxTimeout, timeoutMsg)
+		if timeoutReason == "" {
+			timeoutReason = ReasonSandboxTimeout
+		}
+		patchErr = r.patchStepCondition(ctx, run, condType, metav1.ConditionFalse, timeoutReason, timeoutMsg)
 	} else if pod.Status.Phase == corev1.PodSucceeded {
 		var reason string
 		resultCR, reason = validateResultCR(ctx, r.Client, run, step, r.Namespace)
@@ -146,7 +150,15 @@ func (r *AgenticRunReconciler) completeStep(ctx context.Context, run *agenticv1a
 				metav1.ConditionTrue, stepReason, stepMsg)
 		} else if resultCR != nil {
 			log.Info("agent reported failure", "reason", reason)
-			if step == "verification" {
+			if reason == agenticv1alpha1.ResultReasonAgentTimeout && step == "verification" {
+				// A verification timeout is an agent outcome, not a sandbox
+				// infrastructure failure. Route it through the existing escalation
+				// path so a human can review the incomplete verification.
+				patchErr = r.patchVerificationFailedEscalating(ctx, run, resultCR.GetName(), resultCR, reason)
+			} else if reason == agenticv1alpha1.ResultReasonAgentTimeout {
+				patchErr = r.patchStepResult(ctx, run, step, condType, resultCR.GetName(), resultCR,
+					metav1.ConditionFalse, ReasonAgentTimeout, "Agent exceeded its configured execution budget")
+			} else if step == "verification" {
 				// OLS-3817: an objective verification failure (the agent ran and
 				// its VerificationResult reports the remediation did not work)
 				// escalates directly instead of retrying execution or terminating.
@@ -384,6 +396,11 @@ func validateResultCR(ctx context.Context, c client.Client, run *agenticv1alpha1
 	cond := meta.FindStatusCondition(conditions, agenticv1alpha1.ResultConditionCompleted)
 	if cond == nil || cond.Status != metav1.ConditionTrue {
 		return nil, "result CR missing Completed condition"
+	}
+	// Cooperative timeout is a distinct agent outcome. Check the Completed
+	// condition before failureReason because the sandbox includes both fields.
+	if cond.Reason == agenticv1alpha1.ResultReasonAgentTimeout {
+		return obj, agenticv1alpha1.ResultReasonAgentTimeout
 	}
 	if failureReason != "" {
 		return obj, failureReason

--- a/controller/agenticrun/pod_handler_test.go
+++ b/controller/agenticrun/pod_handler_test.go
@@ -113,7 +113,7 @@ func TestCompleteStep_VerificationObjectiveFailure_Escalates(t *testing.T) {
 		"Pod still crashing")
 
 	pod := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}}
-	if err := r.completeStep(ctx, run, pod, "verification", stepConditionType("verification"), ""); err != nil {
+	if err := r.completeStep(ctx, run, pod, "verification", stepConditionType("verification"), "", ""); err != nil {
 		t.Fatalf("completeStep: %v", err)
 	}
 
@@ -147,6 +147,45 @@ func TestCompleteStep_VerificationObjectiveFailure_Escalates(t *testing.T) {
 // TestCompleteStep_VerificationSuccess_Completed exercises the REAL pod-handler
 // path for a passing verification (completeStep → patchStepResult): Verified=True
 // and no Escalated condition, so DerivePhase yields Completed.
+func TestCompleteStep_VerificationAgentTimeout_Escalates(t *testing.T) {
+	ctx := context.Background()
+	r, run := newVerifyingReconciler(t)
+
+	name := resultCRName(run.Name, "verification", nextResultIndex(run, "verification"))
+	createVerificationResult(t, r, run, agenticv1alpha1.ActionOutcomeFailed, nil, "Agent invocation timed out")
+	result := &agenticv1alpha1.VerificationResult{}
+	if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: "default"}, result); err != nil {
+		t.Fatalf("get VerificationResult: %v", err)
+	}
+	completed := meta.FindStatusCondition(result.Status.Conditions, agenticv1alpha1.ResultConditionCompleted)
+	completed.Reason = agenticv1alpha1.ResultReasonAgentTimeout
+	completed.Message = "Agent invocation timeout"
+	if err := r.Status().Update(ctx, result); err != nil {
+		t.Fatalf("update VerificationResult timeout status: %v", err)
+	}
+
+	pod := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}}
+	if err := r.completeStep(ctx, run, pod, "verification", stepConditionType("verification"), "", ""); err != nil {
+		t.Fatalf("completeStep: %v", err)
+	}
+
+	got, err := getAgenticRun(r, "fix-crash")
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if phase := agenticv1alpha1.DerivePhase(got.Status.Conditions); phase != agenticv1alpha1.AgenticRunPhaseEscalating {
+		t.Fatalf("expected Escalating, got %s", phase)
+	}
+	verified := meta.FindStatusCondition(got.Status.Conditions, agenticv1alpha1.AgenticRunConditionVerified)
+	if verified == nil || verified.Status != metav1.ConditionFalse {
+		t.Fatalf("expected Verified=False, got %+v", verified)
+	}
+	escalated := meta.FindStatusCondition(got.Status.Conditions, agenticv1alpha1.AgenticRunConditionEscalated)
+	if escalated == nil || escalated.Status != metav1.ConditionUnknown {
+		t.Fatalf("expected Escalated=Unknown, got %+v", escalated)
+	}
+}
+
 func TestCompleteStep_VerificationSuccess_Completed(t *testing.T) {
 	ctx := context.Background()
 	r, run := newVerifyingReconciler(t)
@@ -156,7 +195,7 @@ func TestCompleteStep_VerificationSuccess_Completed(t *testing.T) {
 		"Pod healthy")
 
 	pod := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}}
-	if err := r.completeStep(ctx, run, pod, "verification", stepConditionType("verification"), ""); err != nil {
+	if err := r.completeStep(ctx, run, pod, "verification", stepConditionType("verification"), "", ""); err != nil {
 		t.Fatalf("completeStep: %v", err)
 	}
 
@@ -188,7 +227,7 @@ func TestCompleteStep_VerificationSystemFailure_Terminal(t *testing.T) {
 
 	// No VerificationResult CR is created — validateResultCR returns msgSandboxNoResult.
 	pod := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}}
-	if err := r.completeStep(ctx, run, pod, "verification", stepConditionType("verification"), ""); err != nil {
+	if err := r.completeStep(ctx, run, pod, "verification", stepConditionType("verification"), "", ""); err != nil {
 		t.Fatalf("completeStep: %v", err)
 	}
 
@@ -356,7 +395,7 @@ func TestCompleteStep_AggregatesTokenUsage(t *testing.T) {
 			setupVerificationResultCR(t, r, run, tt.outcome, tt.checks, tt.summary, tt.tu)
 
 			pod := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}}
-			if err := r.completeStep(ctx, run, pod, "verification", stepConditionType("verification"), ""); err != nil {
+			if err := r.completeStep(ctx, run, pod, "verification", stepConditionType("verification"), "", ""); err != nil {
 				t.Fatalf("completeStep: %v", err)
 			}
 
@@ -452,6 +491,20 @@ func TestStartTimedOut(t *testing.T) {
 				t.Errorf("startTimedOut = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMainContainerStartedAt(t *testing.T) {
+	started := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	pod := &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+		{Name: "sidecar", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(started.Add(-time.Minute))}}},
+		{Name: "agent", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(started)}}},
+	}}}
+	if got := mainContainerStartedAt(pod); !got.Equal(started) {
+		t.Fatalf("mainContainerStartedAt = %v, want %v", got, started)
+	}
+	if got := mainContainerStartedAt(&corev1.Pod{}); !got.IsZero() {
+		t.Fatalf("mainContainerStartedAt without running container = %v, want zero", got)
 	}
 }
 

--- a/controller/agenticrun/podspec_builder.go
+++ b/controller/agenticrun/podspec_builder.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel/trace"
@@ -59,6 +60,8 @@ type PodSpecBuilder struct{}
 // inputConfigMapName is mounted read-only at /input/ (OLS-3794 batch model).
 // The base PodSpec must contain at least one container (the agent container).
 // HTTP readiness/liveness probes are not set — batch sandboxes have no HTTP server.
+// timeoutSeconds and maxTurns are injected as LIGHTSPEED_AGENT_TIMEOUT_SECONDS
+// and LIGHTSPEED_AGENT_MAX_TURNS env vars for cooperative timeout enforcement.
 func (b *PodSpecBuilder) Build(
 	base *corev1.PodSpec,
 	agent *agenticv1alpha1.Agent,
@@ -71,6 +74,8 @@ func (b *PodSpecBuilder) Build(
 	serviceAccount string,
 	inputConfigMapName string,
 	traceparent string,
+	timeoutSeconds int,
+	maxTurns int,
 ) (*corev1.PodSpec, error) {
 	if base == nil || len(base.Containers) == 0 {
 		return nil, fmt.Errorf("%s", ErrBuildBasePodSpec)
@@ -100,6 +105,8 @@ func (b *PodSpecBuilder) Build(
 	container.Env = append(container.Env,
 		corev1.EnvVar{Name: "LIGHTSPEED_PROVIDER", Value: providerTypeString(llm.Spec.Type)},
 		corev1.EnvVar{Name: "LIGHTSPEED_MODEL", Value: agent.Spec.Model},
+		corev1.EnvVar{Name: "LIGHTSPEED_AGENT_TIMEOUT_SECONDS", Value: strconv.Itoa(timeoutSeconds)},
+		corev1.EnvVar{Name: "LIGHTSPEED_AGENT_MAX_TURNS", Value: strconv.Itoa(maxTurns)},
 	)
 	b.addProviderSpecificEnv(container, llm)
 

--- a/controller/agenticrun/podspec_builder_test.go
+++ b/controller/agenticrun/podspec_builder_test.go
@@ -333,7 +333,7 @@ func TestBuild_NilBase(t *testing.T) {
 	b := &PodSpecBuilder{}
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
-	_, err := b.Build(nil, agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	_, err := b.Build(nil, agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err == nil {
 		t.Fatal("expected error for nil base")
 	}
@@ -342,7 +342,7 @@ func TestBuild_NilBase(t *testing.T) {
 func TestBuild_NilAgent(t *testing.T) {
 	b := &PodSpecBuilder{}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
-	_, err := b.Build(testBasePodSpec(), nil, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	_, err := b.Build(testBasePodSpec(), nil, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err == nil {
 		t.Fatal("expected error for nil agent")
 	}
@@ -351,7 +351,7 @@ func TestBuild_NilAgent(t *testing.T) {
 func TestBuild_NilLLM(t *testing.T) {
 	b := &PodSpecBuilder{}
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
-	_, err := b.Build(testBasePodSpec(), agent, nil, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	_, err := b.Build(testBasePodSpec(), agent, nil, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err == nil {
 		t.Fatal("expected error for nil LLM")
 	}
@@ -361,9 +361,30 @@ func TestBuild_EmptySA(t *testing.T) {
 	b := &PodSpecBuilder{}
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
-	_, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "", "uid-test-run", "")
+	_, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "", "uid-test-run", "", 600, 200)
 	if err == nil {
 		t.Fatal("expected error for empty serviceAccount")
+	}
+}
+
+func TestBuild_ConfiguredAgentLimits(t *testing.T) {
+	b := &PodSpecBuilder{}
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{
+		Model:    "claude-opus-4-6",
+		MaxTurns: 3,
+		Timeouts: agenticv1alpha1.AgentTimeouts{AnalysisSeconds: 31},
+	}}
+	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 31, 3)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	env := envToMap(ps.Containers[0].Env)
+	if env["LIGHTSPEED_AGENT_TIMEOUT_SECONDS"] != "31" {
+		t.Errorf("configured timeout = %q, want 31", env["LIGHTSPEED_AGENT_TIMEOUT_SECONDS"])
+	}
+	if env["LIGHTSPEED_AGENT_MAX_TURNS"] != "3" {
+		t.Errorf("configured max turns = %q, want 3", env["LIGHTSPEED_AGENT_MAX_TURNS"])
 	}
 }
 
@@ -372,7 +393,7 @@ func TestBuild_Anthropic(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-opus-4-6"}}
 	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderAnthropic, "https://custom.api")
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid-123", "my-sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid-123", "my-sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -389,6 +410,12 @@ func TestBuild_Anthropic(t *testing.T) {
 	if env["LIGHTSPEED_PROVIDER_URL"] != "https://custom.api" {
 		t.Errorf("URL = %q", env["LIGHTSPEED_PROVIDER_URL"])
 	}
+	if env["LIGHTSPEED_AGENT_TIMEOUT_SECONDS"] != "600" {
+		t.Errorf("AGENT_TIMEOUT_SECONDS = %q, want 600", env["LIGHTSPEED_AGENT_TIMEOUT_SECONDS"])
+	}
+	if env["LIGHTSPEED_AGENT_MAX_TURNS"] != "200" {
+		t.Errorf("AGENT_MAX_TURNS = %q, want 200", env["LIGHTSPEED_AGENT_MAX_TURNS"])
+	}
 	if ps.Containers[0].ReadinessProbe != nil || ps.Containers[0].LivenessProbe != nil {
 		t.Error("HTTP probes must not be set for batch sandboxes")
 	}
@@ -399,7 +426,7 @@ func TestBuild_RequiresInputConfigMapName(t *testing.T) {
 	b := &PodSpecBuilder{}
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
-	_, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "", "")
+	_, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "", "", 600, 200)
 	if err == nil {
 		t.Fatal("expected error for empty inputConfigMapName")
 	}
@@ -411,7 +438,7 @@ func TestBuild_InputConfigMapMount(t *testing.T) {
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 	const cmName = "uid-my-run"
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", cmName, "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", cmName, "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -427,7 +454,7 @@ func TestBuild_Traceparent(t *testing.T) {
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 	const tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", tp)
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", tp, 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -436,7 +463,7 @@ func TestBuild_Traceparent(t *testing.T) {
 		t.Fatalf("TRACEPARENT = %q, want %q", env["TRACEPARENT"], tp)
 	}
 
-	ps, err = b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err = b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -484,7 +511,7 @@ func TestBuild_Vertex(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "gemini-2.0"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderGoogleCloudVertex)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -508,7 +535,7 @@ func TestBuild_Azure(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "gpt-4o"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAzureOpenAI)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -529,7 +556,7 @@ func TestBuild_Bedrock(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "claude-v3"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAWSBedrock)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -547,7 +574,7 @@ func TestBuild_OpenAI(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "gpt-4o"}}
 	llm := testLLMProviderWithURL(agenticv1alpha1.LLMProviderOpenAI, "https://api.example.com")
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -573,7 +600,7 @@ func TestBuild_ReasoningConfig(t *testing.T) {
 	}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -596,7 +623,7 @@ func TestBuild_NoReasoningConfig(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -611,7 +638,7 @@ func TestBuild_CredentialsSecretMounted(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -648,7 +675,7 @@ func TestBuild_RHOKPEndpointAndCA(t *testing.T) {
 		CASecretName: "lightspeed-agentic-rhokp-ca",
 	}
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, rhokp, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, rhokp, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -696,7 +723,7 @@ func TestBuild_RHOKPOmitted(t *testing.T) {
 	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{Model: "m"}}
 	llm := testLLMProvider(agenticv1alpha1.LLMProviderAnthropic)
 
-	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(testBasePodSpec(), agent, llm, nil, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -739,7 +766,7 @@ func TestBuild_DeduplicatesVolumes(t *testing.T) {
 		}},
 	}
 
-	ps, err := b.Build(base, agent, llm, tools, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(base, agent, llm, tools, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -821,7 +848,7 @@ func TestBuild_GeneratedVolumeOverridesBase(t *testing.T) {
 		Skills: []agenticv1alpha1.SkillsSource{{Image: "quay.io/real/skills:v1"}},
 	}
 
-	ps, err := b.Build(base, agent, llm, tools, nil, nil, "analysis", "uid", "sa", "uid-test-run", "")
+	ps, err := b.Build(base, agent, llm, tools, nil, nil, "analysis", "uid", "sa", "uid-test-run", "", 600, 200)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}

--- a/controller/agenticrun/resolve.go
+++ b/controller/agenticrun/resolve.go
@@ -68,10 +68,7 @@ func resolveAgenticRun(ctx context.Context, c client.Client, run *agenticv1alpha
 	}
 
 	effectiveAgent := func(stage agenticv1alpha1.SandboxStep, step agenticv1alpha1.AgenticRunStep) string {
-		if override := getStageOverrideAgent(approval, stage); override != "" {
-			return override
-		}
-		return stepAgentName(step)
+		return effectiveStepAgentName(approval, stage, step)
 	}
 
 	resolved := &resolvedWorkflow{}
@@ -106,4 +103,14 @@ func stepAgentName(step agenticv1alpha1.AgenticRunStep) string {
 		return step.Agent
 	}
 	return "default"
+}
+
+// effectiveStepAgentName is the single source of truth for selecting a stage's
+// Agent. Timeout enforcement and sandbox launch must use the same override
+// resolution.
+func effectiveStepAgentName(approval *agenticv1alpha1.AgenticRunApproval, stage agenticv1alpha1.SandboxStep, step agenticv1alpha1.AgenticRunStep) string {
+	if override := getStageOverrideAgent(approval, stage); override != "" {
+		return override
+	}
+	return stepAgentName(step)
 }

--- a/controller/agenticrun/sandbox_agent.go
+++ b/controller/agenticrun/sandbox_agent.go
@@ -13,7 +13,10 @@ import (
 )
 
 const (
-	defaultSandboxTimeout = 5 * time.Minute
+	// activeDeadlineSeconds is measured from pod creation. The operator
+	// separately enforces the startup and startedAt-based running deadlines.
+	sandboxStartupTimeout = 5 * time.Minute
+	sandboxRunningGrace   = 1 * time.Minute
 
 	analysisStepTimeout     = 10 * time.Minute
 	executionStepTimeout    = 10 * time.Minute
@@ -25,11 +28,13 @@ const (
 	// Spec: .ai/spec/what/sandbox-execution.md, .ai/spec/what/run-lifecycle.md rule 14a.
 
 	// Step condition reasons (run-lifecycle.md rule 14a).
-	ReasonWaitingForSandbox = "WaitingForSandbox"
-	ReasonRunning           = "Running"
-	ReasonSucceeded         = "Succeeded"
-	ReasonSandboxTimeout    = "SandboxTimeout"
-	ReasonSandboxFailed     = "SandboxFailed"
+	ReasonWaitingForSandbox     = "WaitingForSandbox"
+	ReasonRunning               = "Running"
+	ReasonSucceeded             = "Succeeded"
+	ReasonSandboxTimeout        = "SandboxTimeout"
+	ReasonSandboxStartupTimeout = "SandboxStartupTimeout"
+	ReasonSandboxFailed         = "SandboxFailed"
+	ReasonAgentTimeout          = "AgentTimeout"
 
 	// Pod start timeout — covers image pull, scheduling, resource limits, etc.
 	podStartTimeout = 5 * time.Minute
@@ -153,6 +158,10 @@ func (s *SandboxAgentCaller) Escalate(ctx context.Context, run *agenticv1alpha1.
 	return s.launchSandbox(ctx, run, stepString(agenticv1alpha1.SandboxStepEscalation), step, buildAgentContext(run))
 }
 
+func sandboxPodDeadline(agent *agenticv1alpha1.Agent, step string) time.Duration {
+	return sandboxStartupTimeout + time.Duration(resolveTimeout(agent, step))*time.Second + sandboxRunningGrace
+}
+
 // launchSandbox delegates to SandboxLifecycle.Create which handles all setup
 // (ConfigMap, SA, RBAC, pod) and patches the sandbox info on the status.
 func (s *SandboxAgentCaller) launchSandbox(
@@ -162,7 +171,12 @@ func (s *SandboxAgentCaller) launchSandbox(
 	step resolvedStep,
 	agentCtx *agentContext,
 ) error {
-	podDeadline := stepTimeout(stepName) + defaultSandboxTimeout
+	// activeDeadlineSeconds is measured from pod creation, while the product
+	// running deadline starts at the main container's startedAt. Include the
+	// complete startup allowance here so Kubernetes cannot kill a pod before
+	// the operator's timestamp-derived deadline. The operator still enforces
+	// the precise startup/running clocks in timeout_handler.go.
+	podDeadline := sandboxPodDeadline(step.Agent, stepName)
 	var name string
 	if err := retryOnTransient(ctx, func() error {
 		var createErr error

--- a/controller/agenticrun/sandbox_agent_test.go
+++ b/controller/agenticrun/sandbox_agent_test.go
@@ -265,6 +265,16 @@ func TestStepTimeout_Values(t *testing.T) {
 	}
 }
 
+func TestSandboxPodDeadline_UsesConfiguredTimeout(t *testing.T) {
+	agent := &agenticv1alpha1.Agent{Spec: agenticv1alpha1.AgentSpec{
+		Timeouts: agenticv1alpha1.AgentTimeouts{AnalysisSeconds: 30},
+	}}
+	want := sandboxStartupTimeout + 30*time.Second + sandboxRunningGrace
+	if got := sandboxPodDeadline(agent, "analysis"); got != want {
+		t.Fatalf("sandboxPodDeadline = %v, want %v", got, want)
+	}
+}
+
 type trackingMockSandbox struct {
 	released   *[]string
 	errOnClaim string

--- a/controller/agenticrun/sandbox_manager.go
+++ b/controller/agenticrun/sandbox_manager.go
@@ -156,6 +156,9 @@ func (m *SandboxManager) Create(
 	}
 	span.AddEvent("sandbox.rbac.created")
 
+	timeoutSecs := resolveTimeout(agent, step)
+	maxTurns := resolveMaxTurns(agent)
+
 	podSpec, err := m.builder.Build(
 		cfg.Sandbox.PodSpec,
 		agent,
@@ -168,6 +171,8 @@ func (m *SandboxManager) Create(
 		serviceAccount,
 		inputCM.Name,
 		traceparentFromContext(ctx),
+		timeoutSecs,
+		maxTurns,
 	)
 	if err != nil {
 		createErr = fmt.Errorf("%s: %w", errBuildPodSpec, err)

--- a/controller/agenticrun/timeout_handler.go
+++ b/controller/agenticrun/timeout_handler.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -43,6 +46,9 @@ type podEntry struct {
 	pod     *corev1.Pod
 	step    string
 	runName string
+	// created is the sandbox resource creation time. In claim mode this is
+	// the claim timestamp, not the backing pod timestamp.
+	created time.Time
 }
 
 func (r *AgenticRunReconciler) handleTimeEvent(ctx context.Context) {
@@ -68,24 +74,59 @@ func (r *AgenticRunReconciler) handleTimeEvent(ctx context.Context) {
 			continue
 		}
 
+		// A SandboxClaim can exist before its backing Pod is created. Enforce
+		// the startup clock from the claim timestamp instead of waiting for a
+		// pod entry to appear.
+		if e.pod == nil {
+			if now.Sub(e.created) > podStartTimeout {
+				message := fmt.Sprintf("sandbox did not start within %s", podStartTimeout)
+				if err := r.patchStepCondition(ctx, &run, condType, metav1.ConditionFalse, ReasonSandboxStartupTimeout, message); err == nil {
+					r.releaseSandbox(ctx, &run, e.step)
+				}
+			}
+			continue
+		}
+
 		phase := e.pod.Status.Phase
 		if phase == corev1.PodSucceeded || phase == corev1.PodFailed {
 			log.Info("retrying completion for terminal pod", LogKeyName, e.pod.Name, LogKeyStep, e.step)
-			_ = r.completeStep(ctx, &run, e.pod, e.step, condType, "")
+			_ = r.completeStep(ctx, &run, e.pod, e.step, condType, "", "")
 			continue
 		}
 
-		var message string
-		created := e.pod.CreationTimestamp.Time
+		var message, reason string
+		created := e.created
+		if created.IsZero() {
+			created = e.pod.CreationTimestamp.Time
+		}
 		if startTimedOut(phase, created, now, podStartTimeout) {
 			message = fmt.Sprintf("sandbox pod did not start within %s", podStartTimeout)
-		} else if overallTimedOut(created, now, stepTimeout(e.step)) {
-			message = fmt.Sprintf("sandbox exceeded timeout %s", stepTimeout(e.step))
+			reason = ReasonSandboxStartupTimeout
 		} else {
-			continue
+			// Resolve the agent for this step to get the configured timeout
+			agent, err := r.resolveStepAgent(ctx, &run, e.step)
+			if err != nil {
+				log.Error(err, "failed to resolve step agent", LogKeyStep, e.step)
+				continue
+			}
+
+			agentTimeoutSecs := resolveTimeout(agent, e.step)
+			agentTimeout := time.Duration(agentTimeoutSecs) * time.Second
+
+			startedAt := mainContainerStartedAt(e.pod)
+			// Keep a creation-based upper bound across container restarts. The
+			// startedAt clock additionally enforces the current container run.
+			creationDeadline := sandboxStartupTimeout + agentTimeout + sandboxRunningGrace
+			if overallTimedOut(created, now, creationDeadline) ||
+				(!startedAt.IsZero() && overallTimedOut(startedAt, now, agentTimeout+sandboxRunningGrace)) {
+				message = fmt.Sprintf("sandbox exceeded timeout %s", agentTimeout+sandboxRunningGrace)
+				reason = ReasonSandboxTimeout
+			} else {
+				continue
+			}
 		}
 
-		_ = r.completeStep(ctx, &run, e.pod, e.step, condType, message)
+		_ = r.completeStep(ctx, &run, e.pod, e.step, condType, message, reason)
 	}
 }
 
@@ -106,7 +147,7 @@ func (r *AgenticRunReconciler) listBarePods(ctx context.Context, log logr.Logger
 		if step == "" || runName == "" {
 			continue
 		}
-		entries = append(entries, podEntry{pod, step, runName})
+		entries = append(entries, podEntry{pod: pod, step: step, runName: runName, created: pod.CreationTimestamp.Time})
 	}
 	return entries
 }
@@ -118,13 +159,44 @@ func (r *AgenticRunReconciler) listSandboxPods(ctx context.Context, log logr.Log
 		return nil
 	}
 	var entries []podEntry
+	seen := make(map[string]bool)
 	for i := range pods.Items {
 		pod := &pods.Items[i]
-		step, runName, _ := resolveSandboxPodMetadata(ctx, r.Client, pod)
+		step, runName, err := resolveSandboxPodMetadata(ctx, r.Client, pod)
+		if err != nil {
+			// Do not let the claim-only fallback classify this pod-backed step
+			// as still provisioning when its owner chain cannot be resolved.
+			log.Error(err, "failed to resolve sandbox pod metadata", LogKeyName, pod.Name)
+			return entries
+		}
 		if step == "" || runName == "" {
 			continue
 		}
-		entries = append(entries, podEntry{pod, step, runName})
+		created := pod.CreationTimestamp.Time
+		if claimCreated, err := sandboxClaimCreationTime(ctx, r.Client, pod); err == nil && !claimCreated.IsZero() {
+			created = claimCreated
+		}
+		entries = append(entries, podEntry{pod: pod, step: step, runName: runName, created: created})
+		seen[runName+"\x00"+step] = true
+	}
+
+	// Include claims with no backing pod so a claim stuck in provisioning still
+	// reaches the five-minute startup deadline.
+	claims := &unstructured.UnstructuredList{}
+	claims.SetGroupVersionKind(smClaimGVK)
+	if err := r.List(ctx, claims, client.InNamespace(r.Namespace)); err != nil {
+		log.Error(err, "failed to list sandbox claims")
+		return entries
+	}
+	for i := range claims.Items {
+		claim := &claims.Items[i]
+		labels := claim.GetLabels()
+		annotations := claim.GetAnnotations()
+		step, runName := labels[LabelStep], annotations[AnnotationRunName]
+		if step == "" || runName == "" || seen[runName+"\x00"+step] {
+			continue
+		}
+		entries = append(entries, podEntry{step: step, runName: runName, created: claim.GetCreationTimestamp().Time})
 	}
 	return entries
 }
@@ -132,6 +204,38 @@ func (r *AgenticRunReconciler) listSandboxPods(ctx context.Context, log logr.Log
 // ---------------------------------------------------------------------------
 // Shared timeout helpers
 // ---------------------------------------------------------------------------
+
+// resolveStepAgent gets the Agent CR for the given step. It handles both
+// the configured agent for the step and any approval overrides.
+func (r *AgenticRunReconciler) resolveStepAgent(ctx context.Context, run *agenticv1alpha1.AgenticRun, step string) (*agenticv1alpha1.Agent, error) {
+	var approval agenticv1alpha1.AgenticRunApproval
+	if err := r.Get(ctx, client.ObjectKey{Name: run.Name, Namespace: run.Namespace}, &approval); err != nil && !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("get AgenticRunApproval: %w", err)
+	}
+	var agentName string
+	switch step {
+	case "analysis":
+		agentName = effectiveStepAgentName(&approval, agenticv1alpha1.SandboxStepAnalysis, run.Spec.Analysis)
+	case "execution":
+		agentName = effectiveStepAgentName(&approval, agenticv1alpha1.SandboxStepExecution, run.Spec.Execution)
+	case "verification":
+		agentName = effectiveStepAgentName(&approval, agenticv1alpha1.SandboxStepVerification, run.Spec.Verification)
+	case "escalation":
+		// Escalation falls back to the resolved analysis Agent, unless it
+		// has an explicit escalation override.
+		agentName = effectiveStepAgentName(&approval, agenticv1alpha1.SandboxStepAnalysis, run.Spec.Analysis)
+		if override := getStageOverrideAgent(&approval, agenticv1alpha1.SandboxStepEscalation); override != "" {
+			agentName = override
+		}
+	}
+
+	agent := &agenticv1alpha1.Agent{}
+	if err := r.Get(ctx, client.ObjectKey{Name: agentName}, agent); err != nil {
+		return nil, err
+	}
+
+	return agent, nil
+}
 
 // startTimedOut returns true if the resource has not reached Running within the deadline.
 // For bare-pod mode, phase is checked to skip already-terminal pods.
@@ -143,6 +247,48 @@ func startTimedOut(phase corev1.PodPhase, created, now time.Time, timeout time.D
 	return now.Sub(created) > timeout
 }
 
-func overallTimedOut(created, now time.Time, timeout time.Duration) bool {
-	return now.Sub(created) > timeout
+func overallTimedOut(startedAt, now time.Time, timeout time.Duration) bool {
+	return now.Sub(startedAt) > timeout
+}
+
+func mainContainerStartedAt(pod *corev1.Pod) time.Time {
+	if pod == nil {
+		return time.Time{}
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == "agent" && status.State.Running != nil {
+			return status.State.Running.StartedAt.Time
+		}
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.State.Running != nil {
+			return status.State.Running.StartedAt.Time
+		}
+	}
+	return time.Time{}
+}
+
+func sandboxClaimCreationTime(ctx context.Context, c client.Client, pod *corev1.Pod) (time.Time, error) {
+	for _, ref := range pod.OwnerReferences {
+		if ref.Kind != "Sandbox" {
+			continue
+		}
+		sb := &unstructured.Unstructured{}
+		sb.SetGroupVersionKind(smSandboxGVK)
+		if err := c.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: pod.Namespace}, sb); err != nil {
+			return time.Time{}, err
+		}
+		for _, sbRef := range sb.GetOwnerReferences() {
+			if sbRef.Kind != "SandboxClaim" {
+				continue
+			}
+			claim := &unstructured.Unstructured{}
+			claim.SetGroupVersionKind(smClaimGVK)
+			if err := c.Get(ctx, client.ObjectKey{Name: sbRef.Name, Namespace: pod.Namespace}, claim); err != nil {
+				return time.Time{}, err
+			}
+			return claim.GetCreationTimestamp().Time, nil
+		}
+	}
+	return time.Time{}, nil
 }


### PR DESCRIPTION
## Summary
- Wire Agent timeout and max-turn settings into sandbox environment variables.
- Enforce startup and running deadlines using resolved Agent budgets and container start timestamps.
- Handle sandbox claims without backing Pods and cooperative AgentTimeout Result conditions.
- Replace the removed chat timeout field with escalation timeout configuration.

## Validation
- `make test`
- `go vet ./...`
- API module tests (`cd api && GOWORK=off go test ./...`)

Related: OLS-4024, [OLS-4025](https://redhat.atlassian.net/browse/OLS-4025)