### PR TITLE
chore: add quickstart trace endpoint flag

### DIFF
--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -32,6 +32,16 @@ Deploy with Postgres backend for OTEL audit logs:
 bash hack/quickstart/install.sh --postgres
 ```
 
+Export traces to a Jaeger OTLP gRPC endpoint:
+
+```bash
+bash hack/quickstart/install.sh \
+  --traces=jaeger-otlp-grpc.observability.svc.cluster.local:4317
+```
+
+The `--traces` endpoint uses insecure OTLP gRPC. This matches the Jaeger
+instance deployed by `hack/deploy-jaeger.sh`.
+
 Or deploy components individually (run from the repo root — scripts
 call each other via `hack/quickstart/`):
 
@@ -77,6 +87,7 @@ bash hack/quickstart/undeploy-otel.sh
 | `--alerts-adapter-image=IMAGE` | Alerts adapter image (default: Konflux `:main`) |
 | `--otel-image=IMAGE` | OTEL collector image (default: Konflux `:main`) |
 | `--postgres` | Deploy Postgres backend for OTEL audit logs |
+| `--traces=ENDPOINT` | Export traces to an insecure OTLP gRPC endpoint |
 
 ### Individual scripts
 
@@ -87,6 +98,7 @@ bash hack/quickstart/undeploy-otel.sh
 | `deploy-alerts-adapter.sh` | `--image=IMAGE` | Konflux `:main` |
 | `deploy-otel.sh` | `--image=IMAGE` | Konflux `:main` |
 | `deploy-otel.sh` | `--postgres` | Deploy Postgres backend for audit logs |
+| `deploy-otel.sh` | `--traces=ENDPOINT` | Export traces to an insecure OTLP gRPC endpoint |
 | `deploy-configmap.sh` | `--sandbox-image=IMAGE` | Konflux `:main` |
 
 All images use the Konflux floating `:main` tag by default.

--- a/hack/quickstart/deploy-otel.sh
+++ b/hack/quickstart/deploy-otel.sh
@@ -3,6 +3,7 @@
 # Deploy the OTEL collector for quickstart.
 #
 # By default, accepts OTLP gRPC/HTTP and drops all data (nop exporter).
+# With --traces=ENDPOINT, exports traces to an OTLP gRPC endpoint.
 # With --postgres, deploys a Postgres instance and routes agentic logs
 # to it for the console audit UI.
 #
@@ -13,6 +14,8 @@
 # Usage:
 #   bash hack/quickstart/deploy-otel.sh
 #   bash hack/quickstart/deploy-otel.sh --postgres
+#   bash hack/quickstart/deploy-otel.sh \
+#     --traces=jaeger-otlp-grpc.observability.svc.cluster.local:4317
 #   bash hack/quickstart/deploy-otel.sh --image=quay.io/my-org/my-collector:tag
 #
 # Prerequisites:
@@ -20,13 +23,15 @@
 #   - Namespace openshift-lightspeed exists
 #
 # Flags:
-#   --image=IMAGE   OTEL collector image (default: Konflux :main).
-#   --postgres      Deploy Postgres and wire the collector to export logs to it.
+#   --image=IMAGE       OTEL collector image (default: Konflux :main).
+#   --postgres          Deploy Postgres and wire the collector to export logs to it.
+#   --traces=ENDPOINT   Export traces to this OTLP gRPC endpoint without TLS.
 
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-openshift-lightspeed}"
 OTEL_IMAGE="quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector:main"
+TRACE_ENDPOINT=""
 WITH_POSTGRES=0
 
 COLLECTOR_NAME="lightspeed-otel-collector"
@@ -38,6 +43,8 @@ while [ $# -gt 0 ]; do
     --image=*)   OTEL_IMAGE="${1#*=}"; shift ;;
     --image)     [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; OTEL_IMAGE="$2"; shift 2 ;;
     --postgres)  WITH_POSTGRES=1; shift ;;
+    --traces=*)  TRACE_ENDPOINT="${1#*=}"; shift ;;
+    --traces)    [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; TRACE_ENDPOINT="$2"; shift 2 ;;
     *) echo "Unknown flag: $1" >&2; exit 1 ;;
   esac
 done
@@ -104,6 +111,7 @@ COLLECTOR_CONFIG='
         send_batch_size: 100
     exporters:
       nop: {}
+      __TRACE_EXPORTER_CONFIG__
       postgres:
         connection_string: ${env:POSTGRES_CONNECTION_STRING}
         schema: templogs
@@ -152,7 +160,7 @@ COLLECTOR_CONFIG='
           exporters: [nop]
         traces:
           receivers: [otlp]
-          exporters: [nop]
+          exporters: [__TRACE_EXPORTER_NAME__]
       telemetry:
         logs:
           level: info'
@@ -177,6 +185,7 @@ COLLECTOR_CONFIG='
         send_batch_size: 100
     exporters:
       nop: {}
+      __TRACE_EXPORTER_CONFIG__
     extensions:
       health_check:
         endpoint: "0.0.0.0:13133"
@@ -189,11 +198,25 @@ COLLECTOR_CONFIG='
           exporters: [nop]
         traces:
           receivers: [otlp]
-          exporters: [nop]
+          exporters: [__TRACE_EXPORTER_NAME__]
       telemetry:
         logs:
           level: info'
 fi
+
+if [ -n "${TRACE_ENDPOINT}" ]; then
+  TRACE_EXPORTER_NAME="otlp/traces"
+  TRACE_EXPORTER_CONFIG="otlp/traces:
+        endpoint: ${TRACE_ENDPOINT}
+        tls:
+          insecure: true"
+  info "Trace export enabled: ${TRACE_ENDPOINT} (insecure OTLP gRPC)"
+else
+  TRACE_EXPORTER_NAME="nop"
+  TRACE_EXPORTER_CONFIG=""
+fi
+COLLECTOR_CONFIG="${COLLECTOR_CONFIG//__TRACE_EXPORTER_NAME__/${TRACE_EXPORTER_NAME}}"
+COLLECTOR_CONFIG="${COLLECTOR_CONFIG//__TRACE_EXPORTER_CONFIG__/${TRACE_EXPORTER_CONFIG}}"
 
 # --- Deployment env/volumes (conditional on Postgres) -------------------------
 

--- a/hack/quickstart/install.sh
+++ b/hack/quickstart/install.sh
@@ -29,6 +29,7 @@ SANDBOX_IMAGE=""
 CONSOLE_IMAGE=""
 ALERTS_ADAPTER_IMAGE=""
 OTEL_IMAGE=""
+TRACE_ENDPOINT=""
 WITH_POSTGRES=0
 
 usage() {
@@ -42,6 +43,7 @@ Options:
   --alerts-adapter-image=IMAGE    Alerts adapter image (default: Konflux :main)
   --otel-image=IMAGE              OTEL collector image (default: Konflux :main)
   --postgres                      Deploy Postgres backend for OTEL audit logs
+  --traces=ENDPOINT               Export traces to an OTLP gRPC endpoint without TLS
   -h, --help                      Show this help and exit
 EOF
 }
@@ -59,6 +61,8 @@ while [ $# -gt 0 ]; do
     --otel-image=*)            OTEL_IMAGE="${1#*=}"; shift ;;
     --otel-image)              [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; OTEL_IMAGE="$2"; shift 2 ;;
     --postgres)                WITH_POSTGRES=1; shift ;;
+    --traces=*)                TRACE_ENDPOINT="${1#*=}"; shift ;;
+    --traces)                  [ $# -lt 2 ] && { echo "Missing value for $1" >&2; exit 1; }; TRACE_ENDPOINT="$2"; shift 2 ;;
     -h|--help)                 usage; exit 0 ;;
     *)                         echo "Unknown flag: $1 (try --help)" >&2; exit 1 ;;
   esac
@@ -114,6 +118,9 @@ if [ -n "${OTEL_IMAGE}" ]; then
 fi
 if [ "${WITH_POSTGRES}" = "1" ]; then
   OTEL_ARGS="${OTEL_ARGS} --postgres"
+fi
+if [ -n "${TRACE_ENDPOINT}" ]; then
+  OTEL_ARGS="${OTEL_ARGS} --traces=${TRACE_ENDPOINT}"
 fi
 bash "${SCRIPT_DIR}/deploy-otel.sh" ${OTEL_ARGS}
 


### PR DESCRIPTION
## Summary

- Add `--traces=ENDPOINT` to the quickstart installer.
- Configure the OTLP trace exporter when an endpoint is provided.
- Preserve the `nop` trace exporter by default when the flag is omitted.
- Document Jaeger setup in the quickstart README.

## Usage

```bash
bash hack/quickstart/install.sh \
  --postgres \
  --traces=jaeger-otlp-grpc.observability.svc.cluster.local:4317
```

The endpoint uses insecure OTLP gRPC, which matches the Jaeger deployment created by `hack/deploy-jaeger.sh`.

## Verification

- `bash -n hack/quickstart/install.sh hack/quickstart/deploy-otel.sh`
- Validated generated collector YAML with and without `--traces`.
- Verified trace flow in Jaeger with spans from both the operator and sandbox services.
